### PR TITLE
Fixes for Swift 1.2

### DIFF
--- a/CocoaMQTT.xcodeproj/project.pbxproj
+++ b/CocoaMQTT.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 47;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -118,7 +118,7 @@
 				};
 			};
 			buildConfigurationList = 8BF7033B198DDB7900A220F6 /* Build configuration list for PBXProject "CocoaMQTT" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 6.3";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -229,16 +229,21 @@
 		8BF70348198DDB7900A220F6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "CocoaMQTT/CocoaMQTT-Bridging-Header.h";
+				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
 		8BF70349198DDB7900A220F6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "CocoaMQTT/CocoaMQTT-Bridging-Header.h";
+				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};

--- a/CocoaMQTT/CocoaMQTT.swift
+++ b/CocoaMQTT/CocoaMQTT.swift
@@ -206,7 +206,7 @@ class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, CocoaMQTTRea
     }
     
     func publish(topic: String, withString string: String, qos: CocoaMQTTQOS = .QOS1) -> UInt16 {
-        var data = [Byte](string.utf8)
+        var data = [UInt8](string.utf8)
         let message = CocoaMQTTMessage(topic: topic, string: string, qos: qos)
         return publish(message)
     }
@@ -273,7 +273,7 @@ class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, CocoaMQTTRea
     
     func socket(sock: GCDAsyncSocket!, didReadData data: NSData!, withTag tag: Int) {
         let etag : CocoaMQTTReadTag = CocoaMQTTReadTag(rawValue: tag)!
-        var bytes = [Byte]([0])
+        var bytes = [UInt8]([0])
         switch etag {
         case CocoaMQTTReadTag.TAG_HEADER:
             data.getBytes(&bytes, length: 1)
@@ -348,7 +348,7 @@ class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, CocoaMQTTRea
 
     func didReceivePubAck(reader: CocoaMQTTReader, msgid: UInt16) {
         NSLog("CocoaMQTT: PUBACK Received: \(msgid)")
-        if let message = messages[msgid]? {
+        if let message = messages[msgid] {
             messages.removeValueForKey(msgid)
             delegate?.mqtt(self, didPublishMessage: message, id: msgid)
         }
@@ -361,7 +361,7 @@ class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, CocoaMQTTRea
     
     func didReceivePubRel(reader: CocoaMQTTReader, msgid: UInt16) {
         NSLog("CocoaMQTT: PUBREL Received: \(msgid)")
-        if let message = messages[msgid]? {
+        if let message = messages[msgid] {
             messages.removeValueForKey(msgid)
             delegate?.mqtt(self, didPublishMessage: message, id: msgid)
         }
@@ -430,7 +430,7 @@ class CocoaMQTTReader {
 
     var header: UInt8 = 0
 
-    var data: [Byte] = []
+    var data: [UInt8] = []
 
     var length: UInt = 0
 
@@ -462,7 +462,7 @@ class CocoaMQTTReader {
     }
 
     func lengthReady(byte: UInt8) {
-         length += Int(byte & 127) * multiply
+        length += (UInt)((Int)(byte & 127) * multiply)
          if (byte & 0x80) == 0 { //done
             if length == 0 {
                 frameReady()
@@ -480,7 +480,7 @@ class CocoaMQTTReader {
     }
 
     func payloadReady(data: NSData) {
-        self.data = [Byte](count: data.length, repeatedValue: 0)
+        self.data = [UInt8](count: data.length, repeatedValue: 0)
         data.getBytes(&(self.data), length: data.length)
         frameReady()
     }
@@ -523,7 +523,7 @@ class CocoaMQTTReader {
         return (msgId, message)
     }
 
-    func _msgid(bytes: [Byte]) -> UInt16 {
+    func _msgid(bytes: [UInt8]) -> UInt16 {
         if bytes.count < 2 { return 0 }
         return UInt16(bytes[0]) << 8 + UInt16(bytes[1])
     }

--- a/CocoaMQTT/CocoaMQTTFrame.swift
+++ b/CocoaMQTT/CocoaMQTTFrame.swift
@@ -19,7 +19,7 @@ extension UInt16 {
     //Least Significant Byte (LSB)
     var lowByte: UInt8 { return UInt8(self & 0x00FF) }
     
-    var hlBytes: [Byte] { return [highByte, lowByte] }
+    var hlBytes: [UInt8] { return [highByte, lowByte] }
 
 }
 
@@ -29,7 +29,7 @@ extension UInt16 {
 extension String {
     
     //ok?
-    var bytesWithLength: [Byte] { return UInt16(countElements(utf8)).hlBytes + utf8 }
+    var bytesWithLength: [UInt8] { return UInt16(count(utf8)).hlBytes + utf8 }
     
 }
 
@@ -145,12 +145,12 @@ class CocoaMQTTFrame {
     /*
      * Variable Header
      */
-    var variableHeader: [Byte] = []
+    var variableHeader: [UInt8] = []
     
     /*
      * Playload
      */
-    var payload: [Byte] = []
+    var payload: [UInt8] = []
     
     /*
      * Type
@@ -209,18 +209,18 @@ class CocoaMQTTFrame {
         self.header = header
     }
     
-    init(type: CocoaMQTTFrameType, payload: [Byte] = []) {
+    init(type: CocoaMQTTFrameType, payload: [UInt8] = []) {
         self.header = type.rawValue
         self.payload = payload
     }
     
-    func data() -> [Byte] {
+    func data() -> [UInt8] {
         self.pack()
-        return [Byte]([header]) + encodeLength() + variableHeader + payload
+        return [UInt8]([header]) + encodeLength() + variableHeader + payload
     }
     
-    func encodeLength() -> [Byte] {
-        var bytes: [Byte] = []
+    func encodeLength() -> [UInt8] {
+        var bytes: [UInt8] = []
         var digit: UInt8 = 0
         var len: UInt32 = UInt32(variableHeader.count+payload.count)
         do {
@@ -288,16 +288,16 @@ class CocoaMQTTFramePublish : CocoaMQTTFrame {
 
     var topic: String?
     
-    var data: [Byte]?
+    var data: [UInt8]?
 
-    init(msgid: UInt16, topic: String, payload: [Byte]) {
+    init(msgid: UInt16, topic: String, payload: [UInt8]) {
         super.init(type: CocoaMQTTFrameType.PUBLISH, payload: payload)
         self.msgid = msgid
         self.topic = topic
         self.qos = 1
     }
     
-    init(header: UInt8, data: [Byte]) {
+    init(header: UInt8, data: [UInt8]) {
         super.init(header: header)
         self.data = data
     }
@@ -306,7 +306,7 @@ class CocoaMQTTFramePublish : CocoaMQTTFrame {
         var msb = data![0], lsb = data![1]
         var len = UInt16(msb) << 8 + UInt16(lsb)
         var pos : Int = 2 + Int(len)
-        topic = NSString(bytes: [Byte](data![2...(pos-1)]), length: Int(len), encoding: NSUTF8StringEncoding)
+        topic = NSString(bytes: [UInt8](data![2...(pos-1)]), length: Int(len), encoding: NSUTF8StringEncoding) as? String
 //        topic = String.stringWithBytes(
 //            [Byte](data![2...(pos-1)]),
 //            length: Int(len),
@@ -321,7 +321,7 @@ class CocoaMQTTFramePublish : CocoaMQTTFrame {
         //payload
         var end = data!.count - 1
         
-        payload = [Byte](data![pos...end])
+        payload = [UInt8](data![pos...end])
     }
 
     override func pack() {

--- a/CocoaMQTT/CocoaMQTTMessage.swift
+++ b/CocoaMQTT/CocoaMQTTMessage.swift
@@ -15,12 +15,12 @@ class CocoaMQTTMessage {
     
     var topic: String
     
-    var payload: [Byte]
+    var payload: [UInt8]
     
     //utf8 bytes array to string
     var string: String? {
     get {
-        return NSString(bytes: payload, length: payload.count, encoding: NSUTF8StringEncoding)
+        return NSString(bytes: payload, length: payload.count, encoding: NSUTF8StringEncoding) as? String
 //        return String.stringWithBytes(payload,
 //            length: payload.count,
 //            encoding: NSUTF8StringEncoding)
@@ -35,11 +35,11 @@ class CocoaMQTTMessage {
     
     init(topic: String, string: String, qos: CocoaMQTTQOS = .QOS1) {
         self.topic = topic
-        self.payload = [Byte](string.utf8)
+        self.payload = [UInt8](string.utf8)
         self.qos = qos
     }
     
-    init(topic: String, payload: [Byte], qos: CocoaMQTTQOS = .QOS1, retain: Bool = false, dup: Bool = false) {
+    init(topic: String, payload: [UInt8], qos: CocoaMQTTQOS = .QOS1, retain: Bool = false, dup: Bool = false) {
         self.topic = topic
         self.payload = payload
         self.qos = qos

--- a/CocoaMQTT/GCDAsyncSocket.h
+++ b/CocoaMQTT/GCDAsyncSocket.h
@@ -1,10 +1,10 @@
-//  
+//
 //  GCDAsyncSocket.h
-//  
+//
 //  This class is in the public domain.
 //  Originally created by Robbie Hanson in Q3 2010.
 //  Updated and maintained by Deusty LLC and the Apple development community.
-//  
+//
 //  https://github.com/robbiehanson/CocoaAsyncSocket
 //
 
@@ -12,6 +12,7 @@
 #import <Security/Security.h>
 #import <Security/SecureTransport.h>
 #import <dispatch/dispatch.h>
+#import <Availability.h>
 
 #include <sys/socket.h> // AF_INET, AF_INET6
 
@@ -19,62 +20,27 @@
 @class GCDAsyncWritePacket;
 @class GCDAsyncSocketPreBuffer;
 
-#if TARGET_OS_IPHONE
-
-  // Compiling for iOS
-
-  #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 50000 // iOS 5.0 supported
-  
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000 // iOS 5.0 supported and required
-
-      #define IS_SECURE_TRANSPORT_AVAILABLE      YES
-      #define SECURE_TRANSPORT_MAYBE_AVAILABLE   1
-      #define SECURE_TRANSPORT_MAYBE_UNAVAILABLE 0
-
-    #else                                         // iOS 5.0 supported but not required
-
-      #ifndef NSFoundationVersionNumber_iPhoneOS_5_0
-        #define NSFoundationVersionNumber_iPhoneOS_5_0 881.00
-      #endif
-
-      #define IS_SECURE_TRANSPORT_AVAILABLE     (NSFoundationVersionNumber >= NSFoundationVersionNumber_iPhoneOS_5_0)
-      #define SECURE_TRANSPORT_MAYBE_AVAILABLE   1
-      #define SECURE_TRANSPORT_MAYBE_UNAVAILABLE 1
-
-    #endif
-
-  #else                                        // iOS 5.0 not supported
-
-    #define IS_SECURE_TRANSPORT_AVAILABLE      NO
-    #define SECURE_TRANSPORT_MAYBE_AVAILABLE   0
-    #define SECURE_TRANSPORT_MAYBE_UNAVAILABLE 1
-
-  #endif
-
-#else
-
-  // Compiling for Mac OS X
-
-  #define IS_SECURE_TRANSPORT_AVAILABLE      YES
-  #define SECURE_TRANSPORT_MAYBE_AVAILABLE   1
-  #define SECURE_TRANSPORT_MAYBE_UNAVAILABLE 0
-
-#endif
-
 extern NSString *const GCDAsyncSocketException;
 extern NSString *const GCDAsyncSocketErrorDomain;
 
 extern NSString *const GCDAsyncSocketQueueName;
 extern NSString *const GCDAsyncSocketThreadName;
 
-#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-extern NSString *const GCDAsyncSocketSSLCipherSuites;
+extern NSString *const GCDAsyncSocketManuallyEvaluateTrust;
 #if TARGET_OS_IPHONE
+extern NSString *const GCDAsyncSocketUseCFStreamForTLS;
+#endif
+#define GCDAsyncSocketSSLPeerName     (NSString *)kCFStreamSSLPeerName
+#define GCDAsyncSocketSSLCertificates (NSString *)kCFStreamSSLCertificates
+#define GCDAsyncSocketSSLIsServer     (NSString *)kCFStreamSSLIsServer
+extern NSString *const GCDAsyncSocketSSLPeerID;
 extern NSString *const GCDAsyncSocketSSLProtocolVersionMin;
 extern NSString *const GCDAsyncSocketSSLProtocolVersionMax;
-#else
+extern NSString *const GCDAsyncSocketSSLSessionOptionFalseStart;
+extern NSString *const GCDAsyncSocketSSLSessionOptionSendOneByteRecord;
+extern NSString *const GCDAsyncSocketSSLCipherSuites;
+#if !TARGET_OS_IPHONE
 extern NSString *const GCDAsyncSocketSSLDiffieHellmanParameters;
-#endif
 #endif
 
 #define GCDAsyncSocketLoggingContext 65535
@@ -82,15 +48,15 @@ extern NSString *const GCDAsyncSocketSSLDiffieHellmanParameters;
 
 enum GCDAsyncSocketError
 {
-	GCDAsyncSocketNoError = 0,           // Never used
-	GCDAsyncSocketBadConfigError,        // Invalid configuration
-	GCDAsyncSocketBadParamError,         // Invalid parameter was passed
-	GCDAsyncSocketConnectTimeoutError,   // A connect operation timed out
-	GCDAsyncSocketReadTimeoutError,      // A read operation timed out
-	GCDAsyncSocketWriteTimeoutError,     // A write operation timed out
-	GCDAsyncSocketReadMaxedOutError,     // Reached set maxLength without completing
-	GCDAsyncSocketClosedError,           // The remote peer closed the connection
-	GCDAsyncSocketOtherError,            // Description provided in userInfo
+    GCDAsyncSocketNoError = 0,           // Never used
+    GCDAsyncSocketBadConfigError,        // Invalid configuration
+    GCDAsyncSocketBadParamError,         // Invalid parameter was passed
+    GCDAsyncSocketConnectTimeoutError,   // A connect operation timed out
+    GCDAsyncSocketReadTimeoutError,      // A read operation timed out
+    GCDAsyncSocketWriteTimeoutError,     // A write operation timed out
+    GCDAsyncSocketReadMaxedOutError,     // Reached set maxLength without completing
+    GCDAsyncSocketClosedError,           // The remote peer closed the connection
+    GCDAsyncSocketOtherError,            // Description provided in userInfo
 };
 typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 
@@ -104,18 +70,18 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * GCDAsyncSocket uses the standard delegate paradigm,
  * but executes all delegate callbacks on a given delegate dispatch queue.
  * This allows for maximum concurrency, while at the same time providing easy thread safety.
- * 
+ *
  * You MUST set a delegate AND delegate dispatch queue before attempting to
  * use the socket, or you will get an error.
- * 
+ *
  * The socket queue is optional.
  * If you pass NULL, GCDAsyncSocket will automatically create it's own socket queue.
  * If you choose to provide a socket queue, the socket queue must not be a concurrent queue.
  * If you choose to provide a socket queue, and the socket queue has a configured target queue,
  * then please see the discussion for the method markSocketQueueTargetQueue.
- * 
+ *
  * The delegate queue and socket queue can optionally be the same.
-**/
+ **/
 - (id)init;
 - (id)initWithSocketQueue:(dispatch_queue_t)sq;
 - (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq;
@@ -123,45 +89,47 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 
 #pragma mark Configuration
 
-- (id)delegate;
-- (void)setDelegate:(id)delegate;
-- (void)synchronouslySetDelegate:(id)delegate;
-
-- (dispatch_queue_t)delegateQueue;
-- (void)setDelegateQueue:(dispatch_queue_t)delegateQueue;
-- (void)synchronouslySetDelegateQueue:(dispatch_queue_t)delegateQueue;
+@property (atomic, weak, readwrite) id delegate;
+#if OS_OBJECT_USE_OBJC
+@property (atomic, strong, readwrite) dispatch_queue_t delegateQueue;
+#else
+@property (atomic, assign, readwrite) dispatch_queue_t delegateQueue;
+#endif
 
 - (void)getDelegate:(id *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr;
 - (void)setDelegate:(id)delegate delegateQueue:(dispatch_queue_t)delegateQueue;
+
+/**
+ * If you are setting the delegate to nil within the delegate's dealloc method,
+ * you may need to use the synchronous versions below.
+ **/
+- (void)synchronouslySetDelegate:(id)delegate;
+- (void)synchronouslySetDelegateQueue:(dispatch_queue_t)delegateQueue;
 - (void)synchronouslySetDelegate:(id)delegate delegateQueue:(dispatch_queue_t)delegateQueue;
 
 /**
  * By default, both IPv4 and IPv6 are enabled.
- * 
+ *
  * For accepting incoming connections, this means GCDAsyncSocket automatically supports both protocols,
  * and can simulataneously accept incoming connections on either protocol.
- * 
+ *
  * For outgoing connections, this means GCDAsyncSocket can connect to remote hosts running either protocol.
  * If a DNS lookup returns only IPv4 results, GCDAsyncSocket will automatically use IPv4.
  * If a DNS lookup returns only IPv6 results, GCDAsyncSocket will automatically use IPv6.
  * If a DNS lookup returns both IPv4 and IPv6 results, the preferred protocol will be chosen.
  * By default, the preferred protocol is IPv4, but may be configured as desired.
-**/
-- (BOOL)isIPv4Enabled;
-- (void)setIPv4Enabled:(BOOL)flag;
+ **/
 
-- (BOOL)isIPv6Enabled;
-- (void)setIPv6Enabled:(BOOL)flag;
+@property (atomic, assign, readwrite, getter=isIPv4Enabled) BOOL IPv4Enabled;
+@property (atomic, assign, readwrite, getter=isIPv6Enabled) BOOL IPv6Enabled;
 
-- (BOOL)isIPv4PreferredOverIPv6;
-- (void)setPreferIPv4OverIPv6:(BOOL)flag;
+@property (atomic, assign, readwrite, getter=isIPv4PreferredOverIPv6) BOOL IPv4PreferredOverIPv6;
 
 /**
  * User data allows you to associate arbitrary information with the socket.
  * This data is not used internally by socket in any way.
-**/
-- (id)userData;
-- (void)setUserData:(id)arbitraryUserData;
+ **/
+@property (atomic, strong, readwrite) id userData;
 
 #pragma mark Accepting
 
@@ -169,44 +137,44 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * Tells the socket to begin listening and accepting connections on the given port.
  * When a connection is accepted, a new instance of GCDAsyncSocket will be spawned to handle it,
  * and the socket:didAcceptNewSocket: delegate method will be invoked.
- * 
+ *
  * The socket will listen on all available interfaces (e.g. wifi, ethernet, etc)
-**/
+ **/
 - (BOOL)acceptOnPort:(uint16_t)port error:(NSError **)errPtr;
 
 /**
  * This method is the same as acceptOnPort:error: with the
  * additional option of specifying which interface to listen on.
- * 
+ *
  * For example, you could specify that the socket should only accept connections over ethernet,
  * and not other interfaces such as wifi.
- * 
+ *
  * The interface may be specified by name (e.g. "en1" or "lo0") or by IP address (e.g. "192.168.4.34").
  * You may also use the special strings "localhost" or "loopback" to specify that
  * the socket only accept connections from the local machine.
- * 
+ *
  * You can see the list of interfaces via the command line utility "ifconfig",
  * or programmatically via the getifaddrs() function.
- * 
+ *
  * To accept connections on any interface pass nil, or simply use the acceptOnPort:error: method.
-**/
+ **/
 - (BOOL)acceptOnInterface:(NSString *)interface port:(uint16_t)port error:(NSError **)errPtr;
 
 #pragma mark Connecting
 
 /**
  * Connects to the given host and port.
- * 
+ *
  * This method invokes connectToHost:onPort:viaInterface:withTimeout:error:
  * and uses the default interface, and no timeout.
-**/
+ **/
 - (BOOL)connectToHost:(NSString *)host onPort:(uint16_t)port error:(NSError **)errPtr;
 
 /**
  * Connects to the given host and port with an optional timeout.
- * 
+ *
  * This method invokes connectToHost:onPort:viaInterface:withTimeout:error: and uses the default interface.
-**/
+ **/
 - (BOOL)connectToHost:(NSString *)host
                onPort:(uint16_t)port
           withTimeout:(NSTimeInterval)timeout
@@ -214,26 +182,26 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 
 /**
  * Connects to the given host & port, via the optional interface, with an optional timeout.
- * 
+ *
  * The host may be a domain name (e.g. "deusty.com") or an IP address string (e.g. "192.168.0.2").
  * The host may also be the special strings "localhost" or "loopback" to specify connecting
  * to a service on the local machine.
- * 
+ *
  * The interface may be a name (e.g. "en1" or "lo0") or the corresponding IP address (e.g. "192.168.4.35").
  * The interface may also be used to specify the local port (see below).
- * 
+ *
  * To not time out use a negative time interval.
- * 
+ *
  * This method will return NO if an error is detected, and set the error pointer (if one was given).
  * Possible errors would be a nil host, invalid interface, or socket is already connected.
- * 
+ *
  * If no errors are detected, this method will start a background connect operation and immediately return YES.
  * The delegate callbacks are used to notify you when the socket connects, or if the host was unreachable.
- * 
+ *
  * Since this class supports queued reads and writes, you can immediately start reading and/or writing.
  * All read/write operations will be queued, and upon socket connection,
  * the operations will be dequeued and processed in order.
- * 
+ *
  * The interface may optionally contain a port number at the end of the string, separated by a colon.
  * This allows you to specify the local port that should be used for the outgoing connection. (read paragraph to end)
  * To specify both interface and local port: "en1:8082" or "192.168.4.35:2424".
@@ -243,7 +211,7 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * If you think you need to, there is a very good chance you have a fundamental misunderstanding somewhere.
  * Local ports do NOT need to match remote ports. In fact, they almost never do.
  * This feature is here for networking professionals using very advanced techniques.
-**/
+ **/
 - (BOOL)connectToHost:(NSString *)host
                onPort:(uint16_t)port
          viaInterface:(NSString *)interface
@@ -253,46 +221,46 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 /**
  * Connects to the given address, specified as a sockaddr structure wrapped in a NSData object.
  * For example, a NSData object returned from NSNetService's addresses method.
- * 
+ *
  * If you have an existing struct sockaddr you can convert it to a NSData object like so:
  * struct sockaddr sa  -> NSData *dsa = [NSData dataWithBytes:&remoteAddr length:remoteAddr.sa_len];
  * struct sockaddr *sa -> NSData *dsa = [NSData dataWithBytes:remoteAddr length:remoteAddr->sa_len];
- * 
+ *
  * This method invokes connectToAdd
-**/
+ **/
 - (BOOL)connectToAddress:(NSData *)remoteAddr error:(NSError **)errPtr;
 
 /**
  * This method is the same as connectToAddress:error: with an additional timeout option.
  * To not time out use a negative time interval, or simply use the connectToAddress:error: method.
-**/
+ **/
 - (BOOL)connectToAddress:(NSData *)remoteAddr withTimeout:(NSTimeInterval)timeout error:(NSError **)errPtr;
 
 /**
  * Connects to the given address, using the specified interface and timeout.
- * 
+ *
  * The address is specified as a sockaddr structure wrapped in a NSData object.
  * For example, a NSData object returned from NSNetService's addresses method.
- * 
+ *
  * If you have an existing struct sockaddr you can convert it to a NSData object like so:
  * struct sockaddr sa  -> NSData *dsa = [NSData dataWithBytes:&remoteAddr length:remoteAddr.sa_len];
  * struct sockaddr *sa -> NSData *dsa = [NSData dataWithBytes:remoteAddr length:remoteAddr->sa_len];
- * 
+ *
  * The interface may be a name (e.g. "en1" or "lo0") or the corresponding IP address (e.g. "192.168.4.35").
  * The interface may also be used to specify the local port (see below).
- * 
+ *
  * The timeout is optional. To not time out use a negative time interval.
- * 
+ *
  * This method will return NO if an error is detected, and set the error pointer (if one was given).
  * Possible errors would be a nil host, invalid interface, or socket is already connected.
- * 
+ *
  * If no errors are detected, this method will start a background connect operation and immediately return YES.
  * The delegate callbacks are used to notify you when the socket connects, or if the host was unreachable.
- * 
+ *
  * Since this class supports queued reads and writes, you can immediately start reading and/or writing.
  * All read/write operations will be queued, and upon socket connection,
  * the operations will be dequeued and processed in order.
- * 
+ *
  * The interface may optionally contain a port number at the end of the string, separated by a colon.
  * This allows you to specify the local port that should be used for the outgoing connection. (read paragraph to end)
  * To specify both interface and local port: "en1:8082" or "192.168.4.35:2424".
@@ -302,7 +270,7 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * If you think you need to, there is a very good chance you have a fundamental misunderstanding somewhere.
  * Local ports do NOT need to match remote ports. In fact, they almost never do.
  * This feature is here for networking professionals using very advanced techniques.
-**/
+ **/
 - (BOOL)connectToAddress:(NSData *)remoteAddr
             viaInterface:(NSString *)interface
              withTimeout:(NSTimeInterval)timeout
@@ -312,152 +280,155 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 
 /**
  * Disconnects immediately (synchronously). Any pending reads or writes are dropped.
- * 
+ *
  * If the socket is not already disconnected, an invocation to the socketDidDisconnect:withError: delegate method
  * will be queued onto the delegateQueue asynchronously (behind any previously queued delegate methods).
  * In other words, the disconnected delegate method will be invoked sometime shortly after this method returns.
- * 
+ *
  * Please note the recommended way of releasing a GCDAsyncSocket instance (e.g. in a dealloc method)
  * [asyncSocket setDelegate:nil];
  * [asyncSocket disconnect];
  * [asyncSocket release];
- * 
+ *
  * If you plan on disconnecting the socket, and then immediately asking it to connect again,
  * you'll likely want to do so like this:
  * [asyncSocket setDelegate:nil];
  * [asyncSocket disconnect];
  * [asyncSocket setDelegate:self];
  * [asyncSocket connect...];
-**/
+ **/
 - (void)disconnect;
 
 /**
  * Disconnects after all pending reads have completed.
  * After calling this, the read and write methods will do nothing.
  * The socket will disconnect even if there are still pending writes.
-**/
+ **/
 - (void)disconnectAfterReading;
 
 /**
  * Disconnects after all pending writes have completed.
  * After calling this, the read and write methods will do nothing.
  * The socket will disconnect even if there are still pending reads.
-**/
+ **/
 - (void)disconnectAfterWriting;
 
 /**
  * Disconnects after all pending reads and writes have completed.
  * After calling this, the read and write methods will do nothing.
-**/
+ **/
 - (void)disconnectAfterReadingAndWriting;
 
 #pragma mark Diagnostics
 
 /**
  * Returns whether the socket is disconnected or connected.
- * 
+ *
  * A disconnected socket may be recycled.
  * That is, it can used again for connecting or listening.
- * 
+ *
  * If a socket is in the process of connecting, it may be neither disconnected nor connected.
-**/
-- (BOOL)isDisconnected;
-- (BOOL)isConnected;
+ **/
+@property (atomic, readonly) BOOL isDisconnected;
+@property (atomic, readonly) BOOL isConnected;
 
 /**
  * Returns the local or remote host and port to which this socket is connected, or nil and 0 if not connected.
  * The host will be an IP address.
-**/
-- (NSString *)connectedHost;
-- (uint16_t)connectedPort;
+ **/
+@property (atomic, readonly) NSString *connectedHost;
+@property (atomic, readonly) uint16_t  connectedPort;
 
-- (NSString *)localHost;
-- (uint16_t)localPort;
+@property (atomic, readonly) NSString *localHost;
+@property (atomic, readonly) uint16_t  localPort;
 
 /**
  * Returns the local or remote address to which this socket is connected,
  * specified as a sockaddr structure wrapped in a NSData object.
- * 
- * See also the connectedHost, connectedPort, localHost and localPort methods.
-**/
-- (NSData *)connectedAddress;
-- (NSData *)localAddress;
+ *
+ * @seealso connectedHost
+ * @seealso connectedPort
+ * @seealso localHost
+ * @seealso localPort
+ **/
+@property (atomic, readonly) NSData *connectedAddress;
+@property (atomic, readonly) NSData *localAddress;
 
 /**
  * Returns whether the socket is IPv4 or IPv6.
  * An accepting socket may be both.
-**/
-- (BOOL)isIPv4;
-- (BOOL)isIPv6;
+ **/
+@property (atomic, readonly) BOOL isIPv4;
+@property (atomic, readonly) BOOL isIPv6;
 
 /**
  * Returns whether or not the socket has been secured via SSL/TLS.
- * 
+ *
  * See also the startTLS method.
-**/
-- (BOOL)isSecure;
+ **/
+@property (atomic, readonly) BOOL isSecure;
 
 #pragma mark Reading
 
 // The readData and writeData methods won't block (they are asynchronous).
-// 
+//
 // When a read is complete the socket:didReadData:withTag: delegate method is dispatched on the delegateQueue.
 // When a write is complete the socket:didWriteDataWithTag: delegate method is dispatched on the delegateQueue.
-// 
+//
 // You may optionally set a timeout for any read/write operation. (To not timeout, use a negative time interval.)
 // If a read/write opertion times out, the corresponding "socket:shouldTimeout..." delegate method
 // is called to optionally allow you to extend the timeout.
 // Upon a timeout, the "socket:didDisconnectWithError:" method is called
-// 
+//
 // The tag is for your convenience.
 // You can use it as an array index, step number, state id, pointer, etc.
 
 /**
  * Reads the first available bytes that become available on the socket.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
-**/
+ **/
 - (void)readDataWithTimeout:(NSTimeInterval)timeout tag:(long)tag;
 
 /**
  * Reads the first available bytes that become available on the socket.
  * The bytes will be appended to the given byte buffer starting at the given offset.
  * The given buffer will automatically be increased in size if needed.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
  * If the buffer if nil, the socket will create a buffer for you.
- * 
+ *
  * If the bufferOffset is greater than the length of the given buffer,
  * the method will do nothing, and the delegate will not be called.
- * 
+ *
  * If you pass a buffer, you must not alter it in any way while the socket is using it.
  * After completion, the data returned in socket:didReadData:withTag: will be a subset of the given buffer.
  * That is, it will reference the bytes that were appended to the given buffer via
  * the method [NSData dataWithBytesNoCopy:length:freeWhenDone:NO].
-**/
+ **/
 - (void)readDataWithTimeout:(NSTimeInterval)timeout
-					 buffer:(NSMutableData *)buffer
-			   bufferOffset:(NSUInteger)offset
-						tag:(long)tag;
+                     buffer:(NSMutableData *)buffer
+               bufferOffset:(NSUInteger)offset
+                        tag:(long)tag;
 
 /**
  * Reads the first available bytes that become available on the socket.
  * The bytes will be appended to the given byte buffer starting at the given offset.
  * The given buffer will automatically be increased in size if needed.
  * A maximum of length bytes will be read.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
  * If the buffer if nil, a buffer will automatically be created for you.
  * If maxLength is zero, no length restriction is enforced.
- * 
+ *
  * If the bufferOffset is greater than the length of the given buffer,
  * the method will do nothing, and the delegate will not be called.
- * 
+ *
  * If you pass a buffer, you must not alter it in any way while the socket is using it.
  * After completion, the data returned in socket:didReadData:withTag: will be a subset of the given buffer.
  * That is, it will reference the bytes that were appended to the given buffer  via
  * the method [NSData dataWithBytesNoCopy:length:freeWhenDone:NO].
-**/
+ **/
 - (void)readDataWithTimeout:(NSTimeInterval)timeout
                      buffer:(NSMutableData *)buffer
                bufferOffset:(NSUInteger)offset
@@ -466,30 +437,30 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 
 /**
  * Reads the given number of bytes.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
- * 
+ *
  * If the length is 0, this method does nothing and the delegate is not called.
-**/
+ **/
 - (void)readDataToLength:(NSUInteger)length withTimeout:(NSTimeInterval)timeout tag:(long)tag;
 
 /**
  * Reads the given number of bytes.
  * The bytes will be appended to the given byte buffer starting at the given offset.
  * The given buffer will automatically be increased in size if needed.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
  * If the buffer if nil, a buffer will automatically be created for you.
- * 
+ *
  * If the length is 0, this method does nothing and the delegate is not called.
  * If the bufferOffset is greater than the length of the given buffer,
  * the method will do nothing, and the delegate will not be called.
- * 
+ *
  * If you pass a buffer, you must not alter it in any way while AsyncSocket is using it.
  * After completion, the data returned in socket:didReadData:withTag: will be a subset of the given buffer.
  * That is, it will reference the bytes that were appended to the given buffer via
  * the method [NSData dataWithBytesNoCopy:length:freeWhenDone:NO].
-**/
+ **/
 - (void)readDataToLength:(NSUInteger)length
              withTimeout:(NSTimeInterval)timeout
                   buffer:(NSMutableData *)buffer
@@ -498,12 +469,12 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 
 /**
  * Reads bytes until (and including) the passed "data" parameter, which acts as a separator.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
- * 
+ *
  * If you pass nil or zero-length data as the "data" parameter,
  * the method will do nothing (except maybe print a warning), and the delegate will not be called.
- * 
+ *
  * To read a line from the socket, use the line separator (e.g. CRLF for HTTP, see below) as the "data" parameter.
  * If you're developing your own custom protocol, be sure your separator can not occur naturally as
  * part of the data between separators.
@@ -512,29 +483,29 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * In this particular example, it would be better to use a protocol similar to HTTP with
  * a header that includes the length of the document.
  * Also be careful that your separator cannot occur naturally as part of the encoding for a character.
- * 
+ *
  * The given data (separator) parameter should be immutable.
  * For performance reasons, the socket will retain it, not copy it.
  * So if it is immutable, don't modify it while the socket is using it.
-**/
+ **/
 - (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag;
 
 /**
  * Reads bytes until (and including) the passed "data" parameter, which acts as a separator.
  * The bytes will be appended to the given byte buffer starting at the given offset.
  * The given buffer will automatically be increased in size if needed.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
  * If the buffer if nil, a buffer will automatically be created for you.
- * 
+ *
  * If the bufferOffset is greater than the length of the given buffer,
  * the method will do nothing (except maybe print a warning), and the delegate will not be called.
- * 
+ *
  * If you pass a buffer, you must not alter it in any way while the socket is using it.
  * After completion, the data returned in socket:didReadData:withTag: will be a subset of the given buffer.
  * That is, it will reference the bytes that were appended to the given buffer via
  * the method [NSData dataWithBytesNoCopy:length:freeWhenDone:NO].
- * 
+ *
  * To read a line from the socket, use the line separator (e.g. CRLF for HTTP, see below) as the "data" parameter.
  * If you're developing your own custom protocol, be sure your separator can not occur naturally as
  * part of the data between separators.
@@ -543,11 +514,11 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * In this particular example, it would be better to use a protocol similar to HTTP with
  * a header that includes the length of the document.
  * Also be careful that your separator cannot occur naturally as part of the encoding for a character.
- * 
+ *
  * The given data (separator) parameter should be immutable.
  * For performance reasons, the socket will retain it, not copy it.
  * So if it is immutable, don't modify it while the socket is using it.
-**/
+ **/
 - (void)readDataToData:(NSData *)data
            withTimeout:(NSTimeInterval)timeout
                 buffer:(NSMutableData *)buffer
@@ -556,19 +527,19 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 
 /**
  * Reads bytes until (and including) the passed "data" parameter, which acts as a separator.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
- * 
+ *
  * If maxLength is zero, no length restriction is enforced.
  * Otherwise if maxLength bytes are read without completing the read,
  * it is treated similarly to a timeout - the socket is closed with a GCDAsyncSocketReadMaxedOutError.
  * The read will complete successfully if exactly maxLength bytes are read and the given data is found at the end.
- * 
+ *
  * If you pass nil or zero-length data as the "data" parameter,
  * the method will do nothing (except maybe print a warning), and the delegate will not be called.
  * If you pass a maxLength parameter that is less than the length of the data parameter,
  * the method will do nothing (except maybe print a warning), and the delegate will not be called.
- * 
+ *
  * To read a line from the socket, use the line separator (e.g. CRLF for HTTP, see below) as the "data" parameter.
  * If you're developing your own custom protocol, be sure your separator can not occur naturally as
  * part of the data between separators.
@@ -577,36 +548,36 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * In this particular example, it would be better to use a protocol similar to HTTP with
  * a header that includes the length of the document.
  * Also be careful that your separator cannot occur naturally as part of the encoding for a character.
- * 
+ *
  * The given data (separator) parameter should be immutable.
  * For performance reasons, the socket will retain it, not copy it.
  * So if it is immutable, don't modify it while the socket is using it.
-**/
+ **/
 - (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout maxLength:(NSUInteger)length tag:(long)tag;
 
 /**
  * Reads bytes until (and including) the passed "data" parameter, which acts as a separator.
  * The bytes will be appended to the given byte buffer starting at the given offset.
  * The given buffer will automatically be increased in size if needed.
- * 
+ *
  * If the timeout value is negative, the read operation will not use a timeout.
  * If the buffer if nil, a buffer will automatically be created for you.
- * 
+ *
  * If maxLength is zero, no length restriction is enforced.
  * Otherwise if maxLength bytes are read without completing the read,
  * it is treated similarly to a timeout - the socket is closed with a GCDAsyncSocketReadMaxedOutError.
  * The read will complete successfully if exactly maxLength bytes are read and the given data is found at the end.
- * 
+ *
  * If you pass a maxLength parameter that is less than the length of the data (separator) parameter,
  * the method will do nothing (except maybe print a warning), and the delegate will not be called.
  * If the bufferOffset is greater than the length of the given buffer,
  * the method will do nothing (except maybe print a warning), and the delegate will not be called.
- * 
+ *
  * If you pass a buffer, you must not alter it in any way while the socket is using it.
  * After completion, the data returned in socket:didReadData:withTag: will be a subset of the given buffer.
  * That is, it will reference the bytes that were appended to the given buffer via
  * the method [NSData dataWithBytesNoCopy:length:freeWhenDone:NO].
- * 
+ *
  * To read a line from the socket, use the line separator (e.g. CRLF for HTTP, see below) as the "data" parameter.
  * If you're developing your own custom protocol, be sure your separator can not occur naturally as
  * part of the data between separators.
@@ -615,11 +586,11 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * In this particular example, it would be better to use a protocol similar to HTTP with
  * a header that includes the length of the document.
  * Also be careful that your separator cannot occur naturally as part of the encoding for a character.
- * 
+ *
  * The given data (separator) parameter should be immutable.
  * For performance reasons, the socket will retain it, not copy it.
  * So if it is immutable, don't modify it while the socket is using it.
-**/
+ **/
 - (void)readDataToData:(NSData *)data
            withTimeout:(NSTimeInterval)timeout
                 buffer:(NSMutableData *)buffer
@@ -630,17 +601,17 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 /**
  * Returns progress of the current read, from 0.0 to 1.0, or NaN if no current read (use isnan() to check).
  * The parameters "tag", "done" and "total" will be filled in if they aren't NULL.
-**/
+ **/
 - (float)progressOfReadReturningTag:(long *)tagPtr bytesDone:(NSUInteger *)donePtr total:(NSUInteger *)totalPtr;
 
 #pragma mark Writing
 
 /**
  * Writes data to the socket, and calls the delegate when finished.
- * 
+ *
  * If you pass in nil or zero-length data, this method does nothing and the delegate will not be called.
  * If the timeout value is negative, the write operation will not use a timeout.
- * 
+ *
  * Thread-Safety Note:
  * If the given data parameter is mutable (NSMutableData) then you MUST NOT alter the data while
  * the socket is writing it. In other words, it's not safe to alter the data until after the delegate method
@@ -651,53 +622,134 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * If you need to write data from an immutable buffer, and you need to alter the buffer before the socket
  * completes writing the bytes (which is NOT immediately after this method returns, but rather at a later time
  * when the delegate method notifies you), then you should first copy the bytes, and pass the copy to this method.
-**/
+ **/
 - (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag;
 
 /**
  * Returns progress of the current write, from 0.0 to 1.0, or NaN if no current write (use isnan() to check).
  * The parameters "tag", "done" and "total" will be filled in if they aren't NULL.
-**/
+ **/
 - (float)progressOfWriteReturningTag:(long *)tagPtr bytesDone:(NSUInteger *)donePtr total:(NSUInteger *)totalPtr;
 
 #pragma mark Security
 
 /**
  * Secures the connection using SSL/TLS.
- * 
+ *
  * This method may be called at any time, and the TLS handshake will occur after all pending reads and writes
  * are finished. This allows one the option of sending a protocol dependent StartTLS message, and queuing
  * the upgrade to TLS at the same time, without having to wait for the write to finish.
  * Any reads or writes scheduled after this method is called will occur over the secured connection.
- * 
- * The possible keys and values for the TLS settings are well documented.
- * Standard keys are:
- * 
- * - kCFStreamSSLLevel
- * - kCFStreamSSLAllowsExpiredCertificates
- * - kCFStreamSSLAllowsExpiredRoots
- * - kCFStreamSSLAllowsAnyRoot
- * - kCFStreamSSLValidatesCertificateChain
+ *
+ * ==== The available TOP-LEVEL KEYS are:
+ *
+ * - GCDAsyncSocketManuallyEvaluateTrust
+ *     The value must be of type NSNumber, encapsulating a BOOL value.
+ *     If you set this to YES, then the underlying SecureTransport system will not evaluate the SecTrustRef of the peer.
+ *     Instead it will pause at the moment evaulation would typically occur,
+ *     and allow us to handle the security evaluation however we see fit.
+ *     So GCDAsyncSocket will invoke the delegate method socket:shouldTrustPeer: passing the SecTrustRef.
+ *
+ *     Note that if you set this option, then all other configuration keys are ignored.
+ *     Evaluation will be completely up to you during the socket:didReceiveTrust:completionHandler: delegate method.
+ *
+ *     For more information on trust evaluation see:
+ *     Apple's Technical Note TN2232 - HTTPS Server Trust Evaluation
+ *     https://developer.apple.com/library/ios/technotes/tn2232/_index.html
+ *
+ *     If unspecified, the default value is NO.
+ *
+ * - GCDAsyncSocketUseCFStreamForTLS (iOS only)
+ *     The value must be of type NSNumber, encapsulating a BOOL value.
+ *     By default GCDAsyncSocket will use the SecureTransport layer to perform encryption.
+ *     This gives us more control over the security protocol (many more configuration options),
+ *     plus it allows us to optimize things like sys calls and buffer allocation.
+ *
+ *     However, if you absolutely must, you can instruct GCDAsyncSocket to use the old-fashioned encryption
+ *     technique by going through the CFStream instead. So instead of using SecureTransport, GCDAsyncSocket
+ *     will instead setup a CFRead/CFWriteStream. And then set the kCFStreamPropertySSLSettings property
+ *     (via CFReadStreamSetProperty / CFWriteStreamSetProperty) and will pass the given options to this method.
+ *
+ *     Thus all the other keys in the given dictionary will be ignored by GCDAsyncSocket,
+ *     and will passed directly CFReadStreamSetProperty / CFWriteStreamSetProperty.
+ *     For more infomation on these keys, please see the documentation for kCFStreamPropertySSLSettings.
+ *
+ *     If unspecified, the default value is NO.
+ *
+ * ==== The available CONFIGURATION KEYS are:
+ *
  * - kCFStreamSSLPeerName
+ *     The value must be of type NSString.
+ *     It should match the name in the X.509 certificate given by the remote party.
+ *     See Apple's documentation for SSLSetPeerDomainName.
+ *
  * - kCFStreamSSLCertificates
+ *     The value must be of type NSArray.
+ *     See Apple's documentation for SSLSetCertificate.
+ *
  * - kCFStreamSSLIsServer
- * 
- * If SecureTransport is available on iOS:
- * 
- * - GCDAsyncSocketSSLCipherSuites
+ *     The value must be of type NSNumber, encapsulationg a BOOL value.
+ *     See Apple's documentation for SSLCreateContext for iOS.
+ *     This is optional for iOS. If not supplied, a NO value is the default.
+ *     This is not needed for Mac OS X, and the value is ignored.
+ *
+ * - GCDAsyncSocketSSLPeerID
+ *     The value must be of type NSData.
+ *     You must set this value if you want to use TLS session resumption.
+ *     See Apple's documentation for SSLSetPeerID.
+ *
  * - GCDAsyncSocketSSLProtocolVersionMin
  * - GCDAsyncSocketSSLProtocolVersionMax
- * 
- * If SecureTransport is available on Mac OS X:
- * 
+ *     The value(s) must be of type NSNumber, encapsulting a SSLProtocol value.
+ *     See Apple's documentation for SSLSetProtocolVersionMin & SSLSetProtocolVersionMax.
+ *     See also the SSLProtocol typedef.
+ *
+ * - GCDAsyncSocketSSLSessionOptionFalseStart
+ *     The value must be of type NSNumber, encapsulating a BOOL value.
+ *     See Apple's documentation for kSSLSessionOptionFalseStart.
+ *
+ * - GCDAsyncSocketSSLSessionOptionSendOneByteRecord
+ *     The value must be of type NSNumber, encapsulating a BOOL value.
+ *     See Apple's documentation for kSSLSessionOptionSendOneByteRecord.
+ *
  * - GCDAsyncSocketSSLCipherSuites
- * - GCDAsyncSocketSSLDiffieHellmanParameters;
- * 
- * 
- * Please refer to Apple's documentation for associated values, as well as other possible keys.
- * 
+ *     The values must be of type NSArray.
+ *     Each item within the array must be a NSNumber, encapsulating
+ *     See Apple's documentation for SSLSetEnabledCiphers.
+ *     See also the SSLCipherSuite typedef.
+ *
+ * - GCDAsyncSocketSSLDiffieHellmanParameters (Mac OS X only)
+ *     The value must be of type NSData.
+ *     See Apple's documentation for SSLSetDiffieHellmanParams.
+ *
+ * ==== The following UNAVAILABLE KEYS are: (with throw an exception)
+ *
+ * - kCFStreamSSLAllowsAnyRoot (UNAVAILABLE)
+ *     You MUST use manual trust evaluation instead (see GCDAsyncSocketManuallyEvaluateTrust).
+ *     Corresponding deprecated method: SSLSetAllowsAnyRoot
+ *
+ * - kCFStreamSSLAllowsExpiredRoots (UNAVAILABLE)
+ *     You MUST use manual trust evaluation instead (see GCDAsyncSocketManuallyEvaluateTrust).
+ *     Corresponding deprecated method: SSLSetAllowsExpiredRoots
+ *
+ * - kCFStreamSSLAllowsExpiredCertificates (UNAVAILABLE)
+ *     You MUST use manual trust evaluation instead (see GCDAsyncSocketManuallyEvaluateTrust).
+ *     Corresponding deprecated method: SSLSetAllowsExpiredCerts
+ *
+ * - kCFStreamSSLValidatesCertificateChain (UNAVAILABLE)
+ *     You MUST use manual trust evaluation instead (see GCDAsyncSocketManuallyEvaluateTrust).
+ *     Corresponding deprecated method: SSLSetEnableCertVerify
+ *
+ * - kCFStreamSSLLevel (UNAVAILABLE)
+ *     You MUST use GCDAsyncSocketSSLProtocolVersionMin & GCDAsyncSocketSSLProtocolVersionMin instead.
+ *     Corresponding deprecated method: SSLSetProtocolVersionEnabled
+ *
+ *
+ * Please refer to Apple's documentation for corresponding SSLFunctions.
+ *
  * If you pass in nil or an empty dictionary, the default settings will be used.
- * 
+ *
+ * IMPORTANT SECURITY NOTE:
  * The default settings will check to make sure the remote party's certificate is signed by a
  * trusted 3rd party certificate agency (e.g. verisign) and that the certificate is not expired.
  * However it will not verify the name on the certificate unless you
@@ -709,10 +761,8 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * the default settings will not detect any problems since the certificate is valid.
  * To properly secure your connection in this particular scenario you
  * should set the kCFStreamSSLPeerName property to "MySecureServer.com".
- * If you do not know the peer name of the remote host in advance (for example, you're not sure
- * if it will be "domain.com" or "www.domain.com"), then you can use the default settings to validate the
- * certificate, and then use the X509Certificate class to verify the issuer after the socket has been secured.
- * The X509Certificate class is part of the CocoaAsyncSocket open source project.
+ *
+ * You can also perform additional validation in socketDidSecure.
  **/
 - (void)startTLS:(NSDictionary *)tlsSettings;
 
@@ -723,21 +773,21 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * However, it is technically possible for the remote enpoint to close its write stream.
  * Our socket would then be notified that there is no more data to be read,
  * but our socket would still be writeable and the remote endpoint could continue to receive our data.
- * 
+ *
  * The argument for this confusing functionality stems from the idea that a client could shut down its
  * write stream after sending a request to the server, thus notifying the server there are to be no further requests.
  * In practice, however, this technique did little to help server developers.
- * 
+ *
  * To make matters worse, from a TCP perspective there is no way to tell the difference from a read stream close
  * and a full socket close. They both result in the TCP stack receiving a FIN packet. The only way to tell
  * is by continuing to write to the socket. If it was only a read stream close, then writes will continue to work.
  * Otherwise an error will be occur shortly (when the remote end sends us a RST packet).
- * 
+ *
  * In addition to the technical challenges and confusion, many high level socket/stream API's provide
  * no support for dealing with the problem. If the read stream is closed, the API immediately declares the
  * socket to be closed, and shuts down the write stream as well. In fact, this is what Apple's CFStream API does.
  * It might sound like poor design at first, but in fact it simplifies development.
- * 
+ *
  * The vast majority of the time if the read stream is closed it's because the remote endpoint closed its socket.
  * Thus it actually makes sense to close the socket at this point.
  * And in fact this is what most networking developers want and expect to happen.
@@ -745,11 +795,10 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * you might encounter a client that uses the discouraged technique of shutting down its write stream.
  * If this is the case, you can set this property to NO,
  * and make use of the socketDidCloseReadStream delegate method.
- * 
+ *
  * The default value is YES.
-**/
-- (BOOL)autoDisconnectOnClosedReadStream;
-- (void)setAutoDisconnectOnClosedReadStream:(BOOL)flag;
+ **/
+@property (atomic, assign, readwrite) BOOL autoDisconnectOnClosedReadStream;
 
 /**
  * GCDAsyncSocket maintains thread safety by using an internal serial dispatch_queue.
@@ -757,19 +806,19 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * However, to allow for maximum flexibility, the internal queue may be passed in the init method.
  * This allows for some advanced options such as controlling socket priority via target queues.
  * However, when one begins to use target queues like this, they open the door to some specific deadlock issues.
- * 
+ *
  * For example, imagine there are 2 queues:
  * dispatch_queue_t socketQueue;
  * dispatch_queue_t socketTargetQueue;
- * 
+ *
  * If you do this (pseudo-code):
  * socketQueue.targetQueue = socketTargetQueue;
- * 
+ *
  * Then all socketQueue operations will actually get run on the given socketTargetQueue.
  * This is fine and works great in most situations.
  * But if you run code directly from within the socketTargetQueue that accesses the socket,
  * you could potentially get deadlock. Imagine the following code:
- * 
+ *
  * - (BOOL)socketHasSomething
  * {
  *     __block BOOL result = NO;
@@ -780,20 +829,20 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  *         block();
  *     else
  *         dispatch_sync(socketQueue, block);
- *     
+ *
  *     return result;
  * }
- * 
+ *
  * What happens if you call this method from the socketTargetQueue? The result is deadlock.
  * This is because the GCD API offers no mechanism to discover a queue's targetQueue.
  * Thus we have no idea if our socketQueue is configured with a targetQueue.
  * If we had this information, we could easily avoid deadlock.
  * But, since these API's are missing or unfeasible, you'll have to explicitly set it.
- * 
+ *
  * IF you pass a socketQueue via the init method,
  * AND you've configured the passed socketQueue with a targetQueue,
  * THEN you should pass the end queue in the target hierarchy.
- * 
+ *
  * For example, consider the following queue hierarchy:
  * socketQueue -> ipQueue -> moduleQueue
  *
@@ -802,16 +851,16 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * And all connections for a particular module are executed on the same target queue.
  * Thus, the priority of all networking for the entire module can be changed on the fly.
  * Additionally, networking traffic from a single IP cannot monopolize the module.
- * 
+ *
  * Here's how you would accomplish something like that:
  * - (dispatch_queue_t)newSocketQueueForConnectionFromAddress:(NSData *)address onSocket:(GCDAsyncSocket *)sock
  * {
  *     dispatch_queue_t socketQueue = dispatch_queue_create("", NULL);
  *     dispatch_queue_t ipQueue = [self ipQueueForAddress:address];
- *     
+ *
  *     dispatch_set_target_queue(socketQueue, ipQueue);
  *     dispatch_set_target_queue(iqQueue, moduleQueue);
- *     
+ *
  *     return socketQueue;
  * }
  * - (void)socket:(GCDAsyncSocket *)sock didAcceptNewSocket:(GCDAsyncSocket *)newSocket
@@ -819,31 +868,31 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  *     [clientConnections addObject:newSocket];
  *     [newSocket markSocketQueueTargetQueue:moduleQueue];
  * }
- * 
+ *
  * Note: This workaround is ONLY needed if you intend to execute code directly on the ipQueue or moduleQueue.
  * This is often NOT the case, as such queues are used solely for execution shaping.
-**/
+ **/
 - (void)markSocketQueueTargetQueue:(dispatch_queue_t)socketQueuesPreConfiguredTargetQueue;
 - (void)unmarkSocketQueueTargetQueue:(dispatch_queue_t)socketQueuesPreviouslyConfiguredTargetQueue;
 
 /**
  * It's not thread-safe to access certain variables from outside the socket's internal queue.
- * 
+ *
  * For example, the socket file descriptor.
  * File descriptors are simply integers which reference an index in the per-process file table.
  * However, when one requests a new file descriptor (by opening a file or socket),
  * the file descriptor returned is guaranteed to be the lowest numbered unused descriptor.
  * So if we're not careful, the following could be possible:
- * 
+ *
  * - Thread A invokes a method which returns the socket's file descriptor.
  * - The socket is closed via the socket's internal queue on thread B.
  * - Thread C opens a file, and subsequently receives the file descriptor that was previously the socket's FD.
  * - Thread A is now accessing/altering the file instead of the socket.
- * 
+ *
  * In addition to this, other variables are not actually objects,
  * and thus cannot be retained/released or even autoreleased.
  * An example is the sslContext, of type SSLContextRef, which is actually a malloc'd struct.
- * 
+ *
  * Although there are internal variables that make it difficult to maintain thread-safety,
  * it is important to provide access to these variables
  * to ensure this class can be used in a wide array of environments.
@@ -851,19 +900,19 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * The methods below can be invoked from within the block to access
  * those generally thread-unsafe internal variables in a thread-safe manner.
  * The given block will be invoked synchronously on the socket's internal queue.
- * 
+ *
  * If you save references to any protected variables and use them outside the block, you do so at your own peril.
-**/
+ **/
 - (void)performBlock:(dispatch_block_t)block;
 
 /**
  * These methods are only available from within the context of a performBlock: invocation.
  * See the documentation for the performBlock: method above.
- * 
+ *
  * Provides access to the socket's file descriptor(s).
  * If the socket is a server socket (is accepting incoming connections),
  * it might actually have multiple internal socket file descriptors - one for IPv4 and one for IPv6.
-**/
+ **/
 - (int)socketFD;
 - (int)socket4FD;
 - (int)socket6FD;
@@ -873,84 +922,80 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 /**
  * These methods are only available from within the context of a performBlock: invocation.
  * See the documentation for the performBlock: method above.
- * 
+ *
  * Provides access to the socket's internal CFReadStream/CFWriteStream.
- * 
+ *
  * These streams are only used as workarounds for specific iOS shortcomings:
- * 
+ *
  * - Apple has decided to keep the SecureTransport framework private is iOS.
  *   This means the only supplied way to do SSL/TLS is via CFStream or some other API layered on top of it.
  *   Thus, in order to provide SSL/TLS support on iOS we are forced to rely on CFStream,
  *   instead of the preferred and faster and more powerful SecureTransport.
- * 
+ *
  * - If a socket doesn't have backgrounding enabled, and that socket is closed while the app is backgrounded,
  *   Apple only bothers to notify us via the CFStream API.
  *   The faster and more powerful GCD API isn't notified properly in this case.
- * 
+ *
  * See also: (BOOL)enableBackgroundingOnSocket
-**/
+ **/
 - (CFReadStreamRef)readStream;
 - (CFWriteStreamRef)writeStream;
 
 /**
  * This method is only available from within the context of a performBlock: invocation.
  * See the documentation for the performBlock: method above.
- * 
+ *
  * Configures the socket to allow it to operate when the iOS application has been backgrounded.
  * In other words, this method creates a read & write stream, and invokes:
- * 
+ *
  * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
  * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
- * 
+ *
  * Returns YES if successful, NO otherwise.
- * 
+ *
  * Note: Apple does not officially support backgrounding server sockets.
  * That is, if your socket is accepting incoming connections, Apple does not officially support
  * allowing iOS applications to accept incoming connections while an app is backgrounded.
- * 
+ *
  * Example usage:
- * 
+ *
  * - (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port
  * {
  *     [asyncSocket performBlock:^{
  *         [asyncSocket enableBackgroundingOnSocket];
  *     }];
  * }
-**/
+ **/
 - (BOOL)enableBackgroundingOnSocket;
 
 #endif
 
-#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-
 /**
  * This method is only available from within the context of a performBlock: invocation.
  * See the documentation for the performBlock: method above.
- * 
+ *
  * Provides access to the socket's SSLContext, if SSL/TLS has been started on the socket.
-**/
+ **/
 - (SSLContextRef)sslContext;
-
-#endif
 
 #pragma mark Utilities
 
 /**
  * The address lookup utility used by the class.
  * This method is synchronous, so it's recommended you use it on a background thread/queue.
- * 
+ *
  * The special strings "localhost" and "loopback" return the loopback address for IPv4 and IPv6.
- * 
+ *
  * @returns
  *   A mutable array with all IPv4 and IPv6 addresses returned by getaddrinfo.
  *   The addresses are specifically for TCP connections.
  *   You can filter the addresses, if needed, using the other utility methods provided by the class.
-**/
+ **/
 + (NSMutableArray *)lookupHost:(NSString *)host port:(uint16_t)port error:(NSError **)errPtr;
 
 /**
  * Extracting host and port information from raw address data.
-**/
+ **/
 
 + (NSString *)hostFromAddress:(NSData *)address;
 + (uint16_t)portFromAddress:(NSData *)address;
@@ -964,7 +1009,7 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 
 /**
  * A few common line separators, for use with the readDataToData:... methods.
-**/
+ **/
 + (NSData *)CRLFData;   // 0x0D0A
 + (NSData *)CRData;     // 0x0D
 + (NSData *)LFData;     // 0x0A
@@ -983,62 +1028,62 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * This method is called immediately prior to socket:didAcceptNewSocket:.
  * It optionally allows a listening socket to specify the socketQueue for a new accepted socket.
  * If this method is not implemented, or returns NULL, the new accepted socket will create its own default queue.
- * 
+ *
  * Since you cannot autorelease a dispatch_queue,
  * this method uses the "new" prefix in its name to specify that the returned queue has been retained.
- * 
+ *
  * Thus you could do something like this in the implementation:
  * return dispatch_queue_create("MyQueue", NULL);
- * 
+ *
  * If you are placing multiple sockets on the same queue,
  * then care should be taken to increment the retain count each time this method is invoked.
- * 
+ *
  * For example, your implementation might look something like this:
  * dispatch_retain(myExistingQueue);
  * return myExistingQueue;
-**/
+ **/
 - (dispatch_queue_t)newSocketQueueForConnectionFromAddress:(NSData *)address onSocket:(GCDAsyncSocket *)sock;
 
 /**
  * Called when a socket accepts a connection.
  * Another socket is automatically spawned to handle it.
- * 
+ *
  * You must retain the newSocket if you wish to handle the connection.
  * Otherwise the newSocket instance will be released and the spawned connection will be closed.
- * 
+ *
  * By default the new socket will have the same delegate and delegateQueue.
  * You may, of course, change this at any time.
-**/
+ **/
 - (void)socket:(GCDAsyncSocket *)sock didAcceptNewSocket:(GCDAsyncSocket *)newSocket;
 
 /**
  * Called when a socket connects and is ready for reading and writing.
  * The host parameter will be an IP address, not a DNS name.
-**/
+ **/
 - (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port;
 
 /**
  * Called when a socket has completed reading the requested data into memory.
  * Not called if there is an error.
-**/
+ **/
 - (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag;
 
 /**
  * Called when a socket has read in data, but has not yet completed the read.
  * This would occur if using readToData: or readToLength: methods.
  * It may be used to for things such as updating progress bars.
-**/
+ **/
 - (void)socket:(GCDAsyncSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength tag:(long)tag;
 
 /**
  * Called when a socket has completed writing the requested data. Not called if there is an error.
-**/
+ **/
 - (void)socket:(GCDAsyncSocket *)sock didWriteDataWithTag:(long)tag;
 
 /**
  * Called when a socket has written some data, but has not yet completed the entire write.
  * It may be used to for things such as updating progress bars.
-**/
+ **/
 - (void)socket:(GCDAsyncSocket *)sock didWritePartialDataOfLength:(NSUInteger)partialLength tag:(long)tag;
 
 /**
@@ -1046,69 +1091,89 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * This method allows you to optionally extend the timeout.
  * If you return a positive time interval (> 0) the read's timeout will be extended by the given amount.
  * If you don't implement this method, or return a non-positive time interval (<= 0) the read will timeout as usual.
- * 
+ *
  * The elapsed parameter is the sum of the original timeout, plus any additions previously added via this method.
  * The length parameter is the number of bytes that have been read so far for the read operation.
- * 
+ *
  * Note that this method may be called multiple times for a single read if you return positive numbers.
-**/
+ **/
 - (NSTimeInterval)socket:(GCDAsyncSocket *)sock shouldTimeoutReadWithTag:(long)tag
-                                                                 elapsed:(NSTimeInterval)elapsed
-                                                               bytesDone:(NSUInteger)length;
+                 elapsed:(NSTimeInterval)elapsed
+               bytesDone:(NSUInteger)length;
 
 /**
  * Called if a write operation has reached its timeout without completing.
  * This method allows you to optionally extend the timeout.
  * If you return a positive time interval (> 0) the write's timeout will be extended by the given amount.
  * If you don't implement this method, or return a non-positive time interval (<= 0) the write will timeout as usual.
- * 
+ *
  * The elapsed parameter is the sum of the original timeout, plus any additions previously added via this method.
  * The length parameter is the number of bytes that have been written so far for the write operation.
- * 
+ *
  * Note that this method may be called multiple times for a single write if you return positive numbers.
-**/
+ **/
 - (NSTimeInterval)socket:(GCDAsyncSocket *)sock shouldTimeoutWriteWithTag:(long)tag
-                                                                  elapsed:(NSTimeInterval)elapsed
-                                                                bytesDone:(NSUInteger)length;
+                 elapsed:(NSTimeInterval)elapsed
+               bytesDone:(NSUInteger)length;
 
 /**
  * Conditionally called if the read stream closes, but the write stream may still be writeable.
- * 
+ *
  * This delegate method is only called if autoDisconnectOnClosedReadStream has been set to NO.
  * See the discussion on the autoDisconnectOnClosedReadStream method for more information.
-**/
+ **/
 - (void)socketDidCloseReadStream:(GCDAsyncSocket *)sock;
 
 /**
  * Called when a socket disconnects with or without error.
- * 
+ *
  * If you call the disconnect method, and the socket wasn't already disconnected,
  * then an invocation of this delegate method will be enqueued on the delegateQueue
  * before the disconnect method returns.
- * 
+ *
  * Note: If the GCDAsyncSocket instance is deallocated while it is still connected,
  * and the delegate is not also deallocated, then this method will be invoked,
  * but the sock parameter will be nil. (It must necessarily be nil since it is no longer available.)
  * This is a generally rare, but is possible if one writes code like this:
- * 
+ *
  * asyncSocket = nil; // I'm implicitly disconnecting the socket
- * 
+ *
  * In this case it may preferrable to nil the delegate beforehand, like this:
- * 
+ *
  * asyncSocket.delegate = nil; // Don't invoke my delegate method
  * asyncSocket = nil; // I'm implicitly disconnecting the socket
- * 
+ *
  * Of course, this depends on how your state machine is configured.
-**/
+ **/
 - (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err;
 
 /**
  * Called after the socket has successfully completed SSL/TLS negotiation.
  * This method is not called unless you use the provided startTLS method.
- * 
+ *
  * If a SSL/TLS negotiation fails (invalid certificate, etc) then the socket will immediately close,
  * and the socketDidDisconnect:withError: delegate method will be called with the specific SSL error code.
-**/
+ **/
 - (void)socketDidSecure:(GCDAsyncSocket *)sock;
+
+/**
+ * Allows a socket delegate to hook into the TLS handshake and manually validate the peer it's connecting to.
+ *
+ * This is only called if startTLS is invoked with options that include:
+ * - GCDAsyncSocketManuallyEvaluateTrust == YES
+ *
+ * Typically the delegate will use SecTrustEvaluate (and related functions) to properly validate the peer.
+ *
+ * Note from Apple's documentation:
+ *   Because [SecTrustEvaluate] might look on the network for certificates in the certificate chain,
+ *   [it] might block while attempting network access. You should never call it from your main thread;
+ *   call it only from within a function running on a dispatch queue or on a separate thread.
+ *
+ * Thus this method uses a completionHandler block rather than a normal return value.
+ * The completionHandler block is thread-safe, and may be invoked from a background queue/thread.
+ * It is safe to invoke the completionHandler block even if the socket has been closed.
+ **/
+- (void)socket:(GCDAsyncSocket *)sock didReceiveTrust:(SecTrustRef)trust
+completionHandler:(void (^)(BOOL shouldTrustPeer))completionHandler;
 
 @end

--- a/CocoaMQTT/GCDAsyncSocket.m
+++ b/CocoaMQTT/GCDAsyncSocket.m
@@ -1,6 +1,6 @@
 //
 //  GCDAsyncSocket.m
-//  
+//
 //  This class is in the public domain.
 //  Originally created by Robbie Hanson in Q4 2010.
 //  Updated and maintained by Deusty LLC and the Apple development community.
@@ -14,6 +14,7 @@
 #import <CFNetwork/CFNetwork.h>
 #endif
 
+#import <TargetConditionals.h>
 #import <arpa/inet.h>
 #import <fcntl.h>
 #import <ifaddrs.h>
@@ -43,7 +44,7 @@
 
 // Logging uses the CocoaLumberjack framework (which is also GCD based).
 // https://github.com/robbiehanson/CocoaLumberjack
-// 
+//
 // It allows us to do a lot of logging without significantly slowing down the code.
 #import "DDLog.h"
 
@@ -96,14 +97,14 @@ static const int logLevel = GCDAsyncSocketLogLevel;
  * Seeing a return statements within an inner block
  * can sometimes be mistaken for a return point of the enclosing method.
  * This makes inline blocks a bit easier to read.
-**/
+ **/
 #define return_from_block  return
 
 /**
  * A socket file descriptor is really just an integer.
  * It represents the index of the socket within the kernel.
  * This makes invalid file descriptor comparisons easier to read.
-**/
+ **/
 #define SOCKET_NULL -1
 
 
@@ -113,52 +114,59 @@ NSString *const GCDAsyncSocketErrorDomain = @"GCDAsyncSocketErrorDomain";
 NSString *const GCDAsyncSocketQueueName = @"GCDAsyncSocket";
 NSString *const GCDAsyncSocketThreadName = @"GCDAsyncSocket-CFStream";
 
-#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-NSString *const GCDAsyncSocketSSLCipherSuites = @"GCDAsyncSocketSSLCipherSuites";
+NSString *const GCDAsyncSocketManuallyEvaluateTrust = @"GCDAsyncSocketManuallyEvaluateTrust";
 #if TARGET_OS_IPHONE
+NSString *const GCDAsyncSocketUseCFStreamForTLS = @"GCDAsyncSocketUseCFStreamForTLS";
+#endif
+NSString *const GCDAsyncSocketSSLPeerID = @"GCDAsyncSocketSSLPeerID";
 NSString *const GCDAsyncSocketSSLProtocolVersionMin = @"GCDAsyncSocketSSLProtocolVersionMin";
 NSString *const GCDAsyncSocketSSLProtocolVersionMax = @"GCDAsyncSocketSSLProtocolVersionMax";
-#else
+NSString *const GCDAsyncSocketSSLSessionOptionFalseStart = @"GCDAsyncSocketSSLSessionOptionFalseStart";
+NSString *const GCDAsyncSocketSSLSessionOptionSendOneByteRecord = @"GCDAsyncSocketSSLSessionOptionSendOneByteRecord";
+NSString *const GCDAsyncSocketSSLCipherSuites = @"GCDAsyncSocketSSLCipherSuites";
+#if !TARGET_OS_IPHONE
 NSString *const GCDAsyncSocketSSLDiffieHellmanParameters = @"GCDAsyncSocketSSLDiffieHellmanParameters";
-#endif
 #endif
 
 enum GCDAsyncSocketFlags
 {
-	kSocketStarted                 = 1 <<  0,  // If set, socket has been started (accepting/connecting)
-	kConnected                     = 1 <<  1,  // If set, the socket is connected
-	kForbidReadsWrites             = 1 <<  2,  // If set, no new reads or writes are allowed
-	kReadsPaused                   = 1 <<  3,  // If set, reads are paused due to possible timeout
-	kWritesPaused                  = 1 <<  4,  // If set, writes are paused due to possible timeout
-	kDisconnectAfterReads          = 1 <<  5,  // If set, disconnect after no more reads are queued
-	kDisconnectAfterWrites         = 1 <<  6,  // If set, disconnect after no more writes are queued
-	kSocketCanAcceptBytes          = 1 <<  7,  // If set, we know socket can accept bytes. If unset, it's unknown.
-	kReadSourceSuspended           = 1 <<  8,  // If set, the read source is suspended
-	kWriteSourceSuspended          = 1 <<  9,  // If set, the write source is suspended
-	kQueuedTLS                     = 1 << 10,  // If set, we've queued an upgrade to TLS
-	kStartingReadTLS               = 1 << 11,  // If set, we're waiting for TLS negotiation to complete
-	kStartingWriteTLS              = 1 << 12,  // If set, we're waiting for TLS negotiation to complete
-	kSocketSecure                  = 1 << 13,  // If set, socket is using secure communication via SSL/TLS
-	kSocketHasReadEOF              = 1 << 14,  // If set, we have read EOF from socket
-	kReadStreamClosed              = 1 << 15,  // If set, we've read EOF plus prebuffer has been drained
-	kDealloc                       = 1 << 16,  // If set, the socket is being deallocated
+    kSocketStarted                 = 1 <<  0,  // If set, socket has been started (accepting/connecting)
+    kConnected                     = 1 <<  1,  // If set, the socket is connected
+    kForbidReadsWrites             = 1 <<  2,  // If set, no new reads or writes are allowed
+    kReadsPaused                   = 1 <<  3,  // If set, reads are paused due to possible timeout
+    kWritesPaused                  = 1 <<  4,  // If set, writes are paused due to possible timeout
+    kDisconnectAfterReads          = 1 <<  5,  // If set, disconnect after no more reads are queued
+    kDisconnectAfterWrites         = 1 <<  6,  // If set, disconnect after no more writes are queued
+    kSocketCanAcceptBytes          = 1 <<  7,  // If set, we know socket can accept bytes. If unset, it's unknown.
+    kReadSourceSuspended           = 1 <<  8,  // If set, the read source is suspended
+    kWriteSourceSuspended          = 1 <<  9,  // If set, the write source is suspended
+    kQueuedTLS                     = 1 << 10,  // If set, we've queued an upgrade to TLS
+    kStartingReadTLS               = 1 << 11,  // If set, we're waiting for TLS negotiation to complete
+    kStartingWriteTLS              = 1 << 12,  // If set, we're waiting for TLS negotiation to complete
+    kSocketSecure                  = 1 << 13,  // If set, socket is using secure communication via SSL/TLS
+    kSocketHasReadEOF              = 1 << 14,  // If set, we have read EOF from socket
+    kReadStreamClosed              = 1 << 15,  // If set, we've read EOF plus prebuffer has been drained
+    kDealloc                       = 1 << 16,  // If set, the socket is being deallocated
 #if TARGET_OS_IPHONE
-	kAddedStreamsToRunLoop         = 1 << 17,  // If set, CFStreams have been added to listener thread
-	kUsingCFStreamForTLS           = 1 << 18,  // If set, we're forced to use CFStream instead of SecureTransport
-	kSecureSocketHasBytesAvailable = 1 << 19,  // If set, CFReadStream has notified us of bytes available
+    kAddedStreamsToRunLoop         = 1 << 17,  // If set, CFStreams have been added to listener thread
+    kUsingCFStreamForTLS           = 1 << 18,  // If set, we're forced to use CFStream instead of SecureTransport
+    kSecureSocketHasBytesAvailable = 1 << 19,  // If set, CFReadStream has notified us of bytes available
 #endif
 };
 
 enum GCDAsyncSocketConfig
 {
-	kIPv4Disabled              = 1 << 0,  // If set, IPv4 is disabled
-	kIPv6Disabled              = 1 << 1,  // If set, IPv6 is disabled
-	kPreferIPv6                = 1 << 2,  // If set, IPv6 is preferred over IPv4
-	kAllowHalfDuplexConnection = 1 << 3,  // If set, the socket will stay open even if the read stream closes
+    kIPv4Disabled              = 1 << 0,  // If set, IPv4 is disabled
+    kIPv6Disabled              = 1 << 1,  // If set, IPv6 is disabled
+    kPreferIPv6                = 1 << 2,  // If set, IPv6 is preferred over IPv4
+    kAllowHalfDuplexConnection = 1 << 3,  // If set, the socket will stay open even if the read stream closes
 };
 
 #if TARGET_OS_IPHONE
-  static NSThread *cfstreamThread;  // Used for CFStreams
+static NSThread *cfstreamThread;  // Used for CFStreams
+
+static uint64_t cfstreamThreadRetainCount;   // setup & teardown
+static dispatch_queue_t cfstreamThreadSetupQueue; // setup & teardown
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -170,26 +178,26 @@ enum GCDAsyncSocketConfig
  * than is being requested by current read request.
  * In this case we slurp up all data from the socket (to minimize sys calls),
  * and store additional yet unread data in a "prebuffer".
- * 
+ *
  * The prebuffer is entirely drained before we read from the socket again.
  * In other words, a large chunk of data is written is written to the prebuffer.
  * The prebuffer is then drained via a series of one or more reads (for subsequent read request(s)).
- * 
+ *
  * A ring buffer was once used for this purpose.
  * But a ring buffer takes up twice as much memory as needed (double the size for mirroring).
  * In fact, it generally takes up more than twice the needed size as everything has to be rounded up to vm_page_size.
  * And since the prebuffer is always completely drained after being written to, a full ring buffer isn't needed.
- * 
+ *
  * The current design is very simple and straight-forward, while also keeping memory requirements lower.
-**/
+ **/
 
 @interface GCDAsyncSocketPreBuffer : NSObject
 {
-	uint8_t *preBuffer;
-	size_t preBufferSize;
-	
-	uint8_t *readPointer;
-	uint8_t *writePointer;
+    uint8_t *preBuffer;
+    size_t preBufferSize;
+    
+    uint8_t *readPointer;
+    uint8_t *writePointer;
 }
 
 - (id)initWithCapacity:(size_t)numBytes;
@@ -217,98 +225,98 @@ enum GCDAsyncSocketConfig
 
 - (id)initWithCapacity:(size_t)numBytes
 {
-	if ((self = [super init]))
-	{
-		preBufferSize = numBytes;
-		preBuffer = malloc(preBufferSize);
-		
-		readPointer = preBuffer;
-		writePointer = preBuffer;
-	}
-	return self;
+    if ((self = [super init]))
+    {
+        preBufferSize = numBytes;
+        preBuffer = malloc(preBufferSize);
+        
+        readPointer = preBuffer;
+        writePointer = preBuffer;
+    }
+    return self;
 }
 
 - (void)dealloc
 {
-	if (preBuffer)
-		free(preBuffer);
+    if (preBuffer)
+        free(preBuffer);
 }
 
 - (void)ensureCapacityForWrite:(size_t)numBytes
 {
-	size_t availableSpace = [self availableSpace];
-	
-	if (numBytes > availableSpace)
-	{
-		size_t additionalBytes = numBytes - availableSpace;
-		
-		size_t newPreBufferSize = preBufferSize + additionalBytes;
-		uint8_t *newPreBuffer = realloc(preBuffer, newPreBufferSize);
-		
-		size_t readPointerOffset = readPointer - preBuffer;
-		size_t writePointerOffset = writePointer - preBuffer;
-		
-		preBuffer = newPreBuffer;
-		preBufferSize = newPreBufferSize;
-		
-		readPointer = preBuffer + readPointerOffset;
-		writePointer = preBuffer + writePointerOffset;
-	}
+    size_t availableSpace = [self availableSpace];
+    
+    if (numBytes > availableSpace)
+    {
+        size_t additionalBytes = numBytes - availableSpace;
+        
+        size_t newPreBufferSize = preBufferSize + additionalBytes;
+        uint8_t *newPreBuffer = realloc(preBuffer, newPreBufferSize);
+        
+        size_t readPointerOffset = readPointer - preBuffer;
+        size_t writePointerOffset = writePointer - preBuffer;
+        
+        preBuffer = newPreBuffer;
+        preBufferSize = newPreBufferSize;
+        
+        readPointer = preBuffer + readPointerOffset;
+        writePointer = preBuffer + writePointerOffset;
+    }
 }
 
 - (size_t)availableBytes
 {
-	return writePointer - readPointer;
+    return writePointer - readPointer;
 }
 
 - (uint8_t *)readBuffer
 {
-	return readPointer;
+    return readPointer;
 }
 
 - (void)getReadBuffer:(uint8_t **)bufferPtr availableBytes:(size_t *)availableBytesPtr
 {
-	if (bufferPtr) *bufferPtr = readPointer;
-	if (availableBytesPtr) *availableBytesPtr = [self availableBytes];
+    if (bufferPtr) *bufferPtr = readPointer;
+    if (availableBytesPtr) *availableBytesPtr = [self availableBytes];
 }
 
 - (void)didRead:(size_t)bytesRead
 {
-	readPointer += bytesRead;
-	
-	if (readPointer == writePointer)
-	{
-		// The prebuffer has been drained. Reset pointers.
-		readPointer  = preBuffer;
-		writePointer = preBuffer;
-	}
+    readPointer += bytesRead;
+    
+    if (readPointer == writePointer)
+    {
+        // The prebuffer has been drained. Reset pointers.
+        readPointer  = preBuffer;
+        writePointer = preBuffer;
+    }
 }
 
 - (size_t)availableSpace
 {
-	return preBufferSize - (writePointer - preBuffer);
+    return preBufferSize - (writePointer - preBuffer);
 }
 
 - (uint8_t *)writeBuffer
 {
-	return writePointer;
+    return writePointer;
 }
 
 - (void)getWriteBuffer:(uint8_t **)bufferPtr availableSpace:(size_t *)availableSpacePtr
 {
-	if (bufferPtr) *bufferPtr = writePointer;
-	if (availableSpacePtr) *availableSpacePtr = [self availableSpace];
+    if (bufferPtr) *bufferPtr = writePointer;
+    if (availableSpacePtr) *availableSpacePtr = [self availableSpace];
 }
 
 - (void)didWrite:(size_t)bytesWritten
 {
-	writePointer += bytesWritten;
+    writePointer += bytesWritten;
 }
 
 - (void)reset
 {
-	readPointer  = preBuffer;
-	writePointer = preBuffer;
+    readPointer  = preBuffer;
+    writePointer = preBuffer;
 }
 
 @end
@@ -323,20 +331,20 @@ enum GCDAsyncSocketConfig
  *  - reading to a certain length
  *  - reading to a certain separator
  *  - or simply reading the first chunk of available data
-**/
+ **/
 @interface GCDAsyncReadPacket : NSObject
 {
-  @public
-	NSMutableData *buffer;
-	NSUInteger startOffset;
-	NSUInteger bytesDone;
-	NSUInteger maxLength;
-	NSTimeInterval timeout;
-	NSUInteger readLength;
-	NSData *term;
-	BOOL bufferOwner;
-	NSUInteger originalBufferLength;
-	long tag;
+@public
+    NSMutableData *buffer;
+    NSUInteger startOffset;
+    NSUInteger bytesDone;
+    NSUInteger maxLength;
+    NSTimeInterval timeout;
+    NSUInteger readLength;
+    NSData *term;
+    BOOL bufferOwner;
+    NSUInteger originalBufferLength;
+    long tag;
 }
 - (id)initWithData:(NSMutableData *)d
        startOffset:(NSUInteger)s
@@ -368,416 +376,416 @@ enum GCDAsyncSocketConfig
         terminator:(NSData *)e
                tag:(long)i
 {
-	if((self = [super init]))
-	{
-		bytesDone = 0;
-		maxLength = m;
-		timeout = t;
-		readLength = l;
-		term = [e copy];
-		tag = i;
-		
-		if (d)
-		{
-			buffer = d;
-			startOffset = s;
-			bufferOwner = NO;
-			originalBufferLength = [d length];
-		}
-		else
-		{
-			if (readLength > 0)
-				buffer = [[NSMutableData alloc] initWithLength:readLength];
-			else
-				buffer = [[NSMutableData alloc] initWithLength:0];
-			
-			startOffset = 0;
-			bufferOwner = YES;
-			originalBufferLength = 0;
-		}
-	}
-	return self;
+    if((self = [super init]))
+    {
+        bytesDone = 0;
+        maxLength = m;
+        timeout = t;
+        readLength = l;
+        term = [e copy];
+        tag = i;
+        
+        if (d)
+        {
+            buffer = d;
+            startOffset = s;
+            bufferOwner = NO;
+            originalBufferLength = [d length];
+        }
+        else
+        {
+            if (readLength > 0)
+                buffer = [[NSMutableData alloc] initWithLength:readLength];
+            else
+                buffer = [[NSMutableData alloc] initWithLength:0];
+            
+            startOffset = 0;
+            bufferOwner = YES;
+            originalBufferLength = 0;
+        }
+    }
+    return self;
 }
 
 /**
  * Increases the length of the buffer (if needed) to ensure a read of the given size will fit.
-**/
+ **/
 - (void)ensureCapacityForAdditionalDataOfLength:(NSUInteger)bytesToRead
 {
-	NSUInteger buffSize = [buffer length];
-	NSUInteger buffUsed = startOffset + bytesDone;
-	
-	NSUInteger buffSpace = buffSize - buffUsed;
-	
-	if (bytesToRead > buffSpace)
-	{
-		NSUInteger buffInc = bytesToRead - buffSpace;
-		
-		[buffer increaseLengthBy:buffInc];
-	}
+    NSUInteger buffSize = [buffer length];
+    NSUInteger buffUsed = startOffset + bytesDone;
+    
+    NSUInteger buffSpace = buffSize - buffUsed;
+    
+    if (bytesToRead > buffSpace)
+    {
+        NSUInteger buffInc = bytesToRead - buffSpace;
+        
+        [buffer increaseLengthBy:buffInc];
+    }
 }
 
 /**
  * This method is used when we do NOT know how much data is available to be read from the socket.
  * This method returns the default value unless it exceeds the specified readLength or maxLength.
- * 
+ *
  * Furthermore, the shouldPreBuffer decision is based upon the packet type,
  * and whether the returned value would fit in the current buffer without requiring a resize of the buffer.
-**/
+ **/
 - (NSUInteger)optimalReadLengthWithDefault:(NSUInteger)defaultValue shouldPreBuffer:(BOOL *)shouldPreBufferPtr
 {
-	NSUInteger result;
-	
-	if (readLength > 0)
-	{
-		// Read a specific length of data
-		
-		result = MIN(defaultValue, (readLength - bytesDone));
-		
-		// There is no need to prebuffer since we know exactly how much data we need to read.
-		// Even if the buffer isn't currently big enough to fit this amount of data,
-		// it would have to be resized eventually anyway.
-		
-		if (shouldPreBufferPtr)
-			*shouldPreBufferPtr = NO;
-	}
-	else
-	{
-		// Either reading until we find a specified terminator,
-		// or we're simply reading all available data.
-		// 
-		// In other words, one of:
-		// 
-		// - readDataToData packet
-		// - readDataWithTimeout packet
-		
-		if (maxLength > 0)
-			result =  MIN(defaultValue, (maxLength - bytesDone));
-		else
-			result = defaultValue;
-		
-		// Since we don't know the size of the read in advance,
-		// the shouldPreBuffer decision is based upon whether the returned value would fit
-		// in the current buffer without requiring a resize of the buffer.
-		// 
-		// This is because, in all likelyhood, the amount read from the socket will be less than the default value.
-		// Thus we should avoid over-allocating the read buffer when we can simply use the pre-buffer instead.
-		
-		if (shouldPreBufferPtr)
-		{
-			NSUInteger buffSize = [buffer length];
-			NSUInteger buffUsed = startOffset + bytesDone;
-			
-			NSUInteger buffSpace = buffSize - buffUsed;
-			
-			if (buffSpace >= result)
-				*shouldPreBufferPtr = NO;
-			else
-				*shouldPreBufferPtr = YES;
-		}
-	}
-	
-	return result;
+    NSUInteger result;
+    
+    if (readLength > 0)
+    {
+        // Read a specific length of data
+        
+        result = MIN(defaultValue, (readLength - bytesDone));
+        
+        // There is no need to prebuffer since we know exactly how much data we need to read.
+        // Even if the buffer isn't currently big enough to fit this amount of data,
+        // it would have to be resized eventually anyway.
+        
+        if (shouldPreBufferPtr)
+            *shouldPreBufferPtr = NO;
+    }
+    else
+    {
+        // Either reading until we find a specified terminator,
+        // or we're simply reading all available data.
+        //
+        // In other words, one of:
+        //
+        // - readDataToData packet
+        // - readDataWithTimeout packet
+        
+        if (maxLength > 0)
+            result =  MIN(defaultValue, (maxLength - bytesDone));
+        else
+            result = defaultValue;
+        
+        // Since we don't know the size of the read in advance,
+        // the shouldPreBuffer decision is based upon whether the returned value would fit
+        // in the current buffer without requiring a resize of the buffer.
+        //
+        // This is because, in all likelyhood, the amount read from the socket will be less than the default value.
+        // Thus we should avoid over-allocating the read buffer when we can simply use the pre-buffer instead.
+        
+        if (shouldPreBufferPtr)
+        {
+            NSUInteger buffSize = [buffer length];
+            NSUInteger buffUsed = startOffset + bytesDone;
+            
+            NSUInteger buffSpace = buffSize - buffUsed;
+            
+            if (buffSpace >= result)
+                *shouldPreBufferPtr = NO;
+            else
+                *shouldPreBufferPtr = YES;
+        }
+    }
+    
+    return result;
 }
 
 /**
  * For read packets without a set terminator, returns the amount of data
  * that can be read without exceeding the readLength or maxLength.
- * 
+ *
  * The given parameter indicates the number of bytes estimated to be available on the socket,
  * which is taken into consideration during the calculation.
- * 
+ *
  * The given hint MUST be greater than zero.
-**/
+ **/
 - (NSUInteger)readLengthForNonTermWithHint:(NSUInteger)bytesAvailable
 {
-	NSAssert(term == nil, @"This method does not apply to term reads");
-	NSAssert(bytesAvailable > 0, @"Invalid parameter: bytesAvailable");
-	
-	if (readLength > 0)
-	{
-		// Read a specific length of data
-		
-		return MIN(bytesAvailable, (readLength - bytesDone));
-		
-		// No need to avoid resizing the buffer.
-		// If the user provided their own buffer,
-		// and told us to read a certain length of data that exceeds the size of the buffer,
-		// then it is clear that our code will resize the buffer during the read operation.
-		// 
-		// This method does not actually do any resizing.
-		// The resizing will happen elsewhere if needed.
-	}
-	else
-	{
-		// Read all available data
-		
-		NSUInteger result = bytesAvailable;
-		
-		if (maxLength > 0)
-		{
-			result = MIN(result, (maxLength - bytesDone));
-		}
-		
-		// No need to avoid resizing the buffer.
-		// If the user provided their own buffer,
-		// and told us to read all available data without giving us a maxLength,
-		// then it is clear that our code might resize the buffer during the read operation.
-		// 
-		// This method does not actually do any resizing.
-		// The resizing will happen elsewhere if needed.
-		
-		return result;
-	}
+    NSAssert(term == nil, @"This method does not apply to term reads");
+    NSAssert(bytesAvailable > 0, @"Invalid parameter: bytesAvailable");
+    
+    if (readLength > 0)
+    {
+        // Read a specific length of data
+        
+        return MIN(bytesAvailable, (readLength - bytesDone));
+        
+        // No need to avoid resizing the buffer.
+        // If the user provided their own buffer,
+        // and told us to read a certain length of data that exceeds the size of the buffer,
+        // then it is clear that our code will resize the buffer during the read operation.
+        //
+        // This method does not actually do any resizing.
+        // The resizing will happen elsewhere if needed.
+    }
+    else
+    {
+        // Read all available data
+        
+        NSUInteger result = bytesAvailable;
+        
+        if (maxLength > 0)
+        {
+            result = MIN(result, (maxLength - bytesDone));
+        }
+        
+        // No need to avoid resizing the buffer.
+        // If the user provided their own buffer,
+        // and told us to read all available data without giving us a maxLength,
+        // then it is clear that our code might resize the buffer during the read operation.
+        //
+        // This method does not actually do any resizing.
+        // The resizing will happen elsewhere if needed.
+        
+        return result;
+    }
 }
 
 /**
  * For read packets with a set terminator, returns the amount of data
  * that can be read without exceeding the maxLength.
- * 
+ *
  * The given parameter indicates the number of bytes estimated to be available on the socket,
  * which is taken into consideration during the calculation.
- * 
+ *
  * To optimize memory allocations, mem copies, and mem moves
  * the shouldPreBuffer boolean value will indicate if the data should be read into a prebuffer first,
  * or if the data can be read directly into the read packet's buffer.
-**/
+ **/
 - (NSUInteger)readLengthForTermWithHint:(NSUInteger)bytesAvailable shouldPreBuffer:(BOOL *)shouldPreBufferPtr
 {
-	NSAssert(term != nil, @"This method does not apply to non-term reads");
-	NSAssert(bytesAvailable > 0, @"Invalid parameter: bytesAvailable");
-	
-	
-	NSUInteger result = bytesAvailable;
-	
-	if (maxLength > 0)
-	{
-		result = MIN(result, (maxLength - bytesDone));
-	}
-	
-	// Should the data be read into the read packet's buffer, or into a pre-buffer first?
-	// 
-	// One would imagine the preferred option is the faster one.
-	// So which one is faster?
-	// 
-	// Reading directly into the packet's buffer requires:
-	// 1. Possibly resizing packet buffer (malloc/realloc)
-	// 2. Filling buffer (read)
-	// 3. Searching for term (memcmp)
-	// 4. Possibly copying overflow into prebuffer (malloc/realloc, memcpy)
-	// 
-	// Reading into prebuffer first:
-	// 1. Possibly resizing prebuffer (malloc/realloc)
-	// 2. Filling buffer (read)
-	// 3. Searching for term (memcmp)
-	// 4. Copying underflow into packet buffer (malloc/realloc, memcpy)
-	// 5. Removing underflow from prebuffer (memmove)
-	// 
-	// Comparing the performance of the two we can see that reading
-	// data into the prebuffer first is slower due to the extra memove.
-	// 
-	// However:
-	// The implementation of NSMutableData is open source via core foundation's CFMutableData.
-	// Decreasing the length of a mutable data object doesn't cause a realloc.
-	// In other words, the capacity of a mutable data object can grow, but doesn't shrink.
-	// 
-	// This means the prebuffer will rarely need a realloc.
-	// The packet buffer, on the other hand, may often need a realloc.
-	// This is especially true if we are the buffer owner.
-	// Furthermore, if we are constantly realloc'ing the packet buffer,
-	// and then moving the overflow into the prebuffer,
-	// then we're consistently over-allocating memory for each term read.
-	// And now we get into a bit of a tradeoff between speed and memory utilization.
-	// 
-	// The end result is that the two perform very similarly.
-	// And we can answer the original question very simply by another means.
-	// 
-	// If we can read all the data directly into the packet's buffer without resizing it first,
-	// then we do so. Otherwise we use the prebuffer.
-	
-	if (shouldPreBufferPtr)
-	{
-		NSUInteger buffSize = [buffer length];
-		NSUInteger buffUsed = startOffset + bytesDone;
-		
-		if ((buffSize - buffUsed) >= result)
-			*shouldPreBufferPtr = NO;
-		else
-			*shouldPreBufferPtr = YES;
-	}
-	
-	return result;
+    NSAssert(term != nil, @"This method does not apply to non-term reads");
+    NSAssert(bytesAvailable > 0, @"Invalid parameter: bytesAvailable");
+    
+    
+    NSUInteger result = bytesAvailable;
+    
+    if (maxLength > 0)
+    {
+        result = MIN(result, (maxLength - bytesDone));
+    }
+    
+    // Should the data be read into the read packet's buffer, or into a pre-buffer first?
+    //
+    // One would imagine the preferred option is the faster one.
+    // So which one is faster?
+    //
+    // Reading directly into the packet's buffer requires:
+    // 1. Possibly resizing packet buffer (malloc/realloc)
+    // 2. Filling buffer (read)
+    // 3. Searching for term (memcmp)
+    // 4. Possibly copying overflow into prebuffer (malloc/realloc, memcpy)
+    //
+    // Reading into prebuffer first:
+    // 1. Possibly resizing prebuffer (malloc/realloc)
+    // 2. Filling buffer (read)
+    // 3. Searching for term (memcmp)
+    // 4. Copying underflow into packet buffer (malloc/realloc, memcpy)
+    // 5. Removing underflow from prebuffer (memmove)
+    //
+    // Comparing the performance of the two we can see that reading
+    // data into the prebuffer first is slower due to the extra memove.
+    //
+    // However:
+    // The implementation of NSMutableData is open source via core foundation's CFMutableData.
+    // Decreasing the length of a mutable data object doesn't cause a realloc.
+    // In other words, the capacity of a mutable data object can grow, but doesn't shrink.
+    //
+    // This means the prebuffer will rarely need a realloc.
+    // The packet buffer, on the other hand, may often need a realloc.
+    // This is especially true if we are the buffer owner.
+    // Furthermore, if we are constantly realloc'ing the packet buffer,
+    // and then moving the overflow into the prebuffer,
+    // then we're consistently over-allocating memory for each term read.
+    // And now we get into a bit of a tradeoff between speed and memory utilization.
+    //
+    // The end result is that the two perform very similarly.
+    // And we can answer the original question very simply by another means.
+    //
+    // If we can read all the data directly into the packet's buffer without resizing it first,
+    // then we do so. Otherwise we use the prebuffer.
+    
+    if (shouldPreBufferPtr)
+    {
+        NSUInteger buffSize = [buffer length];
+        NSUInteger buffUsed = startOffset + bytesDone;
+        
+        if ((buffSize - buffUsed) >= result)
+            *shouldPreBufferPtr = NO;
+        else
+            *shouldPreBufferPtr = YES;
+    }
+    
+    return result;
 }
 
 /**
  * For read packets with a set terminator,
  * returns the amount of data that can be read from the given preBuffer,
  * without going over a terminator or the maxLength.
- * 
+ *
  * It is assumed the terminator has not already been read.
-**/
+ **/
 - (NSUInteger)readLengthForTermWithPreBuffer:(GCDAsyncSocketPreBuffer *)preBuffer found:(BOOL *)foundPtr
 {
-	NSAssert(term != nil, @"This method does not apply to non-term reads");
-	NSAssert([preBuffer availableBytes] > 0, @"Invoked with empty pre buffer!");
-	
-	// We know that the terminator, as a whole, doesn't exist in our own buffer.
-	// But it is possible that a _portion_ of it exists in our buffer.
-	// So we're going to look for the terminator starting with a portion of our own buffer.
-	// 
-	// Example:
-	// 
-	// term length      = 3 bytes
-	// bytesDone        = 5 bytes
-	// preBuffer length = 5 bytes
-	// 
-	// If we append the preBuffer to our buffer,
-	// it would look like this:
-	// 
-	// ---------------------
-	// |B|B|B|B|B|P|P|P|P|P|
-	// ---------------------
-	// 
-	// So we start our search here:
-	// 
-	// ---------------------
-	// |B|B|B|B|B|P|P|P|P|P|
-	// -------^-^-^---------
-	// 
-	// And move forwards...
-	// 
-	// ---------------------
-	// |B|B|B|B|B|P|P|P|P|P|
-	// ---------^-^-^-------
-	// 
-	// Until we find the terminator or reach the end.
-	// 
-	// ---------------------
-	// |B|B|B|B|B|P|P|P|P|P|
-	// ---------------^-^-^-
-	
-	BOOL found = NO;
-	
-	NSUInteger termLength = [term length];
-	NSUInteger preBufferLength = [preBuffer availableBytes];
-	
-	if ((bytesDone + preBufferLength) < termLength)
-	{
-		// Not enough data for a full term sequence yet
-		return preBufferLength;
-	}
-	
-	NSUInteger maxPreBufferLength;
-	if (maxLength > 0) {
-		maxPreBufferLength = MIN(preBufferLength, (maxLength - bytesDone));
-		
-		// Note: maxLength >= termLength
-	}
-	else {
-		maxPreBufferLength = preBufferLength;
-	}
-	
-	uint8_t seq[termLength];
-	const void *termBuf = [term bytes];
-	
-	NSUInteger bufLen = MIN(bytesDone, (termLength - 1));
-	uint8_t *buf = (uint8_t *)[buffer mutableBytes] + startOffset + bytesDone - bufLen;
-	
-	NSUInteger preLen = termLength - bufLen;
-	const uint8_t *pre = [preBuffer readBuffer];
-	
-	NSUInteger loopCount = bufLen + maxPreBufferLength - termLength + 1; // Plus one. See example above.
-	
-	NSUInteger result = maxPreBufferLength;
-	
-	NSUInteger i;
-	for (i = 0; i < loopCount; i++)
-	{
-		if (bufLen > 0)
-		{
-			// Combining bytes from buffer and preBuffer
-			
-			memcpy(seq, buf, bufLen);
-			memcpy(seq + bufLen, pre, preLen);
-			
-			if (memcmp(seq, termBuf, termLength) == 0)
-			{
-				result = preLen;
-				found = YES;
-				break;
-			}
-			
-			buf++;
-			bufLen--;
-			preLen++;
-		}
-		else
-		{
-			// Comparing directly from preBuffer
-			
-			if (memcmp(pre, termBuf, termLength) == 0)
-			{
-				NSUInteger preOffset = pre - [preBuffer readBuffer]; // pointer arithmetic
-				
-				result = preOffset + termLength;
-				found = YES;
-				break;
-			}
-			
-			pre++;
-		}
-	}
-	
-	// There is no need to avoid resizing the buffer in this particular situation.
-	
-	if (foundPtr) *foundPtr = found;
-	return result;
+    NSAssert(term != nil, @"This method does not apply to non-term reads");
+    NSAssert([preBuffer availableBytes] > 0, @"Invoked with empty pre buffer!");
+    
+    // We know that the terminator, as a whole, doesn't exist in our own buffer.
+    // But it is possible that a _portion_ of it exists in our buffer.
+    // So we're going to look for the terminator starting with a portion of our own buffer.
+    //
+    // Example:
+    //
+    // term length      = 3 bytes
+    // bytesDone        = 5 bytes
+    // preBuffer length = 5 bytes
+    //
+    // If we append the preBuffer to our buffer,
+    // it would look like this:
+    //
+    // ---------------------
+    // |B|B|B|B|B|P|P|P|P|P|
+    // ---------------------
+    //
+    // So we start our search here:
+    //
+    // ---------------------
+    // |B|B|B|B|B|P|P|P|P|P|
+    // -------^-^-^---------
+    //
+    // And move forwards...
+    //
+    // ---------------------
+    // |B|B|B|B|B|P|P|P|P|P|
+    // ---------^-^-^-------
+    //
+    // Until we find the terminator or reach the end.
+    //
+    // ---------------------
+    // |B|B|B|B|B|P|P|P|P|P|
+    // ---------------^-^-^-
+    
+    BOOL found = NO;
+    
+    NSUInteger termLength = [term length];
+    NSUInteger preBufferLength = [preBuffer availableBytes];
+    
+    if ((bytesDone + preBufferLength) < termLength)
+    {
+        // Not enough data for a full term sequence yet
+        return preBufferLength;
+    }
+    
+    NSUInteger maxPreBufferLength;
+    if (maxLength > 0) {
+        maxPreBufferLength = MIN(preBufferLength, (maxLength - bytesDone));
+        
+        // Note: maxLength >= termLength
+    }
+    else {
+        maxPreBufferLength = preBufferLength;
+    }
+    
+    uint8_t seq[termLength];
+    const void *termBuf = [term bytes];
+    
+    NSUInteger bufLen = MIN(bytesDone, (termLength - 1));
+    uint8_t *buf = (uint8_t *)[buffer mutableBytes] + startOffset + bytesDone - bufLen;
+    
+    NSUInteger preLen = termLength - bufLen;
+    const uint8_t *pre = [preBuffer readBuffer];
+    
+    NSUInteger loopCount = bufLen + maxPreBufferLength - termLength + 1; // Plus one. See example above.
+    
+    NSUInteger result = maxPreBufferLength;
+    
+    NSUInteger i;
+    for (i = 0; i < loopCount; i++)
+    {
+        if (bufLen > 0)
+        {
+            // Combining bytes from buffer and preBuffer
+            
+            memcpy(seq, buf, bufLen);
+            memcpy(seq + bufLen, pre, preLen);
+            
+            if (memcmp(seq, termBuf, termLength) == 0)
+            {
+                result = preLen;
+                found = YES;
+                break;
+            }
+            
+            buf++;
+            bufLen--;
+            preLen++;
+        }
+        else
+        {
+            // Comparing directly from preBuffer
+            
+            if (memcmp(pre, termBuf, termLength) == 0)
+            {
+                NSUInteger preOffset = pre - [preBuffer readBuffer]; // pointer arithmetic
+                
+                result = preOffset + termLength;
+                found = YES;
+                break;
+            }
+            
+            pre++;
+        }
+    }
+    
+    // There is no need to avoid resizing the buffer in this particular situation.
+    
+    if (foundPtr) *foundPtr = found;
+    return result;
 }
 
 /**
  * For read packets with a set terminator, scans the packet buffer for the term.
  * It is assumed the terminator had not been fully read prior to the new bytes.
- * 
+ *
  * If the term is found, the number of excess bytes after the term are returned.
  * If the term is not found, this method will return -1.
- * 
+ *
  * Note: A return value of zero means the term was found at the very end.
- * 
+ *
  * Prerequisites:
  * The given number of bytes have been added to the end of our buffer.
  * Our bytesDone variable has NOT been changed due to the prebuffered bytes.
-**/
+ **/
 - (NSInteger)searchForTermAfterPreBuffering:(ssize_t)numBytes
 {
-	NSAssert(term != nil, @"This method does not apply to non-term reads");
-	
-	// The implementation of this method is very similar to the above method.
-	// See the above method for a discussion of the algorithm used here.
-	
-	uint8_t *buff = [buffer mutableBytes];
-	NSUInteger buffLength = bytesDone + numBytes;
-	
-	const void *termBuff = [term bytes];
-	NSUInteger termLength = [term length];
-	
-	// Note: We are dealing with unsigned integers,
-	// so make sure the math doesn't go below zero.
-	
-	NSUInteger i = ((buffLength - numBytes) >= termLength) ? (buffLength - numBytes - termLength + 1) : 0;
-	
-	while (i + termLength <= buffLength)
-	{
-		uint8_t *subBuffer = buff + startOffset + i;
-		
-		if (memcmp(subBuffer, termBuff, termLength) == 0)
-		{
-			return buffLength - (i + termLength);
-		}
-		
-		i++;
-	}
-	
-	return -1;
+    NSAssert(term != nil, @"This method does not apply to non-term reads");
+    
+    // The implementation of this method is very similar to the above method.
+    // See the above method for a discussion of the algorithm used here.
+    
+    uint8_t *buff = [buffer mutableBytes];
+    NSUInteger buffLength = bytesDone + numBytes;
+    
+    const void *termBuff = [term bytes];
+    NSUInteger termLength = [term length];
+    
+    // Note: We are dealing with unsigned integers,
+    // so make sure the math doesn't go below zero.
+    
+    NSUInteger i = ((buffLength - numBytes) >= termLength) ? (buffLength - numBytes - termLength + 1) : 0;
+    
+    while (i + termLength <= buffLength)
+    {
+        uint8_t *subBuffer = buff + startOffset + i;
+        
+        if (memcmp(subBuffer, termBuff, termLength) == 0)
+        {
+            return buffLength - (i + termLength);
+        }
+        
+        i++;
+    }
+    
+    return -1;
 }
 
 
@@ -789,14 +797,14 @@ enum GCDAsyncSocketConfig
 
 /**
  * The GCDAsyncWritePacket encompasses the instructions for any given write.
-**/
+ **/
 @interface GCDAsyncWritePacket : NSObject
 {
-  @public
-	NSData *buffer;
-	NSUInteger bytesDone;
-	long tag;
-	NSTimeInterval timeout;
+@public
+    NSData *buffer;
+    NSUInteger bytesDone;
+    long tag;
+    NSTimeInterval timeout;
 }
 - (id)initWithData:(NSData *)d timeout:(NSTimeInterval)t tag:(long)i;
 @end
@@ -805,14 +813,14 @@ enum GCDAsyncSocketConfig
 
 - (id)initWithData:(NSData *)d timeout:(NSTimeInterval)t tag:(long)i
 {
-	if((self = [super init]))
-	{
-		buffer = d; // Retain not copy. For performance as documented in header file.
-		bytesDone = 0;
-		timeout = t;
-		tag = i;
-	}
-	return self;
+    if((self = [super init]))
+    {
+        buffer = d; // Retain not copy. For performance as documented in header file.
+        bytesDone = 0;
+        timeout = t;
+        tag = i;
+    }
+    return self;
 }
 
 
@@ -825,11 +833,11 @@ enum GCDAsyncSocketConfig
 /**
  * The GCDAsyncSpecialPacket encompasses special instructions for interruptions in the read/write queues.
  * This class my be altered to support more than just TLS in the future.
-**/
+ **/
 @interface GCDAsyncSpecialPacket : NSObject
 {
-  @public
-	NSDictionary *tlsSettings;
+@public
+    NSDictionary *tlsSettings;
 }
 - (id)initWithTLSSettings:(NSDictionary *)settings;
 @end
@@ -838,11 +846,11 @@ enum GCDAsyncSocketConfig
 
 - (id)initWithTLSSettings:(NSDictionary *)settings
 {
-	if((self = [super init]))
-	{
-		tlsSettings = [settings copy];
-	}
-	return self;
+    if((self = [super init]))
+    {
+        tlsSettings = [settings copy];
+    }
+    return self;
 }
 
 
@@ -854,169 +862,167 @@ enum GCDAsyncSocketConfig
 
 @implementation GCDAsyncSocket
 {
-	uint32_t flags;
-	uint16_t config;
-	
-	__weak id delegate;
-	dispatch_queue_t delegateQueue;
-	
-	int socket4FD;
-	int socket6FD;
-	int connectIndex;
-	NSData * connectInterface4;
-	NSData * connectInterface6;
-	
-	dispatch_queue_t socketQueue;
-	
-	dispatch_source_t accept4Source;
-	dispatch_source_t accept6Source;
-	dispatch_source_t connectTimer;
-	dispatch_source_t readSource;
-	dispatch_source_t writeSource;
-	dispatch_source_t readTimer;
-	dispatch_source_t writeTimer;
-	
-	NSMutableArray *readQueue;
-	NSMutableArray *writeQueue;
-	
-	GCDAsyncReadPacket *currentRead;
-	GCDAsyncWritePacket *currentWrite;
-	
-	unsigned long socketFDBytesAvailable;
-	
-	GCDAsyncSocketPreBuffer *preBuffer;
-		
+    uint32_t flags;
+    uint16_t config;
+    
+    __weak id delegate;
+    dispatch_queue_t delegateQueue;
+    
+    int socket4FD;
+    int socket6FD;
+    int stateIndex;
+    NSData * connectInterface4;
+    NSData * connectInterface6;
+    
+    dispatch_queue_t socketQueue;
+    
+    dispatch_source_t accept4Source;
+    dispatch_source_t accept6Source;
+    dispatch_source_t connectTimer;
+    dispatch_source_t readSource;
+    dispatch_source_t writeSource;
+    dispatch_source_t readTimer;
+    dispatch_source_t writeTimer;
+    
+    NSMutableArray *readQueue;
+    NSMutableArray *writeQueue;
+    
+    GCDAsyncReadPacket *currentRead;
+    GCDAsyncWritePacket *currentWrite;
+    
+    unsigned long socketFDBytesAvailable;
+    
+    GCDAsyncSocketPreBuffer *preBuffer;
+    
 #if TARGET_OS_IPHONE
-	CFStreamClientContext streamContext;
-	CFReadStreamRef readStream;
-	CFWriteStreamRef writeStream;
+    CFStreamClientContext streamContext;
+    CFReadStreamRef readStream;
+    CFWriteStreamRef writeStream;
 #endif
-#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-	SSLContextRef sslContext;
-	GCDAsyncSocketPreBuffer *sslPreBuffer;
-	size_t sslWriteCachedLength;
-	OSStatus sslErrCode;
-#endif
-	
-	void *IsOnSocketQueueOrTargetQueueKey;
-	
-	id userData;
+    SSLContextRef sslContext;
+    GCDAsyncSocketPreBuffer *sslPreBuffer;
+    size_t sslWriteCachedLength;
+    OSStatus sslErrCode;
+    
+    void *IsOnSocketQueueOrTargetQueueKey;
+    
+    id userData;
 }
 
 - (id)init
 {
-	return [self initWithDelegate:nil delegateQueue:NULL socketQueue:NULL];
+    return [self initWithDelegate:nil delegateQueue:NULL socketQueue:NULL];
 }
 
 - (id)initWithSocketQueue:(dispatch_queue_t)sq
 {
-	return [self initWithDelegate:nil delegateQueue:NULL socketQueue:sq];
+    return [self initWithDelegate:nil delegateQueue:NULL socketQueue:sq];
 }
 
 - (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq
 {
-	return [self initWithDelegate:aDelegate delegateQueue:dq socketQueue:NULL];
+    return [self initWithDelegate:aDelegate delegateQueue:dq socketQueue:NULL];
 }
 
 - (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq socketQueue:(dispatch_queue_t)sq
 {
-	if((self = [super init]))
-	{
-		delegate = aDelegate;
-		delegateQueue = dq;
-		
-		#if !OS_OBJECT_USE_OBJC
-		if (dq) dispatch_retain(dq);
-		#endif
-		
-		socket4FD = SOCKET_NULL;
-		socket6FD = SOCKET_NULL;
-		connectIndex = 0;
-		
-		if (sq)
-		{
-			NSAssert(sq != dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0),
-			         @"The given socketQueue parameter must not be a concurrent queue.");
-			NSAssert(sq != dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0),
-			         @"The given socketQueue parameter must not be a concurrent queue.");
-			NSAssert(sq != dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
-			         @"The given socketQueue parameter must not be a concurrent queue.");
-			
-			socketQueue = sq;
-			#if !OS_OBJECT_USE_OBJC
-			dispatch_retain(sq);
-			#endif
-		}
-		else
-		{
-			socketQueue = dispatch_queue_create([GCDAsyncSocketQueueName UTF8String], NULL);
-		}
-		
-		// The dispatch_queue_set_specific() and dispatch_get_specific() functions take a "void *key" parameter.
-		// From the documentation:
-		//
-		// > Keys are only compared as pointers and are never dereferenced.
-		// > Thus, you can use a pointer to a static variable for a specific subsystem or
-		// > any other value that allows you to identify the value uniquely.
-		//
-		// We're just going to use the memory address of an ivar.
-		// Specifically an ivar that is explicitly named for our purpose to make the code more readable.
-		//
-		// However, it feels tedious (and less readable) to include the "&" all the time:
-		// dispatch_get_specific(&IsOnSocketQueueOrTargetQueueKey)
-		//
-		// So we're going to make it so it doesn't matter if we use the '&' or not,
-		// by assigning the value of the ivar to the address of the ivar.
-		// Thus: IsOnSocketQueueOrTargetQueueKey == &IsOnSocketQueueOrTargetQueueKey;
-		
-		IsOnSocketQueueOrTargetQueueKey = &IsOnSocketQueueOrTargetQueueKey;
-		
-		void *nonNullUnusedPointer = (__bridge void *)self;
-		dispatch_queue_set_specific(socketQueue, IsOnSocketQueueOrTargetQueueKey, nonNullUnusedPointer, NULL);
-		
-		readQueue = [[NSMutableArray alloc] initWithCapacity:5];
-		currentRead = nil;
-		
-		writeQueue = [[NSMutableArray alloc] initWithCapacity:5];
-		currentWrite = nil;
-		
-		preBuffer = [[GCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
-	}
-	return self;
+    if((self = [super init]))
+    {
+        delegate = aDelegate;
+        delegateQueue = dq;
+        
+#if !OS_OBJECT_USE_OBJC
+        if (dq) dispatch_retain(dq);
+#endif
+        
+        socket4FD = SOCKET_NULL;
+        socket6FD = SOCKET_NULL;
+        stateIndex = 0;
+        
+        if (sq)
+        {
+            NSAssert(sq != dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0),
+                     @"The given socketQueue parameter must not be a concurrent queue.");
+            NSAssert(sq != dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0),
+                     @"The given socketQueue parameter must not be a concurrent queue.");
+            NSAssert(sq != dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
+                     @"The given socketQueue parameter must not be a concurrent queue.");
+            
+            socketQueue = sq;
+#if !OS_OBJECT_USE_OBJC
+            dispatch_retain(sq);
+#endif
+        }
+        else
+        {
+            socketQueue = dispatch_queue_create([GCDAsyncSocketQueueName UTF8String], NULL);
+        }
+        
+        // The dispatch_queue_set_specific() and dispatch_get_specific() functions take a "void *key" parameter.
+        // From the documentation:
+        //
+        // > Keys are only compared as pointers and are never dereferenced.
+        // > Thus, you can use a pointer to a static variable for a specific subsystem or
+        // > any other value that allows you to identify the value uniquely.
+        //
+        // We're just going to use the memory address of an ivar.
+        // Specifically an ivar that is explicitly named for our purpose to make the code more readable.
+        //
+        // However, it feels tedious (and less readable) to include the "&" all the time:
+        // dispatch_get_specific(&IsOnSocketQueueOrTargetQueueKey)
+        //
+        // So we're going to make it so it doesn't matter if we use the '&' or not,
+        // by assigning the value of the ivar to the address of the ivar.
+        // Thus: IsOnSocketQueueOrTargetQueueKey == &IsOnSocketQueueOrTargetQueueKey;
+        
+        IsOnSocketQueueOrTargetQueueKey = &IsOnSocketQueueOrTargetQueueKey;
+        
+        void *nonNullUnusedPointer = (__bridge void *)self;
+        dispatch_queue_set_specific(socketQueue, IsOnSocketQueueOrTargetQueueKey, nonNullUnusedPointer, NULL);
+        
+        readQueue = [[NSMutableArray alloc] initWithCapacity:5];
+        currentRead = nil;
+        
+        writeQueue = [[NSMutableArray alloc] initWithCapacity:5];
+        currentWrite = nil;
+        
+        preBuffer = [[GCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
+    }
+    return self;
 }
 
 - (void)dealloc
 {
-	LogInfo(@"%@ - %@ (start)", THIS_METHOD, self);
-	
-	// Set dealloc flag.
-	// This is used by closeWithError to ensure we don't accidentally retain ourself.
-	flags |= kDealloc;
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		[self closeWithError:nil];
-	}
-	else
-	{
-		dispatch_sync(socketQueue, ^{
-			[self closeWithError:nil];
-		});
-	}
-	
-	delegate = nil;
-	
-	#if !OS_OBJECT_USE_OBJC
-	if (delegateQueue) dispatch_release(delegateQueue);
-	#endif
-	delegateQueue = NULL;
-	
-	#if !OS_OBJECT_USE_OBJC
-	if (socketQueue) dispatch_release(socketQueue);
-	#endif
-	socketQueue = NULL;
-	
-	LogInfo(@"%@ - %@ (finish)", THIS_METHOD, self);
+    LogInfo(@"%@ - %@ (start)", THIS_METHOD, self);
+    
+    // Set dealloc flag.
+    // This is used by closeWithError to ensure we don't accidentally retain ourself.
+    flags |= kDealloc;
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        [self closeWithError:nil];
+    }
+    else
+    {
+        dispatch_sync(socketQueue, ^{
+            [self closeWithError:nil];
+        });
+    }
+    
+    delegate = nil;
+    
+#if !OS_OBJECT_USE_OBJC
+    if (delegateQueue) dispatch_release(delegateQueue);
+#endif
+    delegateQueue = NULL;
+    
+#if !OS_OBJECT_USE_OBJC
+    if (socketQueue) dispatch_release(socketQueue);
+#endif
+    socketQueue = NULL;
+    
+    LogInfo(@"%@ - %@ (finish)", THIS_METHOD, self);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1025,302 +1031,302 @@ enum GCDAsyncSocketConfig
 
 - (id)delegate
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return delegate;
-	}
-	else
-	{
-		__block id result;
-		
-		dispatch_sync(socketQueue, ^{
-			result = delegate;
-		});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return delegate;
+    }
+    else
+    {
+        __block id result;
+        
+        dispatch_sync(socketQueue, ^{
+            result = delegate;
+        });
+        
+        return result;
+    }
 }
 
 - (void)setDelegate:(id)newDelegate synchronously:(BOOL)synchronously
 {
-	dispatch_block_t block = ^{
-		delegate = newDelegate;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey)) {
-		block();
-	}
-	else {
-		if (synchronously)
-			dispatch_sync(socketQueue, block);
-		else
-			dispatch_async(socketQueue, block);
-	}
+    dispatch_block_t block = ^{
+        delegate = newDelegate;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey)) {
+        block();
+    }
+    else {
+        if (synchronously)
+            dispatch_sync(socketQueue, block);
+        else
+            dispatch_async(socketQueue, block);
+    }
 }
 
 - (void)setDelegate:(id)newDelegate
 {
-	[self setDelegate:newDelegate synchronously:NO];
+    [self setDelegate:newDelegate synchronously:NO];
 }
 
 - (void)synchronouslySetDelegate:(id)newDelegate
 {
-	[self setDelegate:newDelegate synchronously:YES];
+    [self setDelegate:newDelegate synchronously:YES];
 }
 
 - (dispatch_queue_t)delegateQueue
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return delegateQueue;
-	}
-	else
-	{
-		__block dispatch_queue_t result;
-		
-		dispatch_sync(socketQueue, ^{
-			result = delegateQueue;
-		});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return delegateQueue;
+    }
+    else
+    {
+        __block dispatch_queue_t result;
+        
+        dispatch_sync(socketQueue, ^{
+            result = delegateQueue;
+        });
+        
+        return result;
+    }
 }
 
 - (void)setDelegateQueue:(dispatch_queue_t)newDelegateQueue synchronously:(BOOL)synchronously
 {
-	dispatch_block_t block = ^{
-		
-		#if !OS_OBJECT_USE_OBJC
-		if (delegateQueue) dispatch_release(delegateQueue);
-		if (newDelegateQueue) dispatch_retain(newDelegateQueue);
-		#endif
-		
-		delegateQueue = newDelegateQueue;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey)) {
-		block();
-	}
-	else {
-		if (synchronously)
-			dispatch_sync(socketQueue, block);
-		else
-			dispatch_async(socketQueue, block);
-	}
+    dispatch_block_t block = ^{
+        
+#if !OS_OBJECT_USE_OBJC
+        if (delegateQueue) dispatch_release(delegateQueue);
+        if (newDelegateQueue) dispatch_retain(newDelegateQueue);
+#endif
+        
+        delegateQueue = newDelegateQueue;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey)) {
+        block();
+    }
+    else {
+        if (synchronously)
+            dispatch_sync(socketQueue, block);
+        else
+            dispatch_async(socketQueue, block);
+    }
 }
 
 - (void)setDelegateQueue:(dispatch_queue_t)newDelegateQueue
 {
-	[self setDelegateQueue:newDelegateQueue synchronously:NO];
+    [self setDelegateQueue:newDelegateQueue synchronously:NO];
 }
 
 - (void)synchronouslySetDelegateQueue:(dispatch_queue_t)newDelegateQueue
 {
-	[self setDelegateQueue:newDelegateQueue synchronously:YES];
+    [self setDelegateQueue:newDelegateQueue synchronously:YES];
 }
 
 - (void)getDelegate:(id *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		if (delegatePtr) *delegatePtr = delegate;
-		if (delegateQueuePtr) *delegateQueuePtr = delegateQueue;
-	}
-	else
-	{
-		__block id dPtr = NULL;
-		__block dispatch_queue_t dqPtr = NULL;
-		
-		dispatch_sync(socketQueue, ^{
-			dPtr = delegate;
-			dqPtr = delegateQueue;
-		});
-		
-		if (delegatePtr) *delegatePtr = dPtr;
-		if (delegateQueuePtr) *delegateQueuePtr = dqPtr;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        if (delegatePtr) *delegatePtr = delegate;
+        if (delegateQueuePtr) *delegateQueuePtr = delegateQueue;
+    }
+    else
+    {
+        __block id dPtr = NULL;
+        __block dispatch_queue_t dqPtr = NULL;
+        
+        dispatch_sync(socketQueue, ^{
+            dPtr = delegate;
+            dqPtr = delegateQueue;
+        });
+        
+        if (delegatePtr) *delegatePtr = dPtr;
+        if (delegateQueuePtr) *delegateQueuePtr = dqPtr;
+    }
 }
 
 - (void)setDelegate:(id)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue synchronously:(BOOL)synchronously
 {
-	dispatch_block_t block = ^{
-		
-		delegate = newDelegate;
-		
-		#if !OS_OBJECT_USE_OBJC
-		if (delegateQueue) dispatch_release(delegateQueue);
-		if (newDelegateQueue) dispatch_retain(newDelegateQueue);
-		#endif
-		
-		delegateQueue = newDelegateQueue;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey)) {
-		block();
-	}
-	else {
-		if (synchronously)
-			dispatch_sync(socketQueue, block);
-		else
-			dispatch_async(socketQueue, block);
-	}
+    dispatch_block_t block = ^{
+        
+        delegate = newDelegate;
+        
+#if !OS_OBJECT_USE_OBJC
+        if (delegateQueue) dispatch_release(delegateQueue);
+        if (newDelegateQueue) dispatch_retain(newDelegateQueue);
+#endif
+        
+        delegateQueue = newDelegateQueue;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey)) {
+        block();
+    }
+    else {
+        if (synchronously)
+            dispatch_sync(socketQueue, block);
+        else
+            dispatch_async(socketQueue, block);
+    }
 }
 
 - (void)setDelegate:(id)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
 {
-	[self setDelegate:newDelegate delegateQueue:newDelegateQueue synchronously:NO];
+    [self setDelegate:newDelegate delegateQueue:newDelegateQueue synchronously:NO];
 }
 
 - (void)synchronouslySetDelegate:(id)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
 {
-	[self setDelegate:newDelegate delegateQueue:newDelegateQueue synchronously:YES];
+    [self setDelegate:newDelegate delegateQueue:newDelegateQueue synchronously:YES];
 }
 
 - (BOOL)isIPv4Enabled
 {
-	// Note: YES means kIPv4Disabled is OFF
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return ((config & kIPv4Disabled) == 0);
-	}
-	else
-	{
-		__block BOOL result;
-		
-		dispatch_sync(socketQueue, ^{
-			result = ((config & kIPv4Disabled) == 0);
-		});
-		
-		return result;
-	}
+    // Note: YES means kIPv4Disabled is OFF
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return ((config & kIPv4Disabled) == 0);
+    }
+    else
+    {
+        __block BOOL result;
+        
+        dispatch_sync(socketQueue, ^{
+            result = ((config & kIPv4Disabled) == 0);
+        });
+        
+        return result;
+    }
 }
 
 - (void)setIPv4Enabled:(BOOL)flag
 {
-	// Note: YES means kIPv4Disabled is OFF
-	
-	dispatch_block_t block = ^{
-		
-		if (flag)
-			config &= ~kIPv4Disabled;
-		else
-			config |= kIPv4Disabled;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_async(socketQueue, block);
+    // Note: YES means kIPv4Disabled is OFF
+    
+    dispatch_block_t block = ^{
+        
+        if (flag)
+            config &= ~kIPv4Disabled;
+        else
+            config |= kIPv4Disabled;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_async(socketQueue, block);
 }
 
 - (BOOL)isIPv6Enabled
 {
-	// Note: YES means kIPv6Disabled is OFF
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return ((config & kIPv6Disabled) == 0);
-	}
-	else
-	{
-		__block BOOL result;
-		
-		dispatch_sync(socketQueue, ^{
-			result = ((config & kIPv6Disabled) == 0);
-		});
-		
-		return result;
-	}
+    // Note: YES means kIPv6Disabled is OFF
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return ((config & kIPv6Disabled) == 0);
+    }
+    else
+    {
+        __block BOOL result;
+        
+        dispatch_sync(socketQueue, ^{
+            result = ((config & kIPv6Disabled) == 0);
+        });
+        
+        return result;
+    }
 }
 
 - (void)setIPv6Enabled:(BOOL)flag
 {
-	// Note: YES means kIPv6Disabled is OFF
-	
-	dispatch_block_t block = ^{
-		
-		if (flag)
-			config &= ~kIPv6Disabled;
-		else
-			config |= kIPv6Disabled;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_async(socketQueue, block);
+    // Note: YES means kIPv6Disabled is OFF
+    
+    dispatch_block_t block = ^{
+        
+        if (flag)
+            config &= ~kIPv6Disabled;
+        else
+            config |= kIPv6Disabled;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_async(socketQueue, block);
 }
 
 - (BOOL)isIPv4PreferredOverIPv6
 {
-	// Note: YES means kPreferIPv6 is OFF
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return ((config & kPreferIPv6) == 0);
-	}
-	else
-	{
-		__block BOOL result;
-		
-		dispatch_sync(socketQueue, ^{
-			result = ((config & kPreferIPv6) == 0);
-		});
-		
-		return result;
-	}
+    // Note: YES means kPreferIPv6 is OFF
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return ((config & kPreferIPv6) == 0);
+    }
+    else
+    {
+        __block BOOL result;
+        
+        dispatch_sync(socketQueue, ^{
+            result = ((config & kPreferIPv6) == 0);
+        });
+        
+        return result;
+    }
 }
 
-- (void)setPreferIPv4OverIPv6:(BOOL)flag
+- (void)setIPv4PreferredOverIPv6:(BOOL)flag
 {
-	// Note: YES means kPreferIPv6 is OFF
-	
-	dispatch_block_t block = ^{
-		
-		if (flag)
-			config &= ~kPreferIPv6;
-		else
-			config |= kPreferIPv6;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_async(socketQueue, block);
+    // Note: YES means kPreferIPv6 is OFF
+    
+    dispatch_block_t block = ^{
+        
+        if (flag)
+            config &= ~kPreferIPv6;
+        else
+            config |= kPreferIPv6;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_async(socketQueue, block);
 }
 
 - (id)userData
 {
-	__block id result = nil;
-	
-	dispatch_block_t block = ^{
-		
-		result = userData;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	return result;
+    __block id result = nil;
+    
+    dispatch_block_t block = ^{
+        
+        result = userData;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    return result;
 }
 
 - (void)setUserData:(id)arbitraryUserData
 {
-	dispatch_block_t block = ^{
-		
-		if (userData != arbitraryUserData)
-		{
-			userData = arbitraryUserData;
-		}
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_async(socketQueue, block);
+    dispatch_block_t block = ^{
+        
+        if (userData != arbitraryUserData)
+        {
+            userData = arbitraryUserData;
+        }
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_async(socketQueue, block);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1329,438 +1335,438 @@ enum GCDAsyncSocketConfig
 
 - (BOOL)acceptOnPort:(uint16_t)port error:(NSError **)errPtr
 {
-	return [self acceptOnInterface:nil port:port error:errPtr];
+    return [self acceptOnInterface:nil port:port error:errPtr];
 }
 
 - (BOOL)acceptOnInterface:(NSString *)inInterface port:(uint16_t)port error:(NSError **)errPtr
 {
-	LogTrace();
-	
-	// Just in-case interface parameter is immutable.
-	NSString *interface = [inInterface copy];
-	
-	__block BOOL result = NO;
-	__block NSError *err = nil;
-	
-	// CreateSocket Block
-	// This block will be invoked within the dispatch block below.
-	
-	int(^createSocket)(int, NSData*) = ^int (int domain, NSData *interfaceAddr) {
-		
-		int socketFD = socket(domain, SOCK_STREAM, 0);
-		
-		if (socketFD == SOCKET_NULL)
-		{
-			NSString *reason = @"Error in socket() function";
-			err = [self errnoErrorWithReason:reason];
-			
-			return SOCKET_NULL;
-		}
-		
-		int status;
-		
-		// Set socket options
-		
-		status = fcntl(socketFD, F_SETFL, O_NONBLOCK);
-		if (status == -1)
-		{
-			NSString *reason = @"Error enabling non-blocking IO on socket (fcntl)";
-			err = [self errnoErrorWithReason:reason];
-			
-			LogVerbose(@"close(socketFD)");
-			close(socketFD);
-			return SOCKET_NULL;
-		}
-		
-		int reuseOn = 1;
-		status = setsockopt(socketFD, SOL_SOCKET, SO_REUSEADDR, &reuseOn, sizeof(reuseOn));
-		if (status == -1)
-		{
-			NSString *reason = @"Error enabling address reuse (setsockopt)";
-			err = [self errnoErrorWithReason:reason];
-			
-			LogVerbose(@"close(socketFD)");
-			close(socketFD);
-			return SOCKET_NULL;
-		}
-		
-		// Bind socket
-		
-		status = bind(socketFD, (const struct sockaddr *)[interfaceAddr bytes], (socklen_t)[interfaceAddr length]);
-		if (status == -1)
-		{
-			NSString *reason = @"Error in bind() function";
-			err = [self errnoErrorWithReason:reason];
-			
-			LogVerbose(@"close(socketFD)");
-			close(socketFD);
-			return SOCKET_NULL;
-		}
-		
-		// Listen
-		
-		status = listen(socketFD, 1024);
-		if (status == -1)
-		{
-			NSString *reason = @"Error in listen() function";
-			err = [self errnoErrorWithReason:reason];
-			
-			LogVerbose(@"close(socketFD)");
-			close(socketFD);
-			return SOCKET_NULL;
-		}
-		
-		return socketFD;
-	};
-	
-	// Create dispatch block and run on socketQueue
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		if (delegate == nil) // Must have delegate set
-		{
-			NSString *msg = @"Attempting to accept without a delegate. Set a delegate first.";
-			err = [self badConfigError:msg];
-			
-			return_from_block;
-		}
-		
-		if (delegateQueue == NULL) // Must have delegate queue set
-		{
-			NSString *msg = @"Attempting to accept without a delegate queue. Set a delegate queue first.";
-			err = [self badConfigError:msg];
-			
-			return_from_block;
-		}
-		
-		BOOL isIPv4Disabled = (config & kIPv4Disabled) ? YES : NO;
-		BOOL isIPv6Disabled = (config & kIPv6Disabled) ? YES : NO;
-		
-		if (isIPv4Disabled && isIPv6Disabled) // Must have IPv4 or IPv6 enabled
-		{
-			NSString *msg = @"Both IPv4 and IPv6 have been disabled. Must enable at least one protocol first.";
-			err = [self badConfigError:msg];
-			
-			return_from_block;
-		}
-		
-		if (![self isDisconnected]) // Must be disconnected
-		{
-			NSString *msg = @"Attempting to accept while connected or accepting connections. Disconnect first.";
-			err = [self badConfigError:msg];
-			
-			return_from_block;
-		}
-		
-		// Clear queues (spurious read/write requests post disconnect)
-		[readQueue removeAllObjects];
-		[writeQueue removeAllObjects];
-		
-		// Resolve interface from description
-		
-		NSMutableData *interface4 = nil;
-		NSMutableData *interface6 = nil;
-		
-		[self getInterfaceAddress4:&interface4 address6:&interface6 fromDescription:interface port:port];
-		
-		if ((interface4 == nil) && (interface6 == nil))
-		{
-			NSString *msg = @"Unknown interface. Specify valid interface by name (e.g. \"en1\") or IP address.";
-			err = [self badParamError:msg];
-			
-			return_from_block;
-		}
-		
-		if (isIPv4Disabled && (interface6 == nil))
-		{
-			NSString *msg = @"IPv4 has been disabled and specified interface doesn't support IPv6.";
-			err = [self badParamError:msg];
-			
-			return_from_block;
-		}
-		
-		if (isIPv6Disabled && (interface4 == nil))
-		{
-			NSString *msg = @"IPv6 has been disabled and specified interface doesn't support IPv4.";
-			err = [self badParamError:msg];
-			
-			return_from_block;
-		}
-		
-		BOOL enableIPv4 = !isIPv4Disabled && (interface4 != nil);
-		BOOL enableIPv6 = !isIPv6Disabled && (interface6 != nil);
-		
-		// Create sockets, configure, bind, and listen
-		
-		if (enableIPv4)
-		{
-			LogVerbose(@"Creating IPv4 socket");
-			socket4FD = createSocket(AF_INET, interface4);
-			
-			if (socket4FD == SOCKET_NULL)
-			{
-				return_from_block;
-			}
-		}
-		
-		if (enableIPv6)
-		{
-			LogVerbose(@"Creating IPv6 socket");
-			
-			if (enableIPv4 && (port == 0))
-			{
-				// No specific port was specified, so we allowed the OS to pick an available port for us.
-				// Now we need to make sure the IPv6 socket listens on the same port as the IPv4 socket.
-				
-				struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)[interface6 mutableBytes];
-				addr6->sin6_port = htons([self localPort4]);
-			}
-			
-			socket6FD = createSocket(AF_INET6, interface6);
-			
-			if (socket6FD == SOCKET_NULL)
-			{
-				if (socket4FD != SOCKET_NULL)
-				{
-					LogVerbose(@"close(socket4FD)");
-					close(socket4FD);
-				}
-				
-				return_from_block;
-			}
-		}
-		
-		// Create accept sources
-		
-		if (enableIPv4)
-		{
-			accept4Source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, socket4FD, 0, socketQueue);
-			
-			int socketFD = socket4FD;
-			dispatch_source_t acceptSource = accept4Source;
-			
-			__weak GCDAsyncSocket *weakSelf = self;
-			
-			dispatch_source_set_event_handler(accept4Source, ^{ @autoreleasepool {
-			#pragma clang diagnostic push
-			#pragma clang diagnostic warning "-Wimplicit-retain-self"
-				
-				__strong GCDAsyncSocket *strongSelf = weakSelf;
-				if (strongSelf == nil) return_from_block;
-				
-				LogVerbose(@"event4Block");
-				
-				unsigned long i = 0;
-				unsigned long numPendingConnections = dispatch_source_get_data(acceptSource);
-				
-				LogVerbose(@"numPendingConnections: %lu", numPendingConnections);
-				
-				while ([strongSelf doAccept:socketFD] && (++i < numPendingConnections));
-				
-			#pragma clang diagnostic pop
-			}});
-			
-			
-			dispatch_source_set_cancel_handler(accept4Source, ^{
-			#pragma clang diagnostic push
-			#pragma clang diagnostic warning "-Wimplicit-retain-self"
-				
-				#if !OS_OBJECT_USE_OBJC
-				LogVerbose(@"dispatch_release(accept4Source)");
-				dispatch_release(acceptSource);
-				#endif
-				
-				LogVerbose(@"close(socket4FD)");
-				close(socketFD);
-			
-			#pragma clang diagnostic pop
-			});
-			
-			LogVerbose(@"dispatch_resume(accept4Source)");
-			dispatch_resume(accept4Source);
-		}
-		
-		if (enableIPv6)
-		{
-			accept6Source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, socket6FD, 0, socketQueue);
-			
-			int socketFD = socket6FD;
-			dispatch_source_t acceptSource = accept6Source;
-			
-			__weak GCDAsyncSocket *weakSelf = self;
-			
-			dispatch_source_set_event_handler(accept6Source, ^{ @autoreleasepool {
-			#pragma clang diagnostic push
-			#pragma clang diagnostic warning "-Wimplicit-retain-self"
-				
-				__strong GCDAsyncSocket *strongSelf = weakSelf;
-				if (strongSelf == nil) return_from_block;
-				
-				LogVerbose(@"event6Block");
-				
-				unsigned long i = 0;
-				unsigned long numPendingConnections = dispatch_source_get_data(acceptSource);
-				
-				LogVerbose(@"numPendingConnections: %lu", numPendingConnections);
-				
-				while ([strongSelf doAccept:socketFD] && (++i < numPendingConnections));
-				
-			#pragma clang diagnostic pop
-			}});
-			
-			dispatch_source_set_cancel_handler(accept6Source, ^{
-			#pragma clang diagnostic push
-			#pragma clang diagnostic warning "-Wimplicit-retain-self"
-				
-				#if !OS_OBJECT_USE_OBJC
-				LogVerbose(@"dispatch_release(accept6Source)");
-				dispatch_release(acceptSource);
-				#endif
-				
-				LogVerbose(@"close(socket6FD)");
-				close(socketFD);
-				
-			#pragma clang diagnostic pop
-			});
-			
-			LogVerbose(@"dispatch_resume(accept6Source)");
-			dispatch_resume(accept6Source);
-		}
-		
-		flags |= kSocketStarted;
-		
-		result = YES;
-	}};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	if (result == NO)
-	{
-		LogInfo(@"Error in accept: %@", err);
-		
-		if (errPtr)
-			*errPtr = err;
-	}
-	
-	return result;
+    LogTrace();
+    
+    // Just in-case interface parameter is immutable.
+    NSString *interface = [inInterface copy];
+    
+    __block BOOL result = NO;
+    __block NSError *err = nil;
+    
+    // CreateSocket Block
+    // This block will be invoked within the dispatch block below.
+    
+    int(^createSocket)(int, NSData*) = ^int (int domain, NSData *interfaceAddr) {
+        
+        int socketFD = socket(domain, SOCK_STREAM, 0);
+        
+        if (socketFD == SOCKET_NULL)
+        {
+            NSString *reason = @"Error in socket() function";
+            err = [self errnoErrorWithReason:reason];
+            
+            return SOCKET_NULL;
+        }
+        
+        int status;
+        
+        // Set socket options
+        
+        status = fcntl(socketFD, F_SETFL, O_NONBLOCK);
+        if (status == -1)
+        {
+            NSString *reason = @"Error enabling non-blocking IO on socket (fcntl)";
+            err = [self errnoErrorWithReason:reason];
+            
+            LogVerbose(@"close(socketFD)");
+            close(socketFD);
+            return SOCKET_NULL;
+        }
+        
+        int reuseOn = 1;
+        status = setsockopt(socketFD, SOL_SOCKET, SO_REUSEADDR, &reuseOn, sizeof(reuseOn));
+        if (status == -1)
+        {
+            NSString *reason = @"Error enabling address reuse (setsockopt)";
+            err = [self errnoErrorWithReason:reason];
+            
+            LogVerbose(@"close(socketFD)");
+            close(socketFD);
+            return SOCKET_NULL;
+        }
+        
+        // Bind socket
+        
+        status = bind(socketFD, (const struct sockaddr *)[interfaceAddr bytes], (socklen_t)[interfaceAddr length]);
+        if (status == -1)
+        {
+            NSString *reason = @"Error in bind() function";
+            err = [self errnoErrorWithReason:reason];
+            
+            LogVerbose(@"close(socketFD)");
+            close(socketFD);
+            return SOCKET_NULL;
+        }
+        
+        // Listen
+        
+        status = listen(socketFD, 1024);
+        if (status == -1)
+        {
+            NSString *reason = @"Error in listen() function";
+            err = [self errnoErrorWithReason:reason];
+            
+            LogVerbose(@"close(socketFD)");
+            close(socketFD);
+            return SOCKET_NULL;
+        }
+        
+        return socketFD;
+    };
+    
+    // Create dispatch block and run on socketQueue
+    
+    dispatch_block_t block = ^{ @autoreleasepool {
+        
+        if (delegate == nil) // Must have delegate set
+        {
+            NSString *msg = @"Attempting to accept without a delegate. Set a delegate first.";
+            err = [self badConfigError:msg];
+            
+            return_from_block;
+        }
+        
+        if (delegateQueue == NULL) // Must have delegate queue set
+        {
+            NSString *msg = @"Attempting to accept without a delegate queue. Set a delegate queue first.";
+            err = [self badConfigError:msg];
+            
+            return_from_block;
+        }
+        
+        BOOL isIPv4Disabled = (config & kIPv4Disabled) ? YES : NO;
+        BOOL isIPv6Disabled = (config & kIPv6Disabled) ? YES : NO;
+        
+        if (isIPv4Disabled && isIPv6Disabled) // Must have IPv4 or IPv6 enabled
+        {
+            NSString *msg = @"Both IPv4 and IPv6 have been disabled. Must enable at least one protocol first.";
+            err = [self badConfigError:msg];
+            
+            return_from_block;
+        }
+        
+        if (![self isDisconnected]) // Must be disconnected
+        {
+            NSString *msg = @"Attempting to accept while connected or accepting connections. Disconnect first.";
+            err = [self badConfigError:msg];
+            
+            return_from_block;
+        }
+        
+        // Clear queues (spurious read/write requests post disconnect)
+        [readQueue removeAllObjects];
+        [writeQueue removeAllObjects];
+        
+        // Resolve interface from description
+        
+        NSMutableData *interface4 = nil;
+        NSMutableData *interface6 = nil;
+        
+        [self getInterfaceAddress4:&interface4 address6:&interface6 fromDescription:interface port:port];
+        
+        if ((interface4 == nil) && (interface6 == nil))
+        {
+            NSString *msg = @"Unknown interface. Specify valid interface by name (e.g. \"en1\") or IP address.";
+            err = [self badParamError:msg];
+            
+            return_from_block;
+        }
+        
+        if (isIPv4Disabled && (interface6 == nil))
+        {
+            NSString *msg = @"IPv4 has been disabled and specified interface doesn't support IPv6.";
+            err = [self badParamError:msg];
+            
+            return_from_block;
+        }
+        
+        if (isIPv6Disabled && (interface4 == nil))
+        {
+            NSString *msg = @"IPv6 has been disabled and specified interface doesn't support IPv4.";
+            err = [self badParamError:msg];
+            
+            return_from_block;
+        }
+        
+        BOOL enableIPv4 = !isIPv4Disabled && (interface4 != nil);
+        BOOL enableIPv6 = !isIPv6Disabled && (interface6 != nil);
+        
+        // Create sockets, configure, bind, and listen
+        
+        if (enableIPv4)
+        {
+            LogVerbose(@"Creating IPv4 socket");
+            socket4FD = createSocket(AF_INET, interface4);
+            
+            if (socket4FD == SOCKET_NULL)
+            {
+                return_from_block;
+            }
+        }
+        
+        if (enableIPv6)
+        {
+            LogVerbose(@"Creating IPv6 socket");
+            
+            if (enableIPv4 && (port == 0))
+            {
+                // No specific port was specified, so we allowed the OS to pick an available port for us.
+                // Now we need to make sure the IPv6 socket listens on the same port as the IPv4 socket.
+                
+                struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)[interface6 mutableBytes];
+                addr6->sin6_port = htons([self localPort4]);
+            }
+            
+            socket6FD = createSocket(AF_INET6, interface6);
+            
+            if (socket6FD == SOCKET_NULL)
+            {
+                if (socket4FD != SOCKET_NULL)
+                {
+                    LogVerbose(@"close(socket4FD)");
+                    close(socket4FD);
+                }
+                
+                return_from_block;
+            }
+        }
+        
+        // Create accept sources
+        
+        if (enableIPv4)
+        {
+            accept4Source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, socket4FD, 0, socketQueue);
+            
+            int socketFD = socket4FD;
+            dispatch_source_t acceptSource = accept4Source;
+            
+            __weak GCDAsyncSocket *weakSelf = self;
+            
+            dispatch_source_set_event_handler(accept4Source, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+                
+                __strong GCDAsyncSocket *strongSelf = weakSelf;
+                if (strongSelf == nil) return_from_block;
+                
+                LogVerbose(@"event4Block");
+                
+                unsigned long i = 0;
+                unsigned long numPendingConnections = dispatch_source_get_data(acceptSource);
+                
+                LogVerbose(@"numPendingConnections: %lu", numPendingConnections);
+                
+                while ([strongSelf doAccept:socketFD] && (++i < numPendingConnections));
+                
+#pragma clang diagnostic pop
+            }});
+            
+            
+            dispatch_source_set_cancel_handler(accept4Source, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+                
+#if !OS_OBJECT_USE_OBJC
+                LogVerbose(@"dispatch_release(accept4Source)");
+                dispatch_release(acceptSource);
+#endif
+                
+                LogVerbose(@"close(socket4FD)");
+                close(socketFD);
+                
+#pragma clang diagnostic pop
+            });
+            
+            LogVerbose(@"dispatch_resume(accept4Source)");
+            dispatch_resume(accept4Source);
+        }
+        
+        if (enableIPv6)
+        {
+            accept6Source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, socket6FD, 0, socketQueue);
+            
+            int socketFD = socket6FD;
+            dispatch_source_t acceptSource = accept6Source;
+            
+            __weak GCDAsyncSocket *weakSelf = self;
+            
+            dispatch_source_set_event_handler(accept6Source, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+                
+                __strong GCDAsyncSocket *strongSelf = weakSelf;
+                if (strongSelf == nil) return_from_block;
+                
+                LogVerbose(@"event6Block");
+                
+                unsigned long i = 0;
+                unsigned long numPendingConnections = dispatch_source_get_data(acceptSource);
+                
+                LogVerbose(@"numPendingConnections: %lu", numPendingConnections);
+                
+                while ([strongSelf doAccept:socketFD] && (++i < numPendingConnections));
+                
+#pragma clang diagnostic pop
+            }});
+            
+            dispatch_source_set_cancel_handler(accept6Source, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+                
+#if !OS_OBJECT_USE_OBJC
+                LogVerbose(@"dispatch_release(accept6Source)");
+                dispatch_release(acceptSource);
+#endif
+                
+                LogVerbose(@"close(socket6FD)");
+                close(socketFD);
+                
+#pragma clang diagnostic pop
+            });
+            
+            LogVerbose(@"dispatch_resume(accept6Source)");
+            dispatch_resume(accept6Source);
+        }
+        
+        flags |= kSocketStarted;
+        
+        result = YES;
+    }};
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    if (result == NO)
+    {
+        LogInfo(@"Error in accept: %@", err);
+        
+        if (errPtr)
+            *errPtr = err;
+    }
+    
+    return result;
 }
 
 - (BOOL)doAccept:(int)parentSocketFD
 {
-	LogTrace();
-	
-	BOOL isIPv4;
-	int childSocketFD;
-	NSData *childSocketAddress;
-	
-	if (parentSocketFD == socket4FD)
-	{
-		isIPv4 = YES;
-		
-		struct sockaddr_in addr;
-		socklen_t addrLen = sizeof(addr);
-		
-		childSocketFD = accept(parentSocketFD, (struct sockaddr *)&addr, &addrLen);
-		
-		if (childSocketFD == -1)
-		{
-			LogWarn(@"Accept failed with error: %@", [self errnoError]);
-			return NO;
-		}
-		
-		childSocketAddress = [NSData dataWithBytes:&addr length:addrLen];
-	}
-	else // if (parentSocketFD == socket6FD)
-	{
-		isIPv4 = NO;
-		
-		struct sockaddr_in6 addr;
-		socklen_t addrLen = sizeof(addr);
-		
-		childSocketFD = accept(parentSocketFD, (struct sockaddr *)&addr, &addrLen);
-		
-		if (childSocketFD == -1)
-		{
-			LogWarn(@"Accept failed with error: %@", [self errnoError]);
-			return NO;
-		}
-		
-		childSocketAddress = [NSData dataWithBytes:&addr length:addrLen];
-	}
-	
-	// Enable non-blocking IO on the socket
-	
-	int result = fcntl(childSocketFD, F_SETFL, O_NONBLOCK);
-	if (result == -1)
-	{
-		LogWarn(@"Error enabling non-blocking IO on accepted socket (fcntl)");
-		return NO;
-	}
-	
-	// Prevent SIGPIPE signals
-	
-	int nosigpipe = 1;
-	setsockopt(childSocketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
-	
-	// Notify delegate
-	
-	if (delegateQueue)
-	{
-		__strong id theDelegate = delegate;
-		
-		dispatch_async(delegateQueue, ^{ @autoreleasepool {
-			
-			// Query delegate for custom socket queue
-			
-			dispatch_queue_t childSocketQueue = NULL;
-			
-			if ([theDelegate respondsToSelector:@selector(newSocketQueueForConnectionFromAddress:onSocket:)])
-			{
-				childSocketQueue = [theDelegate newSocketQueueForConnectionFromAddress:childSocketAddress
-				                                                              onSocket:self];
-			}
-			
-			// Create GCDAsyncSocket instance for accepted socket
-			
-			GCDAsyncSocket *acceptedSocket = [[GCDAsyncSocket alloc] initWithDelegate:theDelegate
-			                                                            delegateQueue:delegateQueue
-			                                                              socketQueue:childSocketQueue];
-			
-			if (isIPv4)
-				acceptedSocket->socket4FD = childSocketFD;
-			else
-				acceptedSocket->socket6FD = childSocketFD;
-			
-			acceptedSocket->flags = (kSocketStarted | kConnected);
-			
-			// Setup read and write sources for accepted socket
-			
-			dispatch_async(acceptedSocket->socketQueue, ^{ @autoreleasepool {
-				
-				[acceptedSocket setupReadAndWriteSourcesForNewlyConnectedSocket:childSocketFD];
-			}});
-			
-			// Notify delegate
-			
-			if ([theDelegate respondsToSelector:@selector(socket:didAcceptNewSocket:)])
-			{
-				[theDelegate socket:self didAcceptNewSocket:acceptedSocket];
-			}
-			
-			// Release the socket queue returned from the delegate (it was retained by acceptedSocket)
-			#if !OS_OBJECT_USE_OBJC
-			if (childSocketQueue) dispatch_release(childSocketQueue);
-			#endif
-			
-			// The accepted socket should have been retained by the delegate.
-			// Otherwise it gets properly released when exiting the block.
-		}});
-	}
-	
-	return YES;
+    LogTrace();
+    
+    BOOL isIPv4;
+    int childSocketFD;
+    NSData *childSocketAddress;
+    
+    if (parentSocketFD == socket4FD)
+    {
+        isIPv4 = YES;
+        
+        struct sockaddr_in addr;
+        socklen_t addrLen = sizeof(addr);
+        
+        childSocketFD = accept(parentSocketFD, (struct sockaddr *)&addr, &addrLen);
+        
+        if (childSocketFD == -1)
+        {
+            LogWarn(@"Accept failed with error: %@", [self errnoError]);
+            return NO;
+        }
+        
+        childSocketAddress = [NSData dataWithBytes:&addr length:addrLen];
+    }
+    else // if (parentSocketFD == socket6FD)
+    {
+        isIPv4 = NO;
+        
+        struct sockaddr_in6 addr;
+        socklen_t addrLen = sizeof(addr);
+        
+        childSocketFD = accept(parentSocketFD, (struct sockaddr *)&addr, &addrLen);
+        
+        if (childSocketFD == -1)
+        {
+            LogWarn(@"Accept failed with error: %@", [self errnoError]);
+            return NO;
+        }
+        
+        childSocketAddress = [NSData dataWithBytes:&addr length:addrLen];
+    }
+    
+    // Enable non-blocking IO on the socket
+    
+    int result = fcntl(childSocketFD, F_SETFL, O_NONBLOCK);
+    if (result == -1)
+    {
+        LogWarn(@"Error enabling non-blocking IO on accepted socket (fcntl)");
+        return NO;
+    }
+    
+    // Prevent SIGPIPE signals
+    
+    int nosigpipe = 1;
+    setsockopt(childSocketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
+    
+    // Notify delegate
+    
+    if (delegateQueue)
+    {
+        __strong id theDelegate = delegate;
+        
+        dispatch_async(delegateQueue, ^{ @autoreleasepool {
+            
+            // Query delegate for custom socket queue
+            
+            dispatch_queue_t childSocketQueue = NULL;
+            
+            if ([theDelegate respondsToSelector:@selector(newSocketQueueForConnectionFromAddress:onSocket:)])
+            {
+                childSocketQueue = [theDelegate newSocketQueueForConnectionFromAddress:childSocketAddress
+                                                                              onSocket:self];
+            }
+            
+            // Create GCDAsyncSocket instance for accepted socket
+            
+            GCDAsyncSocket *acceptedSocket = [[GCDAsyncSocket alloc] initWithDelegate:theDelegate
+                                                                        delegateQueue:delegateQueue
+                                                                          socketQueue:childSocketQueue];
+            
+            if (isIPv4)
+                acceptedSocket->socket4FD = childSocketFD;
+            else
+                acceptedSocket->socket6FD = childSocketFD;
+            
+            acceptedSocket->flags = (kSocketStarted | kConnected);
+            
+            // Setup read and write sources for accepted socket
+            
+            dispatch_async(acceptedSocket->socketQueue, ^{ @autoreleasepool {
+                
+                [acceptedSocket setupReadAndWriteSourcesForNewlyConnectedSocket:childSocketFD];
+            }});
+            
+            // Notify delegate
+            
+            if ([theDelegate respondsToSelector:@selector(socket:didAcceptNewSocket:)])
+            {
+                [theDelegate socket:self didAcceptNewSocket:acceptedSocket];
+            }
+            
+            // Release the socket queue returned from the delegate (it was retained by acceptedSocket)
+#if !OS_OBJECT_USE_OBJC
+            if (childSocketQueue) dispatch_release(childSocketQueue);
+#endif
+            
+            // The accepted socket should have been retained by the delegate.
+            // Otherwise it gets properly released when exiting the block.
+        }});
+    }
+    
+    return YES;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1770,106 +1776,106 @@ enum GCDAsyncSocketConfig
 /**
  * This method runs through the various checks required prior to a connection attempt.
  * It is shared between the connectToHost and connectToAddress methods.
- * 
-**/
+ *
+ **/
 - (BOOL)preConnectWithInterface:(NSString *)interface error:(NSError **)errPtr
 {
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	if (delegate == nil) // Must have delegate set
-	{
-		if (errPtr)
-		{
-			NSString *msg = @"Attempting to connect without a delegate. Set a delegate first.";
-			*errPtr = [self badConfigError:msg];
-		}
-		return NO;
-	}
-	
-	if (delegateQueue == NULL) // Must have delegate queue set
-	{
-		if (errPtr)
-		{
-			NSString *msg = @"Attempting to connect without a delegate queue. Set a delegate queue first.";
-			*errPtr = [self badConfigError:msg];
-		}
-		return NO;
-	}
-	
-	if (![self isDisconnected]) // Must be disconnected
-	{
-		if (errPtr)
-		{
-			NSString *msg = @"Attempting to connect while connected or accepting connections. Disconnect first.";
-			*errPtr = [self badConfigError:msg];
-		}
-		return NO;
-	}
-	
-	BOOL isIPv4Disabled = (config & kIPv4Disabled) ? YES : NO;
-	BOOL isIPv6Disabled = (config & kIPv6Disabled) ? YES : NO;
-	
-	if (isIPv4Disabled && isIPv6Disabled) // Must have IPv4 or IPv6 enabled
-	{
-		if (errPtr)
-		{
-			NSString *msg = @"Both IPv4 and IPv6 have been disabled. Must enable at least one protocol first.";
-			*errPtr = [self badConfigError:msg];
-		}
-		return NO;
-	}
-	
-	if (interface)
-	{
-		NSMutableData *interface4 = nil;
-		NSMutableData *interface6 = nil;
-		
-		[self getInterfaceAddress4:&interface4 address6:&interface6 fromDescription:interface port:0];
-		
-		if ((interface4 == nil) && (interface6 == nil))
-		{
-			if (errPtr)
-			{
-				NSString *msg = @"Unknown interface. Specify valid interface by name (e.g. \"en1\") or IP address.";
-				*errPtr = [self badParamError:msg];
-			}
-			return NO;
-		}
-		
-		if (isIPv4Disabled && (interface6 == nil))
-		{
-			if (errPtr)
-			{
-				NSString *msg = @"IPv4 has been disabled and specified interface doesn't support IPv6.";
-				*errPtr = [self badParamError:msg];
-			}
-			return NO;
-		}
-		
-		if (isIPv6Disabled && (interface4 == nil))
-		{
-			if (errPtr)
-			{
-				NSString *msg = @"IPv6 has been disabled and specified interface doesn't support IPv4.";
-				*errPtr = [self badParamError:msg];
-			}
-			return NO;
-		}
-		
-		connectInterface4 = interface4;
-		connectInterface6 = interface6;
-	}
-	
-	// Clear queues (spurious read/write requests post disconnect)
-	[readQueue removeAllObjects];
-	[writeQueue removeAllObjects];
-	
-	return YES;
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    if (delegate == nil) // Must have delegate set
+    {
+        if (errPtr)
+        {
+            NSString *msg = @"Attempting to connect without a delegate. Set a delegate first.";
+            *errPtr = [self badConfigError:msg];
+        }
+        return NO;
+    }
+    
+    if (delegateQueue == NULL) // Must have delegate queue set
+    {
+        if (errPtr)
+        {
+            NSString *msg = @"Attempting to connect without a delegate queue. Set a delegate queue first.";
+            *errPtr = [self badConfigError:msg];
+        }
+        return NO;
+    }
+    
+    if (![self isDisconnected]) // Must be disconnected
+    {
+        if (errPtr)
+        {
+            NSString *msg = @"Attempting to connect while connected or accepting connections. Disconnect first.";
+            *errPtr = [self badConfigError:msg];
+        }
+        return NO;
+    }
+    
+    BOOL isIPv4Disabled = (config & kIPv4Disabled) ? YES : NO;
+    BOOL isIPv6Disabled = (config & kIPv6Disabled) ? YES : NO;
+    
+    if (isIPv4Disabled && isIPv6Disabled) // Must have IPv4 or IPv6 enabled
+    {
+        if (errPtr)
+        {
+            NSString *msg = @"Both IPv4 and IPv6 have been disabled. Must enable at least one protocol first.";
+            *errPtr = [self badConfigError:msg];
+        }
+        return NO;
+    }
+    
+    if (interface)
+    {
+        NSMutableData *interface4 = nil;
+        NSMutableData *interface6 = nil;
+        
+        [self getInterfaceAddress4:&interface4 address6:&interface6 fromDescription:interface port:0];
+        
+        if ((interface4 == nil) && (interface6 == nil))
+        {
+            if (errPtr)
+            {
+                NSString *msg = @"Unknown interface. Specify valid interface by name (e.g. \"en1\") or IP address.";
+                *errPtr = [self badParamError:msg];
+            }
+            return NO;
+        }
+        
+        if (isIPv4Disabled && (interface6 == nil))
+        {
+            if (errPtr)
+            {
+                NSString *msg = @"IPv4 has been disabled and specified interface doesn't support IPv6.";
+                *errPtr = [self badParamError:msg];
+            }
+            return NO;
+        }
+        
+        if (isIPv6Disabled && (interface4 == nil))
+        {
+            if (errPtr)
+            {
+                NSString *msg = @"IPv6 has been disabled and specified interface doesn't support IPv4.";
+                *errPtr = [self badParamError:msg];
+            }
+            return NO;
+        }
+        
+        connectInterface4 = interface4;
+        connectInterface6 = interface6;
+    }
+    
+    // Clear queues (spurious read/write requests post disconnect)
+    [readQueue removeAllObjects];
+    [writeQueue removeAllObjects];
+    
+    return YES;
 }
 
 - (BOOL)connectToHost:(NSString*)host onPort:(uint16_t)port error:(NSError **)errPtr
 {
-	return [self connectToHost:host onPort:port withTimeout:-1 error:errPtr];
+    return [self connectToHost:host onPort:port withTimeout:-1 error:errPtr];
 }
 
 - (BOOL)connectToHost:(NSString *)host
@@ -1877,7 +1883,7 @@ enum GCDAsyncSocketConfig
           withTimeout:(NSTimeInterval)timeout
                 error:(NSError **)errPtr
 {
-	return [self connectToHost:host onPort:port viaInterface:nil withTimeout:timeout error:errPtr];
+    return [self connectToHost:host onPort:port viaInterface:nil withTimeout:timeout error:errPtr];
 }
 
 - (BOOL)connectToHost:(NSString *)inHost
@@ -1886,117 +1892,117 @@ enum GCDAsyncSocketConfig
           withTimeout:(NSTimeInterval)timeout
                 error:(NSError **)errPtr
 {
-	LogTrace();
-	
-	// Just in case immutable objects were passed
-	NSString *host = [inHost copy];
-	NSString *interface = [inInterface copy];
-	
-	__block BOOL result = NO;
-	__block NSError *preConnectErr = nil;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		// Check for problems with host parameter
-		
-		if ([host length] == 0)
-		{
-			NSString *msg = @"Invalid host parameter (nil or \"\"). Should be a domain name or IP address string.";
-			preConnectErr = [self badParamError:msg];
-			
-			return_from_block;
-		}
-		
-		// Run through standard pre-connect checks
-		
-		if (![self preConnectWithInterface:interface error:&preConnectErr])
-		{
-			return_from_block;
-		}
-		
-		// We've made it past all the checks.
-		// It's time to start the connection process.
-		
-		flags |= kSocketStarted;
-		
-		LogVerbose(@"Dispatching DNS lookup...");
-		
-		// It's possible that the given host parameter is actually a NSMutableString.
-		// So we want to copy it now, within this block that will be executed synchronously.
-		// This way the asynchronous lookup block below doesn't have to worry about it changing.
-		
-		int aConnectIndex = connectIndex;
-		NSString *hostCpy = [host copy];
-		
-		__weak GCDAsyncSocket *weakSelf = self;
-		
-		dispatch_queue_t globalConcurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-		dispatch_async(globalConcurrentQueue, ^{ @autoreleasepool {
-		#pragma clang diagnostic push
-		#pragma clang diagnostic warning "-Wimplicit-retain-self"
-			
-			NSError *lookupErr = nil;
-			NSMutableArray *addresses = [GCDAsyncSocket lookupHost:hostCpy port:port error:&lookupErr];
-			
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
-			if (strongSelf == nil) return_from_block;
-			
-			if (lookupErr)
-			{
-				dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
-					
-					[strongSelf lookup:aConnectIndex didFail:lookupErr];
-				}});
-			}
-			else
-			{
-				NSData *address4 = nil;
-				NSData *address6 = nil;
-				
-				for (NSData *address in addresses)
-				{
-					if (!address4 && [GCDAsyncSocket isIPv4Address:address])
-					{
-						address4 = address;
-					}
-					else if (!address6 && [GCDAsyncSocket isIPv6Address:address])
-					{
-						address6 = address;
-					}
-				}
-				
-				dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
-					
-					[strongSelf lookup:aConnectIndex didSucceedWithAddress4:address4 address6:address6];
-				}});
-			}
-			
-		#pragma clang diagnostic pop
-		}});
-		
-		[self startConnectTimeout:timeout];
-		
-		result = YES;
-	}};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	
-	if (errPtr) *errPtr = preConnectErr;
-	return result;
+    LogTrace();
+    
+    // Just in case immutable objects were passed
+    NSString *host = [inHost copy];
+    NSString *interface = [inInterface copy];
+    
+    __block BOOL result = NO;
+    __block NSError *preConnectErr = nil;
+    
+    dispatch_block_t block = ^{ @autoreleasepool {
+        
+        // Check for problems with host parameter
+        
+        if ([host length] == 0)
+        {
+            NSString *msg = @"Invalid host parameter (nil or \"\"). Should be a domain name or IP address string.";
+            preConnectErr = [self badParamError:msg];
+            
+            return_from_block;
+        }
+        
+        // Run through standard pre-connect checks
+        
+        if (![self preConnectWithInterface:interface error:&preConnectErr])
+        {
+            return_from_block;
+        }
+        
+        // We've made it past all the checks.
+        // It's time to start the connection process.
+        
+        flags |= kSocketStarted;
+        
+        LogVerbose(@"Dispatching DNS lookup...");
+        
+        // It's possible that the given host parameter is actually a NSMutableString.
+        // So we want to copy it now, within this block that will be executed synchronously.
+        // This way the asynchronous lookup block below doesn't have to worry about it changing.
+        
+        NSString *hostCpy = [host copy];
+        
+        int aStateIndex = stateIndex;
+        __weak GCDAsyncSocket *weakSelf = self;
+        
+        dispatch_queue_t globalConcurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+        dispatch_async(globalConcurrentQueue, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+            
+            NSError *lookupErr = nil;
+            NSMutableArray *addresses = [GCDAsyncSocket lookupHost:hostCpy port:port error:&lookupErr];
+            
+            __strong GCDAsyncSocket *strongSelf = weakSelf;
+            if (strongSelf == nil) return_from_block;
+            
+            if (lookupErr)
+            {
+                dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
+                    
+                    [strongSelf lookup:aStateIndex didFail:lookupErr];
+                }});
+            }
+            else
+            {
+                NSData *address4 = nil;
+                NSData *address6 = nil;
+                
+                for (NSData *address in addresses)
+                {
+                    if (!address4 && [GCDAsyncSocket isIPv4Address:address])
+                    {
+                        address4 = address;
+                    }
+                    else if (!address6 && [GCDAsyncSocket isIPv6Address:address])
+                    {
+                        address6 = address;
+                    }
+                }
+                
+                dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
+                    
+                    [strongSelf lookup:aStateIndex didSucceedWithAddress4:address4 address6:address6];
+                }});
+            }
+            
+#pragma clang diagnostic pop
+        }});
+        
+        [self startConnectTimeout:timeout];
+        
+        result = YES;
+    }};
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    
+    if (errPtr) *errPtr = preConnectErr;
+    return result;
 }
 
 - (BOOL)connectToAddress:(NSData *)remoteAddr error:(NSError **)errPtr
 {
-	return [self connectToAddress:remoteAddr viaInterface:nil withTimeout:-1 error:errPtr];
+    return [self connectToAddress:remoteAddr viaInterface:nil withTimeout:-1 error:errPtr];
 }
 
 - (BOOL)connectToAddress:(NSData *)remoteAddr withTimeout:(NSTimeInterval)timeout error:(NSError **)errPtr
 {
-	return [self connectToAddress:remoteAddr viaInterface:nil withTimeout:timeout error:errPtr];
+    return [self connectToAddress:remoteAddr viaInterface:nil withTimeout:timeout error:errPtr];
 }
 
 - (BOOL)connectToAddress:(NSData *)inRemoteAddr
@@ -2004,522 +2010,521 @@ enum GCDAsyncSocketConfig
              withTimeout:(NSTimeInterval)timeout
                    error:(NSError **)errPtr
 {
-	LogTrace();
-	
-	// Just in case immutable objects were passed
-	NSData *remoteAddr = [inRemoteAddr copy];
-	NSString *interface = [inInterface copy];
-	
-	__block BOOL result = NO;
-	__block NSError *err = nil;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		// Check for problems with remoteAddr parameter
-		
-		NSData *address4 = nil;
-		NSData *address6 = nil;
-		
-		if ([remoteAddr length] >= sizeof(struct sockaddr))
-		{
-			const struct sockaddr *sockaddr = (const struct sockaddr *)[remoteAddr bytes];
-			
-			if (sockaddr->sa_family == AF_INET)
-			{
-				if ([remoteAddr length] == sizeof(struct sockaddr_in))
-				{
-					address4 = remoteAddr;
-				}
-			}
-			else if (sockaddr->sa_family == AF_INET6)
-			{
-				if ([remoteAddr length] == sizeof(struct sockaddr_in6))
-				{
-					address6 = remoteAddr;
-				}
-			}
-		}
-		
-		if ((address4 == nil) && (address6 == nil))
-		{
-			NSString *msg = @"A valid IPv4 or IPv6 address was not given";
-			err = [self badParamError:msg];
-			
-			return_from_block;
-		}
-		
-		BOOL isIPv4Disabled = (config & kIPv4Disabled) ? YES : NO;
-		BOOL isIPv6Disabled = (config & kIPv6Disabled) ? YES : NO;
-		
-		if (isIPv4Disabled && (address4 != nil))
-		{
-			NSString *msg = @"IPv4 has been disabled and an IPv4 address was passed.";
-			err = [self badParamError:msg];
-			
-			return_from_block;
-		}
-		
-		if (isIPv6Disabled && (address6 != nil))
-		{
-			NSString *msg = @"IPv6 has been disabled and an IPv6 address was passed.";
-			err = [self badParamError:msg];
-			
-			return_from_block;
-		}
-		
-		// Run through standard pre-connect checks
-		
-		if (![self preConnectWithInterface:interface error:&err])
-		{
-			return_from_block;
-		}
-		
-		// We've made it past all the checks.
-		// It's time to start the connection process.
-		
-		if (![self connectWithAddress4:address4 address6:address6 error:&err])
-		{
-			return_from_block;
-		}
-		
-		flags |= kSocketStarted;
-		
-		[self startConnectTimeout:timeout];
-		
-		result = YES;
-	}};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	if (result == NO)
-	{
-		if (errPtr)
-			*errPtr = err;
-	}
-	
-	return result;
+    LogTrace();
+    
+    // Just in case immutable objects were passed
+    NSData *remoteAddr = [inRemoteAddr copy];
+    NSString *interface = [inInterface copy];
+    
+    __block BOOL result = NO;
+    __block NSError *err = nil;
+    
+    dispatch_block_t block = ^{ @autoreleasepool {
+        
+        // Check for problems with remoteAddr parameter
+        
+        NSData *address4 = nil;
+        NSData *address6 = nil;
+        
+        if ([remoteAddr length] >= sizeof(struct sockaddr))
+        {
+            const struct sockaddr *sockaddr = (const struct sockaddr *)[remoteAddr bytes];
+            
+            if (sockaddr->sa_family == AF_INET)
+            {
+                if ([remoteAddr length] == sizeof(struct sockaddr_in))
+                {
+                    address4 = remoteAddr;
+                }
+            }
+            else if (sockaddr->sa_family == AF_INET6)
+            {
+                if ([remoteAddr length] == sizeof(struct sockaddr_in6))
+                {
+                    address6 = remoteAddr;
+                }
+            }
+        }
+        
+        if ((address4 == nil) && (address6 == nil))
+        {
+            NSString *msg = @"A valid IPv4 or IPv6 address was not given";
+            err = [self badParamError:msg];
+            
+            return_from_block;
+        }
+        
+        BOOL isIPv4Disabled = (config & kIPv4Disabled) ? YES : NO;
+        BOOL isIPv6Disabled = (config & kIPv6Disabled) ? YES : NO;
+        
+        if (isIPv4Disabled && (address4 != nil))
+        {
+            NSString *msg = @"IPv4 has been disabled and an IPv4 address was passed.";
+            err = [self badParamError:msg];
+            
+            return_from_block;
+        }
+        
+        if (isIPv6Disabled && (address6 != nil))
+        {
+            NSString *msg = @"IPv6 has been disabled and an IPv6 address was passed.";
+            err = [self badParamError:msg];
+            
+            return_from_block;
+        }
+        
+        // Run through standard pre-connect checks
+        
+        if (![self preConnectWithInterface:interface error:&err])
+        {
+            return_from_block;
+        }
+        
+        // We've made it past all the checks.
+        // It's time to start the connection process.
+        
+        if (![self connectWithAddress4:address4 address6:address6 error:&err])
+        {
+            return_from_block;
+        }
+        
+        flags |= kSocketStarted;
+        
+        [self startConnectTimeout:timeout];
+        
+        result = YES;
+    }};
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    if (result == NO)
+    {
+        if (errPtr)
+            *errPtr = err;
+    }
+    
+    return result;
 }
 
-- (void)lookup:(int)aConnectIndex didSucceedWithAddress4:(NSData *)address4 address6:(NSData *)address6
+- (void)lookup:(int)aStateIndex didSucceedWithAddress4:(NSData *)address4 address6:(NSData *)address6
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	NSAssert(address4 || address6, @"Expected at least one valid address");
-	
-	if (aConnectIndex != connectIndex)
-	{
-		LogInfo(@"Ignoring lookupDidSucceed, already disconnected");
-		
-		// The connect operation has been cancelled.
-		// That is, socket was disconnected, or connection has already timed out.
-		return;
-	}
-	
-	// Check for problems
-	
-	BOOL isIPv4Disabled = (config & kIPv4Disabled) ? YES : NO;
-	BOOL isIPv6Disabled = (config & kIPv6Disabled) ? YES : NO;
-	
-	if (isIPv4Disabled && (address6 == nil))
-	{
-		NSString *msg = @"IPv4 has been disabled and DNS lookup found no IPv6 address.";
-		
-		[self closeWithError:[self otherError:msg]];
-		return;
-	}
-	
-	if (isIPv6Disabled && (address4 == nil))
-	{
-		NSString *msg = @"IPv6 has been disabled and DNS lookup found no IPv4 address.";
-		
-		[self closeWithError:[self otherError:msg]];
-		return;
-	}
-	
-	// Start the normal connection process
-	
-	NSError *err = nil;
-	if (![self connectWithAddress4:address4 address6:address6 error:&err])
-	{
-		[self closeWithError:err];
-	}
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    NSAssert(address4 || address6, @"Expected at least one valid address");
+    
+    if (aStateIndex != stateIndex)
+    {
+        LogInfo(@"Ignoring lookupDidSucceed, already disconnected");
+        
+        // The connect operation has been cancelled.
+        // That is, socket was disconnected, or connection has already timed out.
+        return;
+    }
+    
+    // Check for problems
+    
+    BOOL isIPv4Disabled = (config & kIPv4Disabled) ? YES : NO;
+    BOOL isIPv6Disabled = (config & kIPv6Disabled) ? YES : NO;
+    
+    if (isIPv4Disabled && (address6 == nil))
+    {
+        NSString *msg = @"IPv4 has been disabled and DNS lookup found no IPv6 address.";
+        
+        [self closeWithError:[self otherError:msg]];
+        return;
+    }
+    
+    if (isIPv6Disabled && (address4 == nil))
+    {
+        NSString *msg = @"IPv6 has been disabled and DNS lookup found no IPv4 address.";
+        
+        [self closeWithError:[self otherError:msg]];
+        return;
+    }
+    
+    // Start the normal connection process
+    
+    NSError *err = nil;
+    if (![self connectWithAddress4:address4 address6:address6 error:&err])
+    {
+        [self closeWithError:err];
+    }
 }
 
 /**
  * This method is called if the DNS lookup fails.
  * This method is executed on the socketQueue.
- * 
+ *
  * Since the DNS lookup executed synchronously on a global concurrent queue,
  * the original connection request may have already been cancelled or timed-out by the time this method is invoked.
  * The lookupIndex tells us whether the lookup is still valid or not.
-**/
-- (void)lookup:(int)aConnectIndex didFail:(NSError *)error
+ **/
+- (void)lookup:(int)aStateIndex didFail:(NSError *)error
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	
-	if (aConnectIndex != connectIndex)
-	{
-		LogInfo(@"Ignoring lookup:didFail: - already disconnected");
-		
-		// The connect operation has been cancelled.
-		// That is, socket was disconnected, or connection has already timed out.
-		return;
-	}
-	
-	[self endConnectTimeout];
-	[self closeWithError:error];
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    
+    if (aStateIndex != stateIndex)
+    {
+        LogInfo(@"Ignoring lookup:didFail: - already disconnected");
+        
+        // The connect operation has been cancelled.
+        // That is, socket was disconnected, or connection has already timed out.
+        return;
+    }
+    
+    [self endConnectTimeout];
+    [self closeWithError:error];
 }
 
 - (BOOL)connectWithAddress4:(NSData *)address4 address6:(NSData *)address6 error:(NSError **)errPtr
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	LogVerbose(@"IPv4: %@:%hu", [[self class] hostFromAddress:address4], [[self class] portFromAddress:address4]);
-	LogVerbose(@"IPv6: %@:%hu", [[self class] hostFromAddress:address6], [[self class] portFromAddress:address6]);
-	
-	// Determine socket type
-	
-	BOOL preferIPv6 = (config & kPreferIPv6) ? YES : NO;
-	
-	BOOL useIPv6 = ((preferIPv6 && address6) || (address4 == nil));
-	
-	// Create the socket
-	
-	int socketFD;
-	NSData *address;
-	NSData *connectInterface;
-	
-	if (useIPv6)
-	{
-		LogVerbose(@"Creating IPv6 socket");
-		
-		socket6FD = socket(AF_INET6, SOCK_STREAM, 0);
-		
-		socketFD = socket6FD;
-		address = address6;
-		connectInterface = connectInterface6;
-	}
-	else
-	{
-		LogVerbose(@"Creating IPv4 socket");
-		
-		socket4FD = socket(AF_INET, SOCK_STREAM, 0);
-		
-		socketFD = socket4FD;
-		address = address4;
-		connectInterface = connectInterface4;
-	}
-	
-	if (socketFD == SOCKET_NULL)
-	{
-		if (errPtr)
-			*errPtr = [self errnoErrorWithReason:@"Error in socket() function"];
-		
-		return NO;
-	}
-	
-	// Bind the socket to the desired interface (if needed)
-	
-	if (connectInterface)
-	{
-		LogVerbose(@"Binding socket...");
-		
-		if ([[self class] portFromAddress:connectInterface] > 0)
-		{
-			// Since we're going to be binding to a specific port,
-			// we should turn on reuseaddr to allow us to override sockets in time_wait.
-			
-			int reuseOn = 1;
-			setsockopt(socketFD, SOL_SOCKET, SO_REUSEADDR, &reuseOn, sizeof(reuseOn));
-		}
-		
-		const struct sockaddr *interfaceAddr = (const struct sockaddr *)[connectInterface bytes];
-		
-		int result = bind(socketFD, interfaceAddr, (socklen_t)[connectInterface length]);
-		if (result != 0)
-		{
-			if (errPtr)
-				*errPtr = [self errnoErrorWithReason:@"Error in bind() function"];
-			
-			return NO;
-		}
-	}
-	
-	// Prevent SIGPIPE signals
-	
-	int nosigpipe = 1;
-	setsockopt(socketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
-	
-	// Start the connection process in a background queue
-	
-	int aConnectIndex = connectIndex;
-	
-	__weak GCDAsyncSocket *weakSelf = self;
-	
-	dispatch_queue_t globalConcurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-	dispatch_async(globalConcurrentQueue, ^{
-	#pragma clang diagnostic push
-	#pragma clang diagnostic warning "-Wimplicit-retain-self"
-	
-		int result = connect(socketFD, (const struct sockaddr *)[address bytes], (socklen_t)[address length]);
-		
-		__strong GCDAsyncSocket *strongSelf = weakSelf;
-		if (strongSelf == nil) return_from_block;
-		
-		if (result == 0)
-		{
-			dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
-				
-				[strongSelf didConnect:aConnectIndex];
-			}});
-		}
-		else
-		{
-			NSError *error = [strongSelf errnoErrorWithReason:@"Error in connect() function"];
-			
-			dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
-				
-				[strongSelf didNotConnect:aConnectIndex error:error];
-			}});
-		}
-		
-	#pragma clang diagnostic pop
-	});
-	
-	LogVerbose(@"Connecting...");
-	
-	return YES;
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    LogVerbose(@"IPv4: %@:%hu", [[self class] hostFromAddress:address4], [[self class] portFromAddress:address4]);
+    LogVerbose(@"IPv6: %@:%hu", [[self class] hostFromAddress:address6], [[self class] portFromAddress:address6]);
+    
+    // Determine socket type
+    
+    BOOL preferIPv6 = (config & kPreferIPv6) ? YES : NO;
+    
+    BOOL useIPv6 = ((preferIPv6 && address6) || (address4 == nil));
+    
+    // Create the socket
+    
+    int socketFD;
+    NSData *address;
+    NSData *connectInterface;
+    
+    if (useIPv6)
+    {
+        LogVerbose(@"Creating IPv6 socket");
+        
+        socket6FD = socket(AF_INET6, SOCK_STREAM, 0);
+        
+        socketFD = socket6FD;
+        address = address6;
+        connectInterface = connectInterface6;
+    }
+    else
+    {
+        LogVerbose(@"Creating IPv4 socket");
+        
+        socket4FD = socket(AF_INET, SOCK_STREAM, 0);
+        
+        socketFD = socket4FD;
+        address = address4;
+        connectInterface = connectInterface4;
+    }
+    
+    if (socketFD == SOCKET_NULL)
+    {
+        if (errPtr)
+            *errPtr = [self errnoErrorWithReason:@"Error in socket() function"];
+        
+        return NO;
+    }
+    
+    // Bind the socket to the desired interface (if needed)
+    
+    if (connectInterface)
+    {
+        LogVerbose(@"Binding socket...");
+        
+        if ([[self class] portFromAddress:connectInterface] > 0)
+        {
+            // Since we're going to be binding to a specific port,
+            // we should turn on reuseaddr to allow us to override sockets in time_wait.
+            
+            int reuseOn = 1;
+            setsockopt(socketFD, SOL_SOCKET, SO_REUSEADDR, &reuseOn, sizeof(reuseOn));
+        }
+        
+        const struct sockaddr *interfaceAddr = (const struct sockaddr *)[connectInterface bytes];
+        
+        int result = bind(socketFD, interfaceAddr, (socklen_t)[connectInterface length]);
+        if (result != 0)
+        {
+            if (errPtr)
+                *errPtr = [self errnoErrorWithReason:@"Error in bind() function"];
+            
+            return NO;
+        }
+    }
+    
+    // Prevent SIGPIPE signals
+    
+    int nosigpipe = 1;
+    setsockopt(socketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
+    
+    // Start the connection process in a background queue
+    
+    int aStateIndex = stateIndex;
+    __weak GCDAsyncSocket *weakSelf = self;
+    
+    dispatch_queue_t globalConcurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    dispatch_async(globalConcurrentQueue, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+        
+        int result = connect(socketFD, (const struct sockaddr *)[address bytes], (socklen_t)[address length]);
+        
+        __strong GCDAsyncSocket *strongSelf = weakSelf;
+        if (strongSelf == nil) return_from_block;
+        
+        if (result == 0)
+        {
+            dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
+                
+                [strongSelf didConnect:aStateIndex];
+            }});
+        }
+        else
+        {
+            NSError *error = [strongSelf errnoErrorWithReason:@"Error in connect() function"];
+            
+            dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
+                
+                [strongSelf didNotConnect:aStateIndex error:error];
+            }});
+        }
+        
+#pragma clang diagnostic pop
+    });
+    
+    LogVerbose(@"Connecting...");
+    
+    return YES;
 }
 
-- (void)didConnect:(int)aConnectIndex
+- (void)didConnect:(int)aStateIndex
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	
-	if (aConnectIndex != connectIndex)
-	{
-		LogInfo(@"Ignoring didConnect, already disconnected");
-		
-		// The connect operation has been cancelled.
-		// That is, socket was disconnected, or connection has already timed out.
-		return;
-	}
-	
-	flags |= kConnected;
-	
-	[self endConnectTimeout];
-	
-	#if TARGET_OS_IPHONE
-	// The endConnectTimeout method executed above incremented the connectIndex.
-	aConnectIndex = connectIndex;
-	#endif
-	
-	// Setup read/write streams (as workaround for specific shortcomings in the iOS platform)
-	// 
-	// Note:
-	// There may be configuration options that must be set by the delegate before opening the streams.
-	// The primary example is the kCFStreamNetworkServiceTypeVoIP flag, which only works on an unopened stream.
-	// 
-	// Thus we wait until after the socket:didConnectToHost:port: delegate method has completed.
-	// This gives the delegate time to properly configure the streams if needed.
-	
-	dispatch_block_t SetupStreamsPart1 = ^{
-		#if TARGET_OS_IPHONE
-		
-		if (![self createReadAndWriteStream])
-		{
-			[self closeWithError:[self otherError:@"Error creating CFStreams"]];
-			return;
-		}
-		
-		if (![self registerForStreamCallbacksIncludingReadWrite:NO])
-		{
-			[self closeWithError:[self otherError:@"Error in CFStreamSetClient"]];
-			return;
-		}
-		
-		#endif
-	};
-	dispatch_block_t SetupStreamsPart2 = ^{
-		#if TARGET_OS_IPHONE
-		
-		if (aConnectIndex != connectIndex)
-		{
-			// The socket has been disconnected.
-			return;
-		}
-		
-		if (![self addStreamsToRunLoop])
-		{
-			[self closeWithError:[self otherError:@"Error in CFStreamScheduleWithRunLoop"]];
-			return;
-		}
-		
-		if (![self openStreams])
-		{
-			[self closeWithError:[self otherError:@"Error creating CFStreams"]];
-			return;
-		}
-		
-		#endif
-	};
-	
-	// Notify delegate
-	
-	NSString *host = [self connectedHost];
-	uint16_t port = [self connectedPort];
-	
-	__strong id theDelegate = delegate;
-
-	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didConnectToHost:port:)])
-	{
-		SetupStreamsPart1();
-		
-		dispatch_async(delegateQueue, ^{ @autoreleasepool {
-			
-			[theDelegate socket:self didConnectToHost:host port:port];
-			
-			dispatch_async(socketQueue, ^{ @autoreleasepool {
-				
-				SetupStreamsPart2();
-			}});
-		}});
-	}
-	else
-	{
-		SetupStreamsPart1();
-		SetupStreamsPart2();
-	}
-		
-	// Get the connected socket
-	
-	int socketFD = (socket4FD != SOCKET_NULL) ? socket4FD : socket6FD;
-	
-	// Enable non-blocking IO on the socket
-	
-	int result = fcntl(socketFD, F_SETFL, O_NONBLOCK);
-	if (result == -1)
-	{
-		NSString *errMsg = @"Error enabling non-blocking IO on socket (fcntl)";
-		[self closeWithError:[self otherError:errMsg]];
-		
-		return;
-	}
-	
-	// Setup our read/write sources
-	
-	[self setupReadAndWriteSourcesForNewlyConnectedSocket:socketFD];
-	
-	// Dequeue any pending read/write requests
-	
-	[self maybeDequeueRead];
-	[self maybeDequeueWrite];
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    
+    if (aStateIndex != stateIndex)
+    {
+        LogInfo(@"Ignoring didConnect, already disconnected");
+        
+        // The connect operation has been cancelled.
+        // That is, socket was disconnected, or connection has already timed out.
+        return;
+    }
+    
+    flags |= kConnected;
+    
+    [self endConnectTimeout];
+    
+#if TARGET_OS_IPHONE
+    // The endConnectTimeout method executed above incremented the stateIndex.
+    aStateIndex = stateIndex;
+#endif
+    
+    // Setup read/write streams (as workaround for specific shortcomings in the iOS platform)
+    //
+    // Note:
+    // There may be configuration options that must be set by the delegate before opening the streams.
+    // The primary example is the kCFStreamNetworkServiceTypeVoIP flag, which only works on an unopened stream.
+    //
+    // Thus we wait until after the socket:didConnectToHost:port: delegate method has completed.
+    // This gives the delegate time to properly configure the streams if needed.
+    
+    dispatch_block_t SetupStreamsPart1 = ^{
+#if TARGET_OS_IPHONE
+        
+        if (![self createReadAndWriteStream])
+        {
+            [self closeWithError:[self otherError:@"Error creating CFStreams"]];
+            return;
+        }
+        
+        if (![self registerForStreamCallbacksIncludingReadWrite:NO])
+        {
+            [self closeWithError:[self otherError:@"Error in CFStreamSetClient"]];
+            return;
+        }
+        
+#endif
+    };
+    dispatch_block_t SetupStreamsPart2 = ^{
+#if TARGET_OS_IPHONE
+        
+        if (aStateIndex != stateIndex)
+        {
+            // The socket has been disconnected.
+            return;
+        }
+        
+        if (![self addStreamsToRunLoop])
+        {
+            [self closeWithError:[self otherError:@"Error in CFStreamScheduleWithRunLoop"]];
+            return;
+        }
+        
+        if (![self openStreams])
+        {
+            [self closeWithError:[self otherError:@"Error creating CFStreams"]];
+            return;
+        }
+        
+#endif
+    };
+    
+    // Notify delegate
+    
+    NSString *host = [self connectedHost];
+    uint16_t port = [self connectedPort];
+    
+    __strong id theDelegate = delegate;
+    
+    if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didConnectToHost:port:)])
+    {
+        SetupStreamsPart1();
+        
+        dispatch_async(delegateQueue, ^{ @autoreleasepool {
+            
+            [theDelegate socket:self didConnectToHost:host port:port];
+            
+            dispatch_async(socketQueue, ^{ @autoreleasepool {
+                
+                SetupStreamsPart2();
+            }});
+        }});
+    }
+    else
+    {
+        SetupStreamsPart1();
+        SetupStreamsPart2();
+    }
+    
+    // Get the connected socket
+    
+    int socketFD = (socket4FD != SOCKET_NULL) ? socket4FD : socket6FD;
+    
+    // Enable non-blocking IO on the socket
+    
+    int result = fcntl(socketFD, F_SETFL, O_NONBLOCK);
+    if (result == -1)
+    {
+        NSString *errMsg = @"Error enabling non-blocking IO on socket (fcntl)";
+        [self closeWithError:[self otherError:errMsg]];
+        
+        return;
+    }
+    
+    // Setup our read/write sources
+    
+    [self setupReadAndWriteSourcesForNewlyConnectedSocket:socketFD];
+    
+    // Dequeue any pending read/write requests
+    
+    [self maybeDequeueRead];
+    [self maybeDequeueWrite];
 }
 
-- (void)didNotConnect:(int)aConnectIndex error:(NSError *)error
+- (void)didNotConnect:(int)aStateIndex error:(NSError *)error
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	
-	if (aConnectIndex != connectIndex)
-	{
-		LogInfo(@"Ignoring didNotConnect, already disconnected");
-		
-		// The connect operation has been cancelled.
-		// That is, socket was disconnected, or connection has already timed out.
-		return;
-	}
-	
-	[self closeWithError:error];
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    
+    if (aStateIndex != stateIndex)
+    {
+        LogInfo(@"Ignoring didNotConnect, already disconnected");
+        
+        // The connect operation has been cancelled.
+        // That is, socket was disconnected, or connection has already timed out.
+        return;
+    }
+    
+    [self closeWithError:error];
 }
 
 - (void)startConnectTimeout:(NSTimeInterval)timeout
 {
-	if (timeout >= 0.0)
-	{
-		connectTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
-		
-		__weak GCDAsyncSocket *weakSelf = self;
-		
-		dispatch_source_set_event_handler(connectTimer, ^{ @autoreleasepool {
-		#pragma clang diagnostic push
-		#pragma clang diagnostic warning "-Wimplicit-retain-self"
-		
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
-			if (strongSelf == nil) return_from_block;
-			
-			[strongSelf doConnectTimeout];
-			
-		#pragma clang diagnostic pop
-		}});
-		
-		#if !OS_OBJECT_USE_OBJC
-		dispatch_source_t theConnectTimer = connectTimer;
-		dispatch_source_set_cancel_handler(connectTimer, ^{
-		#pragma clang diagnostic push
-		#pragma clang diagnostic warning "-Wimplicit-retain-self"
-			
-			LogVerbose(@"dispatch_release(connectTimer)");
-			dispatch_release(theConnectTimer);
-			
-		#pragma clang diagnostic pop
-		});
-		#endif
-		
-		dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
-		dispatch_source_set_timer(connectTimer, tt, DISPATCH_TIME_FOREVER, 0);
-		
-		dispatch_resume(connectTimer);
-	}
+    if (timeout >= 0.0)
+    {
+        connectTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
+        
+        __weak GCDAsyncSocket *weakSelf = self;
+        
+        dispatch_source_set_event_handler(connectTimer, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+            
+            __strong GCDAsyncSocket *strongSelf = weakSelf;
+            if (strongSelf == nil) return_from_block;
+            
+            [strongSelf doConnectTimeout];
+            
+#pragma clang diagnostic pop
+        }});
+        
+#if !OS_OBJECT_USE_OBJC
+        dispatch_source_t theConnectTimer = connectTimer;
+        dispatch_source_set_cancel_handler(connectTimer, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+            
+            LogVerbose(@"dispatch_release(connectTimer)");
+            dispatch_release(theConnectTimer);
+            
+#pragma clang diagnostic pop
+        });
+#endif
+        
+        dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
+        dispatch_source_set_timer(connectTimer, tt, DISPATCH_TIME_FOREVER, 0);
+        
+        dispatch_resume(connectTimer);
+    }
 }
 
 - (void)endConnectTimeout
 {
-	LogTrace();
-	
-	if (connectTimer)
-	{
-		dispatch_source_cancel(connectTimer);
-		connectTimer = NULL;
-	}
-	
-	// Increment connectIndex.
-	// This will prevent us from processing results from any related background asynchronous operations.
-	// 
-	// Note: This should be called from close method even if connectTimer is NULL.
-	// This is because one might disconnect a socket prior to a successful connection which had no timeout.
-	
-	connectIndex++;
-	
-	if (connectInterface4)
-	{
-		connectInterface4 = nil;
-	}
-	if (connectInterface6)
-	{
-		connectInterface6 = nil;
-	}
+    LogTrace();
+    
+    if (connectTimer)
+    {
+        dispatch_source_cancel(connectTimer);
+        connectTimer = NULL;
+    }
+    
+    // Increment stateIndex.
+    // This will prevent us from processing results from any related background asynchronous operations.
+    //
+    // Note: This should be called from close method even if connectTimer is NULL.
+    // This is because one might disconnect a socket prior to a successful connection which had no timeout.
+    
+    stateIndex++;
+    
+    if (connectInterface4)
+    {
+        connectInterface4 = nil;
+    }
+    if (connectInterface6)
+    {
+        connectInterface6 = nil;
+    }
 }
 
 - (void)doConnectTimeout
 {
-	LogTrace();
-	
-	[self endConnectTimeout];
-	[self closeWithError:[self connectTimeoutError]];
+    LogTrace();
+    
+    [self endConnectTimeout];
+    [self closeWithError:[self connectTimeoutError]];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2528,254 +2533,251 @@ enum GCDAsyncSocketConfig
 
 - (void)closeWithError:(NSError *)error
 {
-	LogTrace();
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	[self endConnectTimeout];
-	
-	if (currentRead != nil)  [self endCurrentRead];
-	if (currentWrite != nil) [self endCurrentWrite];
-	
-	[readQueue removeAllObjects];
-	[writeQueue removeAllObjects];
-	
-	[preBuffer reset];
-	
-	#if TARGET_OS_IPHONE
-	{
-		if (readStream || writeStream)
-		{
-			[self removeStreamsFromRunLoop];
-			
-			if (readStream)
-			{
-				CFReadStreamSetClient(readStream, kCFStreamEventNone, NULL, NULL);
-				CFReadStreamClose(readStream);
-				CFRelease(readStream);
-				readStream = NULL;
-			}
-			if (writeStream)
-			{
-				CFWriteStreamSetClient(writeStream, kCFStreamEventNone, NULL, NULL);
-				CFWriteStreamClose(writeStream);
-				CFRelease(writeStream);
-				writeStream = NULL;
-			}
-		}
-	}
-	#endif
-	#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-	{
-		[sslPreBuffer reset];
-		sslErrCode = noErr;
-		
-		if (sslContext)
-		{
-			// Getting a linker error here about the SSLx() functions?
-			// You need to add the Security Framework to your application.
-			
-			SSLClose(sslContext);
-			
-			#if TARGET_OS_IPHONE
-			CFRelease(sslContext);
-			#else
-			SSLDisposeContext(sslContext);
-			#endif
-			
-			sslContext = NULL;
-		}
-	}
-	#endif
-	
-	// For some crazy reason (in my opinion), cancelling a dispatch source doesn't
-	// invoke the cancel handler if the dispatch source is paused.
-	// So we have to unpause the source if needed.
-	// This allows the cancel handler to be run, which in turn releases the source and closes the socket.
-	
-	if (!accept4Source && !accept6Source && !readSource && !writeSource)
-	{
-		LogVerbose(@"manually closing close");
-
-		if (socket4FD != SOCKET_NULL)
-		{
-			LogVerbose(@"close(socket4FD)");
-			close(socket4FD);
-			socket4FD = SOCKET_NULL;
-		}
-
-		if (socket6FD != SOCKET_NULL)
-		{
-			LogVerbose(@"close(socket6FD)");
-			close(socket6FD);
-			socket6FD = SOCKET_NULL;
-		}
-	}
-	else
-	{
-		if (accept4Source)
-		{
-			LogVerbose(@"dispatch_source_cancel(accept4Source)");
-			dispatch_source_cancel(accept4Source);
-			
-			// We never suspend accept4Source
-			
-			accept4Source = NULL;
-		}
-		
-		if (accept6Source)
-		{
-			LogVerbose(@"dispatch_source_cancel(accept6Source)");
-			dispatch_source_cancel(accept6Source);
-			
-			// We never suspend accept6Source
-			
-			accept6Source = NULL;
-		}
-	
-		if (readSource)
-		{
-			LogVerbose(@"dispatch_source_cancel(readSource)");
-			dispatch_source_cancel(readSource);
-			
-			[self resumeReadSource];
-			
-			readSource = NULL;
-		}
-		
-		if (writeSource)
-		{
-			LogVerbose(@"dispatch_source_cancel(writeSource)");
-			dispatch_source_cancel(writeSource);
-			
-			[self resumeWriteSource];
-			
-			writeSource = NULL;
-		}
-		
-		// The sockets will be closed by the cancel handlers of the corresponding source
-		
-		socket4FD = SOCKET_NULL;
-		socket6FD = SOCKET_NULL;
-	}
-	
-	// If the client has passed the connect/accept method, then the connection has at least begun.
-	// Notify delegate that it is now ending.
-	BOOL shouldCallDelegate = (flags & kSocketStarted) ? YES : NO;
-	BOOL isDeallocating = (flags & kDealloc) ? YES : NO;
-	
-	// Clear stored socket info and all flags (config remains as is)
-	socketFDBytesAvailable = 0;
-	flags = 0;
-	
-	if (shouldCallDelegate)
-	{
-		__strong id theDelegate = delegate;
-		__strong id theSelf = isDeallocating ? nil : self;
-		
-		if (delegateQueue && [theDelegate respondsToSelector: @selector(socketDidDisconnect:withError:)])
-		{
-			dispatch_async(delegateQueue, ^{ @autoreleasepool {
-				
-				[theDelegate socketDidDisconnect:theSelf withError:error];
-			}});
-		}	
-	}
+    LogTrace();
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    [self endConnectTimeout];
+    
+    if (currentRead != nil)  [self endCurrentRead];
+    if (currentWrite != nil) [self endCurrentWrite];
+    
+    [readQueue removeAllObjects];
+    [writeQueue removeAllObjects];
+    
+    [preBuffer reset];
+    
+#if TARGET_OS_IPHONE
+    {
+        if (readStream || writeStream)
+        {
+            [self removeStreamsFromRunLoop];
+            
+            if (readStream)
+            {
+                CFReadStreamSetClient(readStream, kCFStreamEventNone, NULL, NULL);
+                CFReadStreamClose(readStream);
+                CFRelease(readStream);
+                readStream = NULL;
+            }
+            if (writeStream)
+            {
+                CFWriteStreamSetClient(writeStream, kCFStreamEventNone, NULL, NULL);
+                CFWriteStreamClose(writeStream);
+                CFRelease(writeStream);
+                writeStream = NULL;
+            }
+        }
+    }
+#endif
+    
+    [sslPreBuffer reset];
+    sslErrCode = noErr;
+    
+    if (sslContext)
+    {
+        // Getting a linker error here about the SSLx() functions?
+        // You need to add the Security Framework to your application.
+        
+        SSLClose(sslContext);
+        
+#if TARGET_OS_IPHONE || (__MAC_OS_X_VERSION_MIN_REQUIRED >= 1080)
+        CFRelease(sslContext);
+#else
+        SSLDisposeContext(sslContext);
+#endif
+        
+        sslContext = NULL;
+    }
+    
+    // For some crazy reason (in my opinion), cancelling a dispatch source doesn't
+    // invoke the cancel handler if the dispatch source is paused.
+    // So we have to unpause the source if needed.
+    // This allows the cancel handler to be run, which in turn releases the source and closes the socket.
+    
+    if (!accept4Source && !accept6Source && !readSource && !writeSource)
+    {
+        LogVerbose(@"manually closing close");
+        
+        if (socket4FD != SOCKET_NULL)
+        {
+            LogVerbose(@"close(socket4FD)");
+            close(socket4FD);
+            socket4FD = SOCKET_NULL;
+        }
+        
+        if (socket6FD != SOCKET_NULL)
+        {
+            LogVerbose(@"close(socket6FD)");
+            close(socket6FD);
+            socket6FD = SOCKET_NULL;
+        }
+    }
+    else
+    {
+        if (accept4Source)
+        {
+            LogVerbose(@"dispatch_source_cancel(accept4Source)");
+            dispatch_source_cancel(accept4Source);
+            
+            // We never suspend accept4Source
+            
+            accept4Source = NULL;
+        }
+        
+        if (accept6Source)
+        {
+            LogVerbose(@"dispatch_source_cancel(accept6Source)");
+            dispatch_source_cancel(accept6Source);
+            
+            // We never suspend accept6Source
+            
+            accept6Source = NULL;
+        }
+        
+        if (readSource)
+        {
+            LogVerbose(@"dispatch_source_cancel(readSource)");
+            dispatch_source_cancel(readSource);
+            
+            [self resumeReadSource];
+            
+            readSource = NULL;
+        }
+        
+        if (writeSource)
+        {
+            LogVerbose(@"dispatch_source_cancel(writeSource)");
+            dispatch_source_cancel(writeSource);
+            
+            [self resumeWriteSource];
+            
+            writeSource = NULL;
+        }
+        
+        // The sockets will be closed by the cancel handlers of the corresponding source
+        
+        socket4FD = SOCKET_NULL;
+        socket6FD = SOCKET_NULL;
+    }
+    
+    // If the client has passed the connect/accept method, then the connection has at least begun.
+    // Notify delegate that it is now ending.
+    BOOL shouldCallDelegate = (flags & kSocketStarted) ? YES : NO;
+    BOOL isDeallocating = (flags & kDealloc) ? YES : NO;
+    
+    // Clear stored socket info and all flags (config remains as is)
+    socketFDBytesAvailable = 0;
+    flags = 0;
+    
+    if (shouldCallDelegate)
+    {
+        __strong id theDelegate = delegate;
+        __strong id theSelf = isDeallocating ? nil : self;
+        
+        if (delegateQueue && [theDelegate respondsToSelector: @selector(socketDidDisconnect:withError:)])
+        {
+            dispatch_async(delegateQueue, ^{ @autoreleasepool {
+                
+                [theDelegate socketDidDisconnect:theSelf withError:error];
+            }});
+        }
+    }
 }
 
 - (void)disconnect
 {
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		if (flags & kSocketStarted)
-		{
-			[self closeWithError:nil];
-		}
-	}};
-	
-	// Synchronous disconnection, as documented in the header file
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
+    dispatch_block_t block = ^{ @autoreleasepool {
+        
+        if (flags & kSocketStarted)
+        {
+            [self closeWithError:nil];
+        }
+    }};
+    
+    // Synchronous disconnection, as documented in the header file
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
 }
 
 - (void)disconnectAfterReading
 {
-	dispatch_async(socketQueue, ^{ @autoreleasepool {
-		
-		if (flags & kSocketStarted)
-		{
-			flags |= (kForbidReadsWrites | kDisconnectAfterReads);
-			[self maybeClose];
-		}
-	}});
+    dispatch_async(socketQueue, ^{ @autoreleasepool {
+        
+        if (flags & kSocketStarted)
+        {
+            flags |= (kForbidReadsWrites | kDisconnectAfterReads);
+            [self maybeClose];
+        }
+    }});
 }
 
 - (void)disconnectAfterWriting
 {
-	dispatch_async(socketQueue, ^{ @autoreleasepool {
-		
-		if (flags & kSocketStarted)
-		{
-			flags |= (kForbidReadsWrites | kDisconnectAfterWrites);
-			[self maybeClose];
-		}
-	}});
+    dispatch_async(socketQueue, ^{ @autoreleasepool {
+        
+        if (flags & kSocketStarted)
+        {
+            flags |= (kForbidReadsWrites | kDisconnectAfterWrites);
+            [self maybeClose];
+        }
+    }});
 }
 
 - (void)disconnectAfterReadingAndWriting
 {
-	dispatch_async(socketQueue, ^{ @autoreleasepool {
-		
-		if (flags & kSocketStarted)
-		{
-			flags |= (kForbidReadsWrites | kDisconnectAfterReads | kDisconnectAfterWrites);
-			[self maybeClose];
-		}
-	}});
+    dispatch_async(socketQueue, ^{ @autoreleasepool {
+        
+        if (flags & kSocketStarted)
+        {
+            flags |= (kForbidReadsWrites | kDisconnectAfterReads | kDisconnectAfterWrites);
+            [self maybeClose];
+        }
+    }});
 }
 
 /**
  * Closes the socket if possible.
  * That is, if all writes have completed, and we're set to disconnect after writing,
  * or if all reads have completed, and we're set to disconnect after reading.
-**/
+ **/
 - (void)maybeClose
 {
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	BOOL shouldClose = NO;
-	
-	if (flags & kDisconnectAfterReads)
-	{
-		if (([readQueue count] == 0) && (currentRead == nil))
-		{
-			if (flags & kDisconnectAfterWrites)
-			{
-				if (([writeQueue count] == 0) && (currentWrite == nil))
-				{
-					shouldClose = YES;
-				}
-			}
-			else
-			{
-				shouldClose = YES;
-			}
-		}
-	}
-	else if (flags & kDisconnectAfterWrites)
-	{
-		if (([writeQueue count] == 0) && (currentWrite == nil))
-		{
-			shouldClose = YES;
-		}
-	}
-	
-	if (shouldClose)
-	{
-		[self closeWithError:nil];
-	}
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    BOOL shouldClose = NO;
+    
+    if (flags & kDisconnectAfterReads)
+    {
+        if (([readQueue count] == 0) && (currentRead == nil))
+        {
+            if (flags & kDisconnectAfterWrites)
+            {
+                if (([writeQueue count] == 0) && (currentWrite == nil))
+                {
+                    shouldClose = YES;
+                }
+            }
+            else
+            {
+                shouldClose = YES;
+            }
+        }
+    }
+    else if (flags & kDisconnectAfterWrites)
+    {
+        if (([writeQueue count] == 0) && (currentWrite == nil))
+        {
+            shouldClose = YES;
+        }
+    }
+    
+    if (shouldClose)
+    {
+        [self closeWithError:nil];
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2784,120 +2786,120 @@ enum GCDAsyncSocketConfig
 
 - (NSError *)badConfigError:(NSString *)errMsg
 {
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketBadConfigError userInfo:userInfo];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketBadConfigError userInfo:userInfo];
 }
 
 - (NSError *)badParamError:(NSString *)errMsg
 {
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketBadParamError userInfo:userInfo];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketBadParamError userInfo:userInfo];
 }
 
 + (NSError *)gaiError:(int)gai_error
 {
-	NSString *errMsg = [NSString stringWithCString:gai_strerror(gai_error) encoding:NSASCIIStringEncoding];
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:@"kCFStreamErrorDomainNetDB" code:gai_error userInfo:userInfo];
+    NSString *errMsg = [NSString stringWithCString:gai_strerror(gai_error) encoding:NSASCIIStringEncoding];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:@"kCFStreamErrorDomainNetDB" code:gai_error userInfo:userInfo];
 }
 
 - (NSError *)errnoErrorWithReason:(NSString *)reason
 {
-	NSString *errMsg = [NSString stringWithUTF8String:strerror(errno)];
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:errMsg, NSLocalizedDescriptionKey,
-	                                                                    reason, NSLocalizedFailureReasonErrorKey, nil];
-	
-	return [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:userInfo];
+    NSString *errMsg = [NSString stringWithUTF8String:strerror(errno)];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:errMsg, NSLocalizedDescriptionKey,
+                              reason, NSLocalizedFailureReasonErrorKey, nil];
+    
+    return [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:userInfo];
 }
 
 - (NSError *)errnoError
 {
-	NSString *errMsg = [NSString stringWithUTF8String:strerror(errno)];
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:userInfo];
+    NSString *errMsg = [NSString stringWithUTF8String:strerror(errno)];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:userInfo];
 }
 
 - (NSError *)sslError:(OSStatus)ssl_error
 {
-	NSString *msg = @"Error code definition can be found in Apple's SecureTransport.h";
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:msg forKey:NSLocalizedRecoverySuggestionErrorKey];
-	
-	return [NSError errorWithDomain:@"kCFStreamErrorDomainSSL" code:ssl_error userInfo:userInfo];
+    NSString *msg = @"Error code definition can be found in Apple's SecureTransport.h";
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:msg forKey:NSLocalizedRecoverySuggestionErrorKey];
+    
+    return [NSError errorWithDomain:@"kCFStreamErrorDomainSSL" code:ssl_error userInfo:userInfo];
 }
 
 - (NSError *)connectTimeoutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketConnectTimeoutError",
-	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
-	                                                     @"Attempt to connect to host timed out", nil);
-	
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketConnectTimeoutError userInfo:userInfo];
+    NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketConnectTimeoutError",
+                                                         @"GCDAsyncSocket", [NSBundle mainBundle],
+                                                         @"Attempt to connect to host timed out", nil);
+    
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketConnectTimeoutError userInfo:userInfo];
 }
 
 /**
  * Returns a standard AsyncSocket maxed out error.
-**/
+ **/
 - (NSError *)readMaxedOutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketReadMaxedOutError",
-														 @"GCDAsyncSocket", [NSBundle mainBundle],
-														 @"Read operation reached set maximum length", nil);
-	
-	NSDictionary *info = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketReadMaxedOutError userInfo:info];
+    NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketReadMaxedOutError",
+                                                         @"GCDAsyncSocket", [NSBundle mainBundle],
+                                                         @"Read operation reached set maximum length", nil);
+    
+    NSDictionary *info = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketReadMaxedOutError userInfo:info];
 }
 
 /**
  * Returns a standard AsyncSocket write timeout error.
-**/
+ **/
 - (NSError *)readTimeoutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketReadTimeoutError",
-	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
-	                                                     @"Read operation timed out", nil);
-	
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketReadTimeoutError userInfo:userInfo];
+    NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketReadTimeoutError",
+                                                         @"GCDAsyncSocket", [NSBundle mainBundle],
+                                                         @"Read operation timed out", nil);
+    
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketReadTimeoutError userInfo:userInfo];
 }
 
 /**
  * Returns a standard AsyncSocket write timeout error.
-**/
+ **/
 - (NSError *)writeTimeoutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketWriteTimeoutError",
-	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
-	                                                     @"Write operation timed out", nil);
-	
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketWriteTimeoutError userInfo:userInfo];
+    NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketWriteTimeoutError",
+                                                         @"GCDAsyncSocket", [NSBundle mainBundle],
+                                                         @"Write operation timed out", nil);
+    
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketWriteTimeoutError userInfo:userInfo];
 }
 
 - (NSError *)connectionClosedError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketClosedError",
-	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
-	                                                     @"Socket closed by remote peer", nil);
-	
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketClosedError userInfo:userInfo];
+    NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketClosedError",
+                                                         @"GCDAsyncSocket", [NSBundle mainBundle],
+                                                         @"Socket closed by remote peer", nil);
+    
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketClosedError userInfo:userInfo];
 }
 
 - (NSError *)otherError:(NSString *)errMsg
 {
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
-	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+    
+    return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2906,430 +2908,430 @@ enum GCDAsyncSocketConfig
 
 - (BOOL)isDisconnected
 {
-	__block BOOL result = NO;
-	
-	dispatch_block_t block = ^{
-		result = (flags & kSocketStarted) ? NO : YES;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	return result;
+    __block BOOL result = NO;
+    
+    dispatch_block_t block = ^{
+        result = (flags & kSocketStarted) ? NO : YES;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    return result;
 }
 
 - (BOOL)isConnected
 {
-	__block BOOL result = NO;
-	
-	dispatch_block_t block = ^{
-		result = (flags & kConnected) ? YES : NO;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	return result;
+    __block BOOL result = NO;
+    
+    dispatch_block_t block = ^{
+        result = (flags & kConnected) ? YES : NO;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    return result;
 }
 
 - (NSString *)connectedHost
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		if (socket4FD != SOCKET_NULL)
-			return [self connectedHostFromSocket4:socket4FD];
-		if (socket6FD != SOCKET_NULL)
-			return [self connectedHostFromSocket6:socket6FD];
-		
-		return nil;
-	}
-	else
-	{
-		__block NSString *result = nil;
-		
-		dispatch_sync(socketQueue, ^{ @autoreleasepool {
-			
-			if (socket4FD != SOCKET_NULL)
-				result = [self connectedHostFromSocket4:socket4FD];
-			else if (socket6FD != SOCKET_NULL)
-				result = [self connectedHostFromSocket6:socket6FD];
-		}});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        if (socket4FD != SOCKET_NULL)
+            return [self connectedHostFromSocket4:socket4FD];
+        if (socket6FD != SOCKET_NULL)
+            return [self connectedHostFromSocket6:socket6FD];
+        
+        return nil;
+    }
+    else
+    {
+        __block NSString *result = nil;
+        
+        dispatch_sync(socketQueue, ^{ @autoreleasepool {
+            
+            if (socket4FD != SOCKET_NULL)
+                result = [self connectedHostFromSocket4:socket4FD];
+            else if (socket6FD != SOCKET_NULL)
+                result = [self connectedHostFromSocket6:socket6FD];
+        }});
+        
+        return result;
+    }
 }
 
 - (uint16_t)connectedPort
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		if (socket4FD != SOCKET_NULL)
-			return [self connectedPortFromSocket4:socket4FD];
-		if (socket6FD != SOCKET_NULL)
-			return [self connectedPortFromSocket6:socket6FD];
-		
-		return 0;
-	}
-	else
-	{
-		__block uint16_t result = 0;
-		
-		dispatch_sync(socketQueue, ^{
-			// No need for autorelease pool
-			
-			if (socket4FD != SOCKET_NULL)
-				result = [self connectedPortFromSocket4:socket4FD];
-			else if (socket6FD != SOCKET_NULL)
-				result = [self connectedPortFromSocket6:socket6FD];
-		});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        if (socket4FD != SOCKET_NULL)
+            return [self connectedPortFromSocket4:socket4FD];
+        if (socket6FD != SOCKET_NULL)
+            return [self connectedPortFromSocket6:socket6FD];
+        
+        return 0;
+    }
+    else
+    {
+        __block uint16_t result = 0;
+        
+        dispatch_sync(socketQueue, ^{
+            // No need for autorelease pool
+            
+            if (socket4FD != SOCKET_NULL)
+                result = [self connectedPortFromSocket4:socket4FD];
+            else if (socket6FD != SOCKET_NULL)
+                result = [self connectedPortFromSocket6:socket6FD];
+        });
+        
+        return result;
+    }
 }
 
 - (NSString *)localHost
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		if (socket4FD != SOCKET_NULL)
-			return [self localHostFromSocket4:socket4FD];
-		if (socket6FD != SOCKET_NULL)
-			return [self localHostFromSocket6:socket6FD];
-		
-		return nil;
-	}
-	else
-	{
-		__block NSString *result = nil;
-		
-		dispatch_sync(socketQueue, ^{ @autoreleasepool {
-			
-			if (socket4FD != SOCKET_NULL)
-				result = [self localHostFromSocket4:socket4FD];
-			else if (socket6FD != SOCKET_NULL)
-				result = [self localHostFromSocket6:socket6FD];
-		}});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        if (socket4FD != SOCKET_NULL)
+            return [self localHostFromSocket4:socket4FD];
+        if (socket6FD != SOCKET_NULL)
+            return [self localHostFromSocket6:socket6FD];
+        
+        return nil;
+    }
+    else
+    {
+        __block NSString *result = nil;
+        
+        dispatch_sync(socketQueue, ^{ @autoreleasepool {
+            
+            if (socket4FD != SOCKET_NULL)
+                result = [self localHostFromSocket4:socket4FD];
+            else if (socket6FD != SOCKET_NULL)
+                result = [self localHostFromSocket6:socket6FD];
+        }});
+        
+        return result;
+    }
 }
 
 - (uint16_t)localPort
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		if (socket4FD != SOCKET_NULL)
-			return [self localPortFromSocket4:socket4FD];
-		if (socket6FD != SOCKET_NULL)
-			return [self localPortFromSocket6:socket6FD];
-		
-		return 0;
-	}
-	else
-	{
-		__block uint16_t result = 0;
-		
-		dispatch_sync(socketQueue, ^{
-			// No need for autorelease pool
-			
-			if (socket4FD != SOCKET_NULL)
-				result = [self localPortFromSocket4:socket4FD];
-			else if (socket6FD != SOCKET_NULL)
-				result = [self localPortFromSocket6:socket6FD];
-		});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        if (socket4FD != SOCKET_NULL)
+            return [self localPortFromSocket4:socket4FD];
+        if (socket6FD != SOCKET_NULL)
+            return [self localPortFromSocket6:socket6FD];
+        
+        return 0;
+    }
+    else
+    {
+        __block uint16_t result = 0;
+        
+        dispatch_sync(socketQueue, ^{
+            // No need for autorelease pool
+            
+            if (socket4FD != SOCKET_NULL)
+                result = [self localPortFromSocket4:socket4FD];
+            else if (socket6FD != SOCKET_NULL)
+                result = [self localPortFromSocket6:socket6FD];
+        });
+        
+        return result;
+    }
 }
 
 - (NSString *)connectedHost4
 {
-	if (socket4FD != SOCKET_NULL)
-		return [self connectedHostFromSocket4:socket4FD];
-	
-	return nil;
+    if (socket4FD != SOCKET_NULL)
+        return [self connectedHostFromSocket4:socket4FD];
+    
+    return nil;
 }
 
 - (NSString *)connectedHost6
 {
-	if (socket6FD != SOCKET_NULL)
-		return [self connectedHostFromSocket6:socket6FD];
-	
-	return nil;
+    if (socket6FD != SOCKET_NULL)
+        return [self connectedHostFromSocket6:socket6FD];
+    
+    return nil;
 }
 
 - (uint16_t)connectedPort4
 {
-	if (socket4FD != SOCKET_NULL)
-		return [self connectedPortFromSocket4:socket4FD];
-	
-	return 0;
+    if (socket4FD != SOCKET_NULL)
+        return [self connectedPortFromSocket4:socket4FD];
+    
+    return 0;
 }
 
 - (uint16_t)connectedPort6
 {
-	if (socket6FD != SOCKET_NULL)
-		return [self connectedPortFromSocket6:socket6FD];
-	
-	return 0;
+    if (socket6FD != SOCKET_NULL)
+        return [self connectedPortFromSocket6:socket6FD];
+    
+    return 0;
 }
 
 - (NSString *)localHost4
 {
-	if (socket4FD != SOCKET_NULL)
-		return [self localHostFromSocket4:socket4FD];
-	
-	return nil;
+    if (socket4FD != SOCKET_NULL)
+        return [self localHostFromSocket4:socket4FD];
+    
+    return nil;
 }
 
 - (NSString *)localHost6
 {
-	if (socket6FD != SOCKET_NULL)
-		return [self localHostFromSocket6:socket6FD];
-	
-	return nil;
+    if (socket6FD != SOCKET_NULL)
+        return [self localHostFromSocket6:socket6FD];
+    
+    return nil;
 }
 
 - (uint16_t)localPort4
 {
-	if (socket4FD != SOCKET_NULL)
-		return [self localPortFromSocket4:socket4FD];
-	
-	return 0;
+    if (socket4FD != SOCKET_NULL)
+        return [self localPortFromSocket4:socket4FD];
+    
+    return 0;
 }
 
 - (uint16_t)localPort6
 {
-	if (socket6FD != SOCKET_NULL)
-		return [self localPortFromSocket6:socket6FD];
-	
-	return 0;
+    if (socket6FD != SOCKET_NULL)
+        return [self localPortFromSocket6:socket6FD];
+    
+    return 0;
 }
 
 - (NSString *)connectedHostFromSocket4:(int)socketFD
 {
-	struct sockaddr_in sockaddr4;
-	socklen_t sockaddr4len = sizeof(sockaddr4);
-	
-	if (getpeername(socketFD, (struct sockaddr *)&sockaddr4, &sockaddr4len) < 0)
-	{
-		return nil;
-	}
-	return [[self class] hostFromSockaddr4:&sockaddr4];
+    struct sockaddr_in sockaddr4;
+    socklen_t sockaddr4len = sizeof(sockaddr4);
+    
+    if (getpeername(socketFD, (struct sockaddr *)&sockaddr4, &sockaddr4len) < 0)
+    {
+        return nil;
+    }
+    return [[self class] hostFromSockaddr4:&sockaddr4];
 }
 
 - (NSString *)connectedHostFromSocket6:(int)socketFD
 {
-	struct sockaddr_in6 sockaddr6;
-	socklen_t sockaddr6len = sizeof(sockaddr6);
-	
-	if (getpeername(socketFD, (struct sockaddr *)&sockaddr6, &sockaddr6len) < 0)
-	{
-		return nil;
-	}
-	return [[self class] hostFromSockaddr6:&sockaddr6];
+    struct sockaddr_in6 sockaddr6;
+    socklen_t sockaddr6len = sizeof(sockaddr6);
+    
+    if (getpeername(socketFD, (struct sockaddr *)&sockaddr6, &sockaddr6len) < 0)
+    {
+        return nil;
+    }
+    return [[self class] hostFromSockaddr6:&sockaddr6];
 }
 
 - (uint16_t)connectedPortFromSocket4:(int)socketFD
 {
-	struct sockaddr_in sockaddr4;
-	socklen_t sockaddr4len = sizeof(sockaddr4);
-	
-	if (getpeername(socketFD, (struct sockaddr *)&sockaddr4, &sockaddr4len) < 0)
-	{
-		return 0;
-	}
-	return [[self class] portFromSockaddr4:&sockaddr4];
+    struct sockaddr_in sockaddr4;
+    socklen_t sockaddr4len = sizeof(sockaddr4);
+    
+    if (getpeername(socketFD, (struct sockaddr *)&sockaddr4, &sockaddr4len) < 0)
+    {
+        return 0;
+    }
+    return [[self class] portFromSockaddr4:&sockaddr4];
 }
 
 - (uint16_t)connectedPortFromSocket6:(int)socketFD
 {
-	struct sockaddr_in6 sockaddr6;
-	socklen_t sockaddr6len = sizeof(sockaddr6);
-	
-	if (getpeername(socketFD, (struct sockaddr *)&sockaddr6, &sockaddr6len) < 0)
-	{
-		return 0;
-	}
-	return [[self class] portFromSockaddr6:&sockaddr6];
+    struct sockaddr_in6 sockaddr6;
+    socklen_t sockaddr6len = sizeof(sockaddr6);
+    
+    if (getpeername(socketFD, (struct sockaddr *)&sockaddr6, &sockaddr6len) < 0)
+    {
+        return 0;
+    }
+    return [[self class] portFromSockaddr6:&sockaddr6];
 }
 
 - (NSString *)localHostFromSocket4:(int)socketFD
 {
-	struct sockaddr_in sockaddr4;
-	socklen_t sockaddr4len = sizeof(sockaddr4);
-	
-	if (getsockname(socketFD, (struct sockaddr *)&sockaddr4, &sockaddr4len) < 0)
-	{
-		return nil;
-	}
-	return [[self class] hostFromSockaddr4:&sockaddr4];
+    struct sockaddr_in sockaddr4;
+    socklen_t sockaddr4len = sizeof(sockaddr4);
+    
+    if (getsockname(socketFD, (struct sockaddr *)&sockaddr4, &sockaddr4len) < 0)
+    {
+        return nil;
+    }
+    return [[self class] hostFromSockaddr4:&sockaddr4];
 }
 
 - (NSString *)localHostFromSocket6:(int)socketFD
 {
-	struct sockaddr_in6 sockaddr6;
-	socklen_t sockaddr6len = sizeof(sockaddr6);
-	
-	if (getsockname(socketFD, (struct sockaddr *)&sockaddr6, &sockaddr6len) < 0)
-	{
-		return nil;
-	}
-	return [[self class] hostFromSockaddr6:&sockaddr6];
+    struct sockaddr_in6 sockaddr6;
+    socklen_t sockaddr6len = sizeof(sockaddr6);
+    
+    if (getsockname(socketFD, (struct sockaddr *)&sockaddr6, &sockaddr6len) < 0)
+    {
+        return nil;
+    }
+    return [[self class] hostFromSockaddr6:&sockaddr6];
 }
 
 - (uint16_t)localPortFromSocket4:(int)socketFD
 {
-	struct sockaddr_in sockaddr4;
-	socklen_t sockaddr4len = sizeof(sockaddr4);
-	
-	if (getsockname(socketFD, (struct sockaddr *)&sockaddr4, &sockaddr4len) < 0)
-	{
-		return 0;
-	}
-	return [[self class] portFromSockaddr4:&sockaddr4];
+    struct sockaddr_in sockaddr4;
+    socklen_t sockaddr4len = sizeof(sockaddr4);
+    
+    if (getsockname(socketFD, (struct sockaddr *)&sockaddr4, &sockaddr4len) < 0)
+    {
+        return 0;
+    }
+    return [[self class] portFromSockaddr4:&sockaddr4];
 }
 
 - (uint16_t)localPortFromSocket6:(int)socketFD
 {
-	struct sockaddr_in6 sockaddr6;
-	socklen_t sockaddr6len = sizeof(sockaddr6);
-	
-	if (getsockname(socketFD, (struct sockaddr *)&sockaddr6, &sockaddr6len) < 0)
-	{
-		return 0;
-	}
-	return [[self class] portFromSockaddr6:&sockaddr6];
+    struct sockaddr_in6 sockaddr6;
+    socklen_t sockaddr6len = sizeof(sockaddr6);
+    
+    if (getsockname(socketFD, (struct sockaddr *)&sockaddr6, &sockaddr6len) < 0)
+    {
+        return 0;
+    }
+    return [[self class] portFromSockaddr6:&sockaddr6];
 }
 
 - (NSData *)connectedAddress
 {
-	__block NSData *result = nil;
-	
-	dispatch_block_t block = ^{
-		if (socket4FD != SOCKET_NULL)
-		{
-			struct sockaddr_in sockaddr4;
-			socklen_t sockaddr4len = sizeof(sockaddr4);
-			
-			if (getpeername(socket4FD, (struct sockaddr *)&sockaddr4, &sockaddr4len) == 0)
-			{
-				result = [[NSData alloc] initWithBytes:&sockaddr4 length:sockaddr4len];
-			}
-		}
-		
-		if (socket6FD != SOCKET_NULL)
-		{
-			struct sockaddr_in6 sockaddr6;
-			socklen_t sockaddr6len = sizeof(sockaddr6);
-			
-			if (getpeername(socket6FD, (struct sockaddr *)&sockaddr6, &sockaddr6len) == 0)
-			{
-				result = [[NSData alloc] initWithBytes:&sockaddr6 length:sockaddr6len];
-			}
-		}
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	return result;
+    __block NSData *result = nil;
+    
+    dispatch_block_t block = ^{
+        if (socket4FD != SOCKET_NULL)
+        {
+            struct sockaddr_in sockaddr4;
+            socklen_t sockaddr4len = sizeof(sockaddr4);
+            
+            if (getpeername(socket4FD, (struct sockaddr *)&sockaddr4, &sockaddr4len) == 0)
+            {
+                result = [[NSData alloc] initWithBytes:&sockaddr4 length:sockaddr4len];
+            }
+        }
+        
+        if (socket6FD != SOCKET_NULL)
+        {
+            struct sockaddr_in6 sockaddr6;
+            socklen_t sockaddr6len = sizeof(sockaddr6);
+            
+            if (getpeername(socket6FD, (struct sockaddr *)&sockaddr6, &sockaddr6len) == 0)
+            {
+                result = [[NSData alloc] initWithBytes:&sockaddr6 length:sockaddr6len];
+            }
+        }
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    return result;
 }
 
 - (NSData *)localAddress
 {
-	__block NSData *result = nil;
-	
-	dispatch_block_t block = ^{
-		if (socket4FD != SOCKET_NULL)
-		{
-			struct sockaddr_in sockaddr4;
-			socklen_t sockaddr4len = sizeof(sockaddr4);
-			
-			if (getsockname(socket4FD, (struct sockaddr *)&sockaddr4, &sockaddr4len) == 0)
-			{
-				result = [[NSData alloc] initWithBytes:&sockaddr4 length:sockaddr4len];
-			}
-		}
-		
-		if (socket6FD != SOCKET_NULL)
-		{
-			struct sockaddr_in6 sockaddr6;
-			socklen_t sockaddr6len = sizeof(sockaddr6);
-			
-			if (getsockname(socket6FD, (struct sockaddr *)&sockaddr6, &sockaddr6len) == 0)
-			{
-				result = [[NSData alloc] initWithBytes:&sockaddr6 length:sockaddr6len];
-			}
-		}
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	return result;
+    __block NSData *result = nil;
+    
+    dispatch_block_t block = ^{
+        if (socket4FD != SOCKET_NULL)
+        {
+            struct sockaddr_in sockaddr4;
+            socklen_t sockaddr4len = sizeof(sockaddr4);
+            
+            if (getsockname(socket4FD, (struct sockaddr *)&sockaddr4, &sockaddr4len) == 0)
+            {
+                result = [[NSData alloc] initWithBytes:&sockaddr4 length:sockaddr4len];
+            }
+        }
+        
+        if (socket6FD != SOCKET_NULL)
+        {
+            struct sockaddr_in6 sockaddr6;
+            socklen_t sockaddr6len = sizeof(sockaddr6);
+            
+            if (getsockname(socket6FD, (struct sockaddr *)&sockaddr6, &sockaddr6len) == 0)
+            {
+                result = [[NSData alloc] initWithBytes:&sockaddr6 length:sockaddr6len];
+            }
+        }
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    return result;
 }
 
 - (BOOL)isIPv4
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return (socket4FD != SOCKET_NULL);
-	}
-	else
-	{
-		__block BOOL result = NO;
-		
-		dispatch_sync(socketQueue, ^{
-			result = (socket4FD != SOCKET_NULL);
-		});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return (socket4FD != SOCKET_NULL);
+    }
+    else
+    {
+        __block BOOL result = NO;
+        
+        dispatch_sync(socketQueue, ^{
+            result = (socket4FD != SOCKET_NULL);
+        });
+        
+        return result;
+    }
 }
 
 - (BOOL)isIPv6
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return (socket6FD != SOCKET_NULL);
-	}
-	else
-	{
-		__block BOOL result = NO;
-		
-		dispatch_sync(socketQueue, ^{
-			result = (socket6FD != SOCKET_NULL);
-		});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return (socket6FD != SOCKET_NULL);
+    }
+    else
+    {
+        __block BOOL result = NO;
+        
+        dispatch_sync(socketQueue, ^{
+            result = (socket6FD != SOCKET_NULL);
+        });
+        
+        return result;
+    }
 }
 
 - (BOOL)isSecure
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return (flags & kSocketSecure) ? YES : NO;
-	}
-	else
-	{
-		__block BOOL result;
-		
-		dispatch_sync(socketQueue, ^{
-			result = (flags & kSocketSecure) ? YES : NO;
-		});
-		
-		return result;
-	}
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return (flags & kSocketSecure) ? YES : NO;
+    }
+    else
+    {
+        __block BOOL result;
+        
+        dispatch_sync(socketQueue, ^{
+            result = (flags & kSocketSecure) ? YES : NO;
+        });
+        
+        return result;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3339,351 +3341,355 @@ enum GCDAsyncSocketConfig
 /**
  * Finds the address of an interface description.
  * An inteface description may be an interface name (en0, en1, lo0) or corresponding IP (192.168.4.34).
- * 
+ *
  * The interface description may optionally contain a port number at the end, separated by a colon.
  * If a non-zero port parameter is provided, any port number in the interface description is ignored.
- * 
+ *
  * The returned value is a 'struct sockaddr' wrapped in an NSMutableData object.
-**/
+ **/
 - (void)getInterfaceAddress4:(NSMutableData **)interfaceAddr4Ptr
                     address6:(NSMutableData **)interfaceAddr6Ptr
              fromDescription:(NSString *)interfaceDescription
                         port:(uint16_t)port
 {
-	NSMutableData *addr4 = nil;
-	NSMutableData *addr6 = nil;
-	
-	NSString *interface = nil;
-	
-	NSArray *components = [interfaceDescription componentsSeparatedByString:@":"];
-	if ([components count] > 0)
-	{
-		NSString *temp = [components objectAtIndex:0];
-		if ([temp length] > 0)
-		{
-			interface = temp;
-		}
-	}
-	if ([components count] > 1 && port == 0)
-	{
-		long portL = strtol([[components objectAtIndex:1] UTF8String], NULL, 10);
-		
-		if (portL > 0 && portL <= UINT16_MAX)
-		{
-			port = (uint16_t)portL;
-		}
-	}
-	
-	if (interface == nil)
-	{
-		// ANY address
-		
-		struct sockaddr_in sockaddr4;
-		memset(&sockaddr4, 0, sizeof(sockaddr4));
-		
-		sockaddr4.sin_len         = sizeof(sockaddr4);
-		sockaddr4.sin_family      = AF_INET;
-		sockaddr4.sin_port        = htons(port);
-		sockaddr4.sin_addr.s_addr = htonl(INADDR_ANY);
-		
-		struct sockaddr_in6 sockaddr6;
-		memset(&sockaddr6, 0, sizeof(sockaddr6));
-		
-		sockaddr6.sin6_len       = sizeof(sockaddr6);
-		sockaddr6.sin6_family    = AF_INET6;
-		sockaddr6.sin6_port      = htons(port);
-		sockaddr6.sin6_addr      = in6addr_any;
-		
-		addr4 = [NSMutableData dataWithBytes:&sockaddr4 length:sizeof(sockaddr4)];
-		addr6 = [NSMutableData dataWithBytes:&sockaddr6 length:sizeof(sockaddr6)];
-	}
-	else if ([interface isEqualToString:@"localhost"] || [interface isEqualToString:@"loopback"])
-	{
-		// LOOPBACK address
-		
-		struct sockaddr_in sockaddr4;
-		memset(&sockaddr4, 0, sizeof(sockaddr4));
-		
-		sockaddr4.sin_len         = sizeof(sockaddr4);
-		sockaddr4.sin_family      = AF_INET;
-		sockaddr4.sin_port        = htons(port);
-		sockaddr4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-		
-		struct sockaddr_in6 sockaddr6;
-		memset(&sockaddr6, 0, sizeof(sockaddr6));
-		
-		sockaddr6.sin6_len       = sizeof(sockaddr6);
-		sockaddr6.sin6_family    = AF_INET6;
-		sockaddr6.sin6_port      = htons(port);
-		sockaddr6.sin6_addr      = in6addr_loopback;
-		
-		addr4 = [NSMutableData dataWithBytes:&sockaddr4 length:sizeof(sockaddr4)];
-		addr6 = [NSMutableData dataWithBytes:&sockaddr6 length:sizeof(sockaddr6)];
-	}
-	else
-	{
-		const char *iface = [interface UTF8String];
-		
-		struct ifaddrs *addrs;
-		const struct ifaddrs *cursor;
-		
-		if ((getifaddrs(&addrs) == 0))
-		{
-			cursor = addrs;
-			while (cursor != NULL)
-			{
-				if ((addr4 == nil) && (cursor->ifa_addr->sa_family == AF_INET))
-				{
-					// IPv4
-					
-					struct sockaddr_in nativeAddr4;
-					memcpy(&nativeAddr4, cursor->ifa_addr, sizeof(nativeAddr4));
-					
-					if (strcmp(cursor->ifa_name, iface) == 0)
-					{
-						// Name match
-						
-						nativeAddr4.sin_port = htons(port);
-						
-						addr4 = [NSMutableData dataWithBytes:&nativeAddr4 length:sizeof(nativeAddr4)];
-					}
-					else
-					{
-						char ip[INET_ADDRSTRLEN];
-						
-						const char *conversion = inet_ntop(AF_INET, &nativeAddr4.sin_addr, ip, sizeof(ip));
-						
-						if ((conversion != NULL) && (strcmp(ip, iface) == 0))
-						{
-							// IP match
-							
-							nativeAddr4.sin_port = htons(port);
-							
-							addr4 = [NSMutableData dataWithBytes:&nativeAddr4 length:sizeof(nativeAddr4)];
-						}
-					}
-				}
-				else if ((addr6 == nil) && (cursor->ifa_addr->sa_family == AF_INET6))
-				{
-					// IPv6
-					
-					struct sockaddr_in6 nativeAddr6;
-					memcpy(&nativeAddr6, cursor->ifa_addr, sizeof(nativeAddr6));
-					
-					if (strcmp(cursor->ifa_name, iface) == 0)
-					{
-						// Name match
-						
-						nativeAddr6.sin6_port = htons(port);
-						
-						addr6 = [NSMutableData dataWithBytes:&nativeAddr6 length:sizeof(nativeAddr6)];
-					}
-					else
-					{
-						char ip[INET6_ADDRSTRLEN];
-						
-						const char *conversion = inet_ntop(AF_INET6, &nativeAddr6.sin6_addr, ip, sizeof(ip));
-						
-						if ((conversion != NULL) && (strcmp(ip, iface) == 0))
-						{
-							// IP match
-							
-							nativeAddr6.sin6_port = htons(port);
-							
-							addr6 = [NSMutableData dataWithBytes:&nativeAddr6 length:sizeof(nativeAddr6)];
-						}
-					}
-				}
-				
-				cursor = cursor->ifa_next;
-			}
-			
-			freeifaddrs(addrs);
-		}
-	}
-	
-	if (interfaceAddr4Ptr) *interfaceAddr4Ptr = addr4;
-	if (interfaceAddr6Ptr) *interfaceAddr6Ptr = addr6;
+    NSMutableData *addr4 = nil;
+    NSMutableData *addr6 = nil;
+    
+    NSString *interface = nil;
+    
+    NSArray *components = [interfaceDescription componentsSeparatedByString:@":"];
+    if ([components count] > 0)
+    {
+        NSString *temp = [components objectAtIndex:0];
+        if ([temp length] > 0)
+        {
+            interface = temp;
+        }
+    }
+    if ([components count] > 1 && port == 0)
+    {
+        long portL = strtol([[components objectAtIndex:1] UTF8String], NULL, 10);
+        
+        if (portL > 0 && portL <= UINT16_MAX)
+        {
+            port = (uint16_t)portL;
+        }
+    }
+    
+    if (interface == nil)
+    {
+        // ANY address
+        
+        struct sockaddr_in sockaddr4;
+        memset(&sockaddr4, 0, sizeof(sockaddr4));
+        
+        sockaddr4.sin_len         = sizeof(sockaddr4);
+        sockaddr4.sin_family      = AF_INET;
+        sockaddr4.sin_port        = htons(port);
+        sockaddr4.sin_addr.s_addr = htonl(INADDR_ANY);
+        
+        struct sockaddr_in6 sockaddr6;
+        memset(&sockaddr6, 0, sizeof(sockaddr6));
+        
+        sockaddr6.sin6_len       = sizeof(sockaddr6);
+        sockaddr6.sin6_family    = AF_INET6;
+        sockaddr6.sin6_port      = htons(port);
+        sockaddr6.sin6_addr      = in6addr_any;
+        
+        addr4 = [NSMutableData dataWithBytes:&sockaddr4 length:sizeof(sockaddr4)];
+        addr6 = [NSMutableData dataWithBytes:&sockaddr6 length:sizeof(sockaddr6)];
+    }
+    else if ([interface isEqualToString:@"localhost"] || [interface isEqualToString:@"loopback"])
+    {
+        // LOOPBACK address
+        
+        struct sockaddr_in sockaddr4;
+        memset(&sockaddr4, 0, sizeof(sockaddr4));
+        
+        sockaddr4.sin_len         = sizeof(sockaddr4);
+        sockaddr4.sin_family      = AF_INET;
+        sockaddr4.sin_port        = htons(port);
+        sockaddr4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        
+        struct sockaddr_in6 sockaddr6;
+        memset(&sockaddr6, 0, sizeof(sockaddr6));
+        
+        sockaddr6.sin6_len       = sizeof(sockaddr6);
+        sockaddr6.sin6_family    = AF_INET6;
+        sockaddr6.sin6_port      = htons(port);
+        sockaddr6.sin6_addr      = in6addr_loopback;
+        
+        addr4 = [NSMutableData dataWithBytes:&sockaddr4 length:sizeof(sockaddr4)];
+        addr6 = [NSMutableData dataWithBytes:&sockaddr6 length:sizeof(sockaddr6)];
+    }
+    else
+    {
+        const char *iface = [interface UTF8String];
+        
+        struct ifaddrs *addrs;
+        const struct ifaddrs *cursor;
+        
+        if ((getifaddrs(&addrs) == 0))
+        {
+            cursor = addrs;
+            while (cursor != NULL)
+            {
+                if ((addr4 == nil) && (cursor->ifa_addr->sa_family == AF_INET))
+                {
+                    // IPv4
+                    
+                    struct sockaddr_in nativeAddr4;
+                    memcpy(&nativeAddr4, cursor->ifa_addr, sizeof(nativeAddr4));
+                    
+                    if (strcmp(cursor->ifa_name, iface) == 0)
+                    {
+                        // Name match
+                        
+                        nativeAddr4.sin_port = htons(port);
+                        
+                        addr4 = [NSMutableData dataWithBytes:&nativeAddr4 length:sizeof(nativeAddr4)];
+                    }
+                    else
+                    {
+                        char ip[INET_ADDRSTRLEN];
+                        
+                        const char *conversion = inet_ntop(AF_INET, &nativeAddr4.sin_addr, ip, sizeof(ip));
+                        
+                        if ((conversion != NULL) && (strcmp(ip, iface) == 0))
+                        {
+                            // IP match
+                            
+                            nativeAddr4.sin_port = htons(port);
+                            
+                            addr4 = [NSMutableData dataWithBytes:&nativeAddr4 length:sizeof(nativeAddr4)];
+                        }
+                    }
+                }
+                else if ((addr6 == nil) && (cursor->ifa_addr->sa_family == AF_INET6))
+                {
+                    // IPv6
+                    
+                    struct sockaddr_in6 nativeAddr6;
+                    memcpy(&nativeAddr6, cursor->ifa_addr, sizeof(nativeAddr6));
+                    
+                    if (strcmp(cursor->ifa_name, iface) == 0)
+                    {
+                        // Name match
+                        
+                        nativeAddr6.sin6_port = htons(port);
+                        
+                        addr6 = [NSMutableData dataWithBytes:&nativeAddr6 length:sizeof(nativeAddr6)];
+                    }
+                    else
+                    {
+                        char ip[INET6_ADDRSTRLEN];
+                        
+                        const char *conversion = inet_ntop(AF_INET6, &nativeAddr6.sin6_addr, ip, sizeof(ip));
+                        
+                        if ((conversion != NULL) && (strcmp(ip, iface) == 0))
+                        {
+                            // IP match
+                            
+                            nativeAddr6.sin6_port = htons(port);
+                            
+                            addr6 = [NSMutableData dataWithBytes:&nativeAddr6 length:sizeof(nativeAddr6)];
+                        }
+                    }
+                }
+                
+                cursor = cursor->ifa_next;
+            }
+            
+            freeifaddrs(addrs);
+        }
+    }
+    
+    if (interfaceAddr4Ptr) *interfaceAddr4Ptr = addr4;
+    if (interfaceAddr6Ptr) *interfaceAddr6Ptr = addr6;
 }
 
 - (void)setupReadAndWriteSourcesForNewlyConnectedSocket:(int)socketFD
 {
-	readSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, socketFD, 0, socketQueue);
-	writeSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_WRITE, socketFD, 0, socketQueue);
-	
-	// Setup event handlers
-	
-	__weak GCDAsyncSocket *weakSelf = self;
-	
-	dispatch_source_set_event_handler(readSource, ^{ @autoreleasepool {
-	#pragma clang diagnostic push
-	#pragma clang diagnostic warning "-Wimplicit-retain-self"
-		
-		__strong GCDAsyncSocket *strongSelf = weakSelf;
-		if (strongSelf == nil) return_from_block;
-		
-		LogVerbose(@"readEventBlock");
-		
-		strongSelf->socketFDBytesAvailable = dispatch_source_get_data(strongSelf->readSource);
-		LogVerbose(@"socketFDBytesAvailable: %lu", strongSelf->socketFDBytesAvailable);
-		
-		if (strongSelf->socketFDBytesAvailable > 0)
-			[strongSelf doReadData];
-		else
-			[strongSelf doReadEOF];
-		
-	#pragma clang diagnostic pop
-	}});
-	
-	dispatch_source_set_event_handler(writeSource, ^{ @autoreleasepool {
-	#pragma clang diagnostic push
-	#pragma clang diagnostic warning "-Wimplicit-retain-self"
-		
-		__strong GCDAsyncSocket *strongSelf = weakSelf;
-		if (strongSelf == nil) return_from_block;
-		
-		LogVerbose(@"writeEventBlock");
-		
-		strongSelf->flags |= kSocketCanAcceptBytes;
-		[strongSelf doWriteData];
-		
-	#pragma clang diagnostic pop
-	}});
-	
-	// Setup cancel handlers
-	
-	__block int socketFDRefCount = 2;
-	
-	#if !OS_OBJECT_USE_OBJC
-	dispatch_source_t theReadSource = readSource;
-	dispatch_source_t theWriteSource = writeSource;
-	#endif
-	
-	dispatch_source_set_cancel_handler(readSource, ^{
-	#pragma clang diagnostic push
-	#pragma clang diagnostic warning "-Wimplicit-retain-self"
-		
-		LogVerbose(@"readCancelBlock");
-		
-		#if !OS_OBJECT_USE_OBJC
-		LogVerbose(@"dispatch_release(readSource)");
-		dispatch_release(theReadSource);
-		#endif
-		
-		if (--socketFDRefCount == 0)
-		{
-			LogVerbose(@"close(socketFD)");
-			close(socketFD);
-		}
-		
-	#pragma clang diagnostic pop
-	});
-	
-	dispatch_source_set_cancel_handler(writeSource, ^{
-	#pragma clang diagnostic push
-	#pragma clang diagnostic warning "-Wimplicit-retain-self"
-		
-		LogVerbose(@"writeCancelBlock");
-		
-		#if !OS_OBJECT_USE_OBJC
-		LogVerbose(@"dispatch_release(writeSource)");
-		dispatch_release(theWriteSource);
-		#endif
-		
-		if (--socketFDRefCount == 0)
-		{
-			LogVerbose(@"close(socketFD)");
-			close(socketFD);
-		}
-		
-	#pragma clang diagnostic pop
-	});
-	
-	// We will not be able to read until data arrives.
-	// But we should be able to write immediately.
-	
-	socketFDBytesAvailable = 0;
-	flags &= ~kReadSourceSuspended;
-	
-	LogVerbose(@"dispatch_resume(readSource)");
-	dispatch_resume(readSource);
-	
-	flags |= kSocketCanAcceptBytes;
-	flags |= kWriteSourceSuspended;
+    readSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, socketFD, 0, socketQueue);
+    writeSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_WRITE, socketFD, 0, socketQueue);
+    
+    // Setup event handlers
+    
+    __weak GCDAsyncSocket *weakSelf = self;
+    
+    dispatch_source_set_event_handler(readSource, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+        
+        __strong GCDAsyncSocket *strongSelf = weakSelf;
+        if (strongSelf == nil) return_from_block;
+        
+        LogVerbose(@"readEventBlock");
+        
+        strongSelf->socketFDBytesAvailable = dispatch_source_get_data(strongSelf->readSource);
+        LogVerbose(@"socketFDBytesAvailable: %lu", strongSelf->socketFDBytesAvailable);
+        
+        if (strongSelf->socketFDBytesAvailable > 0)
+            [strongSelf doReadData];
+        else
+            [strongSelf doReadEOF];
+        
+#pragma clang diagnostic pop
+    }});
+    
+    dispatch_source_set_event_handler(writeSource, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+        
+        __strong GCDAsyncSocket *strongSelf = weakSelf;
+        if (strongSelf == nil) return_from_block;
+        
+        LogVerbose(@"writeEventBlock");
+        
+        strongSelf->flags |= kSocketCanAcceptBytes;
+        [strongSelf doWriteData];
+        
+#pragma clang diagnostic pop
+    }});
+    
+    // Setup cancel handlers
+    
+    __block int socketFDRefCount = 2;
+    
+#if !OS_OBJECT_USE_OBJC
+    dispatch_source_t theReadSource = readSource;
+    dispatch_source_t theWriteSource = writeSource;
+#endif
+    
+    dispatch_source_set_cancel_handler(readSource, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+        
+        LogVerbose(@"readCancelBlock");
+        
+#if !OS_OBJECT_USE_OBJC
+        LogVerbose(@"dispatch_release(readSource)");
+        dispatch_release(theReadSource);
+#endif
+        
+        if (--socketFDRefCount == 0)
+        {
+            LogVerbose(@"close(socketFD)");
+            close(socketFD);
+        }
+        
+#pragma clang diagnostic pop
+    });
+    
+    dispatch_source_set_cancel_handler(writeSource, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+        
+        LogVerbose(@"writeCancelBlock");
+        
+#if !OS_OBJECT_USE_OBJC
+        LogVerbose(@"dispatch_release(writeSource)");
+        dispatch_release(theWriteSource);
+#endif
+        
+        if (--socketFDRefCount == 0)
+        {
+            LogVerbose(@"close(socketFD)");
+            close(socketFD);
+        }
+        
+#pragma clang diagnostic pop
+    });
+    
+    // We will not be able to read until data arrives.
+    // But we should be able to write immediately.
+    
+    socketFDBytesAvailable = 0;
+    flags &= ~kReadSourceSuspended;
+    
+    LogVerbose(@"dispatch_resume(readSource)");
+    dispatch_resume(readSource);
+    
+    flags |= kSocketCanAcceptBytes;
+    flags |= kWriteSourceSuspended;
 }
 
 - (BOOL)usingCFStreamForTLS
 {
-	#if TARGET_OS_IPHONE
-	{	
-		if ((flags & kSocketSecure) && (flags & kUsingCFStreamForTLS))
-		{
-			// Due to the fact that Apple doesn't give us the full power of SecureTransport on iOS,
-			// we are relegated to using the slower, less powerful, and RunLoop based CFStream API. :( Boo!
-			// 
-			// Thus we're not able to use the GCD read/write sources in this particular scenario.
-			
-			return YES;
-		}
-	}
-	#endif
-	
-	return NO;
+#if TARGET_OS_IPHONE
+    
+    if ((flags & kSocketSecure) && (flags & kUsingCFStreamForTLS))
+    {
+        // The startTLS method was given the GCDAsyncSocketUseCFStreamForTLS flag.
+        
+        return YES;
+    }
+    
+#endif
+    
+    return NO;
 }
 
 - (BOOL)usingSecureTransportForTLS
 {
-	#if TARGET_OS_IPHONE
-	{
-		return ![self usingCFStreamForTLS];
-	}
-	#endif
-	
-	return YES;
+    // Invoking this method is equivalent to ![self usingCFStreamForTLS] (just more readable)
+    
+#if TARGET_OS_IPHONE
+    
+    if ((flags & kSocketSecure) && (flags & kUsingCFStreamForTLS))
+    {
+        // The startTLS method was given the GCDAsyncSocketUseCFStreamForTLS flag.
+        
+        return NO;
+    }
+    
+#endif
+    
+    return YES;
 }
 
 - (void)suspendReadSource
 {
-	if (!(flags & kReadSourceSuspended))
-	{
-		LogVerbose(@"dispatch_suspend(readSource)");
-		
-		dispatch_suspend(readSource);
-		flags |= kReadSourceSuspended;
-	}
+    if (!(flags & kReadSourceSuspended))
+    {
+        LogVerbose(@"dispatch_suspend(readSource)");
+        
+        dispatch_suspend(readSource);
+        flags |= kReadSourceSuspended;
+    }
 }
 
 - (void)resumeReadSource
 {
-	if (flags & kReadSourceSuspended)
-	{
-		LogVerbose(@"dispatch_resume(readSource)");
-		
-		dispatch_resume(readSource);
-		flags &= ~kReadSourceSuspended;
-	}
+    if (flags & kReadSourceSuspended)
+    {
+        LogVerbose(@"dispatch_resume(readSource)");
+        
+        dispatch_resume(readSource);
+        flags &= ~kReadSourceSuspended;
+    }
 }
 
 - (void)suspendWriteSource
 {
-	if (!(flags & kWriteSourceSuspended))
-	{
-		LogVerbose(@"dispatch_suspend(writeSource)");
-		
-		dispatch_suspend(writeSource);
-		flags |= kWriteSourceSuspended;
-	}
+    if (!(flags & kWriteSourceSuspended))
+    {
+        LogVerbose(@"dispatch_suspend(writeSource)");
+        
+        dispatch_suspend(writeSource);
+        flags |= kWriteSourceSuspended;
+    }
 }
 
 - (void)resumeWriteSource
 {
-	if (flags & kWriteSourceSuspended)
-	{
-		LogVerbose(@"dispatch_resume(writeSource)");
-		
-		dispatch_resume(writeSource);
-		flags &= ~kWriteSourceSuspended;
-	}
+    if (flags & kWriteSourceSuspended)
+    {
+        LogVerbose(@"dispatch_resume(writeSource)");
+        
+        dispatch_resume(writeSource);
+        flags &= ~kWriteSourceSuspended;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3692,7 +3698,7 @@ enum GCDAsyncSocketConfig
 
 - (void)readDataWithTimeout:(NSTimeInterval)timeout tag:(long)tag
 {
-	[self readDataWithTimeout:timeout buffer:nil bufferOffset:0 maxLength:0 tag:tag];
+    [self readDataWithTimeout:timeout buffer:nil bufferOffset:0 maxLength:0 tag:tag];
 }
 
 - (void)readDataWithTimeout:(NSTimeInterval)timeout
@@ -3700,7 +3706,7 @@ enum GCDAsyncSocketConfig
                bufferOffset:(NSUInteger)offset
                         tag:(long)tag
 {
-	[self readDataWithTimeout:timeout buffer:buffer bufferOffset:offset maxLength:0 tag:tag];
+    [self readDataWithTimeout:timeout buffer:buffer bufferOffset:offset maxLength:0 tag:tag];
 }
 
 - (void)readDataWithTimeout:(NSTimeInterval)timeout
@@ -3709,37 +3715,37 @@ enum GCDAsyncSocketConfig
                   maxLength:(NSUInteger)length
                         tag:(long)tag
 {
-	if (offset > [buffer length]) {
-		LogWarn(@"Cannot read: offset > [buffer length]");
-		return;
-	}
-	
-	GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
-	                                                          startOffset:offset
-	                                                            maxLength:length
-	                                                              timeout:timeout
-	                                                           readLength:0
-	                                                           terminator:nil
-	                                                                  tag:tag];
-	
-	dispatch_async(socketQueue, ^{ @autoreleasepool {
-		
-		LogTrace();
-		
-		if ((flags & kSocketStarted) && !(flags & kForbidReadsWrites))
-		{
-			[readQueue addObject:packet];
-			[self maybeDequeueRead];
-		}
-	}});
-	
-	// Do not rely on the block being run in order to release the packet,
-	// as the queue might get released without the block completing.
+    if (offset > [buffer length]) {
+        LogWarn(@"Cannot read: offset > [buffer length]");
+        return;
+    }
+    
+    GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
+                                                              startOffset:offset
+                                                                maxLength:length
+                                                                  timeout:timeout
+                                                               readLength:0
+                                                               terminator:nil
+                                                                      tag:tag];
+    
+    dispatch_async(socketQueue, ^{ @autoreleasepool {
+        
+        LogTrace();
+        
+        if ((flags & kSocketStarted) && !(flags & kForbidReadsWrites))
+        {
+            [readQueue addObject:packet];
+            [self maybeDequeueRead];
+        }
+    }});
+    
+    // Do not rely on the block being run in order to release the packet,
+    // as the queue might get released without the block completing.
 }
 
 - (void)readDataToLength:(NSUInteger)length withTimeout:(NSTimeInterval)timeout tag:(long)tag
 {
-	[self readDataToLength:length withTimeout:timeout buffer:nil bufferOffset:0 tag:tag];
+    [self readDataToLength:length withTimeout:timeout buffer:nil bufferOffset:0 tag:tag];
 }
 
 - (void)readDataToLength:(NSUInteger)length
@@ -3748,41 +3754,41 @@ enum GCDAsyncSocketConfig
             bufferOffset:(NSUInteger)offset
                      tag:(long)tag
 {
-	if (length == 0) {
-		LogWarn(@"Cannot read: length == 0");
-		return;
-	}
-	if (offset > [buffer length]) {
-		LogWarn(@"Cannot read: offset > [buffer length]");
-		return;
-	}
-	
-	GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
-	                                                          startOffset:offset
-	                                                            maxLength:0
-	                                                              timeout:timeout
-	                                                           readLength:length
-	                                                           terminator:nil
-	                                                                  tag:tag];
-	
-	dispatch_async(socketQueue, ^{ @autoreleasepool {
-		
-		LogTrace();
-		
-		if ((flags & kSocketStarted) && !(flags & kForbidReadsWrites))
-		{
-			[readQueue addObject:packet];
-			[self maybeDequeueRead];
-		}
-	}});
-	
-	// Do not rely on the block being run in order to release the packet,
-	// as the queue might get released without the block completing.
+    if (length == 0) {
+        LogWarn(@"Cannot read: length == 0");
+        return;
+    }
+    if (offset > [buffer length]) {
+        LogWarn(@"Cannot read: offset > [buffer length]");
+        return;
+    }
+    
+    GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
+                                                              startOffset:offset
+                                                                maxLength:0
+                                                                  timeout:timeout
+                                                               readLength:length
+                                                               terminator:nil
+                                                                      tag:tag];
+    
+    dispatch_async(socketQueue, ^{ @autoreleasepool {
+        
+        LogTrace();
+        
+        if ((flags & kSocketStarted) && !(flags & kForbidReadsWrites))
+        {
+            [readQueue addObject:packet];
+            [self maybeDequeueRead];
+        }
+    }});
+    
+    // Do not rely on the block being run in order to release the packet,
+    // as the queue might get released without the block completing.
 }
 
 - (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag
 {
-	[self readDataToData:data withTimeout:timeout buffer:nil bufferOffset:0 maxLength:0 tag:tag];
+    [self readDataToData:data withTimeout:timeout buffer:nil bufferOffset:0 maxLength:0 tag:tag];
 }
 
 - (void)readDataToData:(NSData *)data
@@ -3791,12 +3797,12 @@ enum GCDAsyncSocketConfig
           bufferOffset:(NSUInteger)offset
                    tag:(long)tag
 {
-	[self readDataToData:data withTimeout:timeout buffer:buffer bufferOffset:offset maxLength:0 tag:tag];
+    [self readDataToData:data withTimeout:timeout buffer:buffer bufferOffset:offset maxLength:0 tag:tag];
 }
 
 - (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout maxLength:(NSUInteger)length tag:(long)tag
 {
-	[self readDataToData:data withTimeout:timeout buffer:nil bufferOffset:0 maxLength:length tag:tag];
+    [self readDataToData:data withTimeout:timeout buffer:nil bufferOffset:0 maxLength:length tag:tag];
 }
 
 - (void)readDataToData:(NSData *)data
@@ -3806,1289 +3812,1325 @@ enum GCDAsyncSocketConfig
              maxLength:(NSUInteger)maxLength
                    tag:(long)tag
 {
-	if ([data length] == 0) {
-		LogWarn(@"Cannot read: [data length] == 0");
-		return;
-	}
-	if (offset > [buffer length]) {
-		LogWarn(@"Cannot read: offset > [buffer length]");
-		return;
-	}
-	if (maxLength > 0 && maxLength < [data length]) {
-		LogWarn(@"Cannot read: maxLength > 0 && maxLength < [data length]");
-		return;
-	}
-	
-	GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
-	                                                          startOffset:offset
-	                                                            maxLength:maxLength
-	                                                              timeout:timeout
-	                                                           readLength:0
-	                                                           terminator:data
-	                                                                  tag:tag];
-	
-	dispatch_async(socketQueue, ^{ @autoreleasepool {
-		
-		LogTrace();
-		
-		if ((flags & kSocketStarted) && !(flags & kForbidReadsWrites))
-		{
-			[readQueue addObject:packet];
-			[self maybeDequeueRead];
-		}
-	}});
-	
-	// Do not rely on the block being run in order to release the packet,
-	// as the queue might get released without the block completing.
+    if ([data length] == 0) {
+        LogWarn(@"Cannot read: [data length] == 0");
+        return;
+    }
+    if (offset > [buffer length]) {
+        LogWarn(@"Cannot read: offset > [buffer length]");
+        return;
+    }
+    if (maxLength > 0 && maxLength < [data length]) {
+        LogWarn(@"Cannot read: maxLength > 0 && maxLength < [data length]");
+        return;
+    }
+    
+    GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
+                                                              startOffset:offset
+                                                                maxLength:maxLength
+                                                                  timeout:timeout
+                                                               readLength:0
+                                                               terminator:data
+                                                                      tag:tag];
+    
+    dispatch_async(socketQueue, ^{ @autoreleasepool {
+        
+        LogTrace();
+        
+        if ((flags & kSocketStarted) && !(flags & kForbidReadsWrites))
+        {
+            [readQueue addObject:packet];
+            [self maybeDequeueRead];
+        }
+    }});
+    
+    // Do not rely on the block being run in order to release the packet,
+    // as the queue might get released without the block completing.
 }
 
 - (float)progressOfReadReturningTag:(long *)tagPtr bytesDone:(NSUInteger *)donePtr total:(NSUInteger *)totalPtr
 {
-	__block float result = 0.0F;
-	
-	dispatch_block_t block = ^{
-		
-		if (!currentRead || ![currentRead isKindOfClass:[GCDAsyncReadPacket class]])
-		{
-			// We're not reading anything right now.
-			
-			if (tagPtr != NULL)   *tagPtr = 0;
-			if (donePtr != NULL)  *donePtr = 0;
-			if (totalPtr != NULL) *totalPtr = 0;
-			
-			result = NAN;
-		}
-		else
-		{
-			// It's only possible to know the progress of our read if we're reading to a certain length.
-			// If we're reading to data, we of course have no idea when the data will arrive.
-			// If we're reading to timeout, then we have no idea when the next chunk of data will arrive.
-			
-			NSUInteger done = currentRead->bytesDone;
-			NSUInteger total = currentRead->readLength;
-			
-			if (tagPtr != NULL)   *tagPtr = currentRead->tag;
-			if (donePtr != NULL)  *donePtr = done;
-			if (totalPtr != NULL) *totalPtr = total;
-			
-			if (total > 0)
-				result = (float)done / (float)total;
-			else
-				result = 1.0F;
-		}
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	return result;
+    __block float result = 0.0F;
+    
+    dispatch_block_t block = ^{
+        
+        if (!currentRead || ![currentRead isKindOfClass:[GCDAsyncReadPacket class]])
+        {
+            // We're not reading anything right now.
+            
+            if (tagPtr != NULL)   *tagPtr = 0;
+            if (donePtr != NULL)  *donePtr = 0;
+            if (totalPtr != NULL) *totalPtr = 0;
+            
+            result = NAN;
+        }
+        else
+        {
+            // It's only possible to know the progress of our read if we're reading to a certain length.
+            // If we're reading to data, we of course have no idea when the data will arrive.
+            // If we're reading to timeout, then we have no idea when the next chunk of data will arrive.
+            
+            NSUInteger done = currentRead->bytesDone;
+            NSUInteger total = currentRead->readLength;
+            
+            if (tagPtr != NULL)   *tagPtr = currentRead->tag;
+            if (donePtr != NULL)  *donePtr = done;
+            if (totalPtr != NULL) *totalPtr = total;
+            
+            if (total > 0)
+                result = (float)done / (float)total;
+            else
+                result = 1.0F;
+        }
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    return result;
 }
 
 /**
  * This method starts a new read, if needed.
- * 
+ *
  * It is called when:
  * - a user requests a read
  * - after a read request has finished (to handle the next request)
  * - immediately after the socket opens to handle any pending requests
- * 
+ *
  * This method also handles auto-disconnect post read/write completion.
-**/
+ **/
 - (void)maybeDequeueRead
 {
-	LogTrace();
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	// If we're not currently processing a read AND we have an available read stream
-	if ((currentRead == nil) && (flags & kConnected))
-	{
-		if ([readQueue count] > 0)
-		{
-			// Dequeue the next object in the write queue
-			currentRead = [readQueue objectAtIndex:0];
-			[readQueue removeObjectAtIndex:0];
-			
-			
-			if ([currentRead isKindOfClass:[GCDAsyncSpecialPacket class]])
-			{
-				LogVerbose(@"Dequeued GCDAsyncSpecialPacket");
-				
-				// Attempt to start TLS
-				flags |= kStartingReadTLS;
-				
-				// This method won't do anything unless both kStartingReadTLS and kStartingWriteTLS are set
-				[self maybeStartTLS];
-			}
-			else
-			{
-				LogVerbose(@"Dequeued GCDAsyncReadPacket");
-				
-				// Setup read timer (if needed)
-				[self setupReadTimerWithTimeout:currentRead->timeout];
-				
-				// Immediately read, if possible
-				[self doReadData];
-			}
-		}
-		else if (flags & kDisconnectAfterReads)
-		{
-			if (flags & kDisconnectAfterWrites)
-			{
-				if (([writeQueue count] == 0) && (currentWrite == nil))
-				{
-					[self closeWithError:nil];
-				}
-			}
-			else
-			{
-				[self closeWithError:nil];
-			}
-		}
-		else if (flags & kSocketSecure)
-		{
-			[self flushSSLBuffers];
-			
-			// Edge case:
-			// 
-			// We just drained all data from the ssl buffers,
-			// and all known data from the socket (socketFDBytesAvailable).
-			// 
-			// If we didn't get any data from this process,
-			// then we may have reached the end of the TCP stream.
-			// 
-			// Be sure callbacks are enabled so we're notified about a disconnection.
-			
-			if ([preBuffer availableBytes] == 0)
-			{
-				if ([self usingCFStreamForTLS]) {
-					// Callbacks never disabled
-				}
-				else {
-					[self resumeReadSource];
-				}
-			}
-		}
-	}
+    LogTrace();
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    // If we're not currently processing a read AND we have an available read stream
+    if ((currentRead == nil) && (flags & kConnected))
+    {
+        if ([readQueue count] > 0)
+        {
+            // Dequeue the next object in the write queue
+            currentRead = [readQueue objectAtIndex:0];
+            [readQueue removeObjectAtIndex:0];
+            
+            
+            if ([currentRead isKindOfClass:[GCDAsyncSpecialPacket class]])
+            {
+                LogVerbose(@"Dequeued GCDAsyncSpecialPacket");
+                
+                // Attempt to start TLS
+                flags |= kStartingReadTLS;
+                
+                // This method won't do anything unless both kStartingReadTLS and kStartingWriteTLS are set
+                [self maybeStartTLS];
+            }
+            else
+            {
+                LogVerbose(@"Dequeued GCDAsyncReadPacket");
+                
+                // Setup read timer (if needed)
+                [self setupReadTimerWithTimeout:currentRead->timeout];
+                
+                // Immediately read, if possible
+                [self doReadData];
+            }
+        }
+        else if (flags & kDisconnectAfterReads)
+        {
+            if (flags & kDisconnectAfterWrites)
+            {
+                if (([writeQueue count] == 0) && (currentWrite == nil))
+                {
+                    [self closeWithError:nil];
+                }
+            }
+            else
+            {
+                [self closeWithError:nil];
+            }
+        }
+        else if (flags & kSocketSecure)
+        {
+            [self flushSSLBuffers];
+            
+            // Edge case:
+            //
+            // We just drained all data from the ssl buffers,
+            // and all known data from the socket (socketFDBytesAvailable).
+            //
+            // If we didn't get any data from this process,
+            // then we may have reached the end of the TCP stream.
+            //
+            // Be sure callbacks are enabled so we're notified about a disconnection.
+            
+            if ([preBuffer availableBytes] == 0)
+            {
+                if ([self usingCFStreamForTLS]) {
+                    // Callbacks never disabled
+                }
+                else {
+                    [self resumeReadSource];
+                }
+            }
+        }
+    }
 }
 
 - (void)flushSSLBuffers
 {
-	LogTrace();
-	
-	NSAssert((flags & kSocketSecure), @"Cannot flush ssl buffers on non-secure socket");
-	
-	if ([preBuffer availableBytes] > 0)
-	{
-		// Only flush the ssl buffers if the prebuffer is empty.
-		// This is to avoid growing the prebuffer inifinitely large.
-		
-		return;
-	}
-	
+    LogTrace();
+    
+    NSAssert((flags & kSocketSecure), @"Cannot flush ssl buffers on non-secure socket");
+    
+    if ([preBuffer availableBytes] > 0)
+    {
+        // Only flush the ssl buffers if the prebuffer is empty.
+        // This is to avoid growing the prebuffer inifinitely large.
+        
+        return;
+    }
+    
 #if TARGET_OS_IPHONE
-	
-	if ([self usingCFStreamForTLS])
-	{
-		if ((flags & kSecureSocketHasBytesAvailable) && CFReadStreamHasBytesAvailable(readStream))
-		{
-			LogVerbose(@"%@ - Flushing ssl buffers into prebuffer...", THIS_METHOD);
-			
-			CFIndex defaultBytesToRead = (1024 * 4);
-			
-			[preBuffer ensureCapacityForWrite:defaultBytesToRead];
-			
-			uint8_t *buffer = [preBuffer writeBuffer];
-			
-			CFIndex result = CFReadStreamRead(readStream, buffer, defaultBytesToRead);
-			LogVerbose(@"%@ - CFReadStreamRead(): result = %i", THIS_METHOD, (int)result);
-			
-			if (result > 0)
-			{
-				[preBuffer didWrite:result];
-			}
-			
-			flags &= ~kSecureSocketHasBytesAvailable;
-		}
-		
-		return;
-	}
-	
+    
+    if ([self usingCFStreamForTLS])
+    {
+        if ((flags & kSecureSocketHasBytesAvailable) && CFReadStreamHasBytesAvailable(readStream))
+        {
+            LogVerbose(@"%@ - Flushing ssl buffers into prebuffer...", THIS_METHOD);
+            
+            CFIndex defaultBytesToRead = (1024 * 4);
+            
+            [preBuffer ensureCapacityForWrite:defaultBytesToRead];
+            
+            uint8_t *buffer = [preBuffer writeBuffer];
+            
+            CFIndex result = CFReadStreamRead(readStream, buffer, defaultBytesToRead);
+            LogVerbose(@"%@ - CFReadStreamRead(): result = %i", THIS_METHOD, (int)result);
+            
+            if (result > 0)
+            {
+                [preBuffer didWrite:result];
+            }
+            
+            flags &= ~kSecureSocketHasBytesAvailable;
+        }
+        
+        return;
+    }
+    
 #endif
-#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-	
-	__block NSUInteger estimatedBytesAvailable = 0;
-	
-	dispatch_block_t updateEstimatedBytesAvailable = ^{
-		
-		// Figure out if there is any data available to be read
-		// 
-		// socketFDBytesAvailable        <- Number of encrypted bytes we haven't read from the bsd socket
-		// [sslPreBuffer availableBytes] <- Number of encrypted bytes we've buffered from bsd socket
-		// sslInternalBufSize            <- Number of decrypted bytes SecureTransport has buffered
-		// 
-		// We call the variable "estimated" because we don't know how many decrypted bytes we'll get
-		// from the encrypted bytes in the sslPreBuffer.
-		// However, we do know this is an upper bound on the estimation.
-		
-		estimatedBytesAvailable = socketFDBytesAvailable + [sslPreBuffer availableBytes];
-		
-		size_t sslInternalBufSize = 0;
-		SSLGetBufferedReadSize(sslContext, &sslInternalBufSize);
-		
-		estimatedBytesAvailable += sslInternalBufSize;
-	};
-	
-	updateEstimatedBytesAvailable();
-	
-	if (estimatedBytesAvailable > 0)
-	{
-		LogVerbose(@"%@ - Flushing ssl buffers into prebuffer...", THIS_METHOD);
-		
-		BOOL done = NO;
-		do
-		{
-			LogVerbose(@"%@ - estimatedBytesAvailable = %lu", THIS_METHOD, (unsigned long)estimatedBytesAvailable);
-			
-			// Make sure there's enough room in the prebuffer
-			
-			[preBuffer ensureCapacityForWrite:estimatedBytesAvailable];
-			
-			// Read data into prebuffer
-			
-			uint8_t *buffer = [preBuffer writeBuffer];
-			size_t bytesRead = 0;
-			
-			OSStatus result = SSLRead(sslContext, buffer, (size_t)estimatedBytesAvailable, &bytesRead);
-			LogVerbose(@"%@ - read from secure socket = %u", THIS_METHOD, (unsigned)bytesRead);
-			
-			if (bytesRead > 0)
-			{
-				[preBuffer didWrite:bytesRead];
-			}
-			
-			LogVerbose(@"%@ - prebuffer.length = %zu", THIS_METHOD, [preBuffer availableBytes]);
-			
-			if (result != noErr)
-			{
-				done = YES;
-			}
-			else
-			{
-				updateEstimatedBytesAvailable();
-			}
-			
-		} while (!done && estimatedBytesAvailable > 0);
-	}
-	
-#endif
+    
+    __block NSUInteger estimatedBytesAvailable = 0;
+    
+    dispatch_block_t updateEstimatedBytesAvailable = ^{
+        
+        // Figure out if there is any data available to be read
+        //
+        // socketFDBytesAvailable        <- Number of encrypted bytes we haven't read from the bsd socket
+        // [sslPreBuffer availableBytes] <- Number of encrypted bytes we've buffered from bsd socket
+        // sslInternalBufSize            <- Number of decrypted bytes SecureTransport has buffered
+        //
+        // We call the variable "estimated" because we don't know how many decrypted bytes we'll get
+        // from the encrypted bytes in the sslPreBuffer.
+        // However, we do know this is an upper bound on the estimation.
+        
+        estimatedBytesAvailable = socketFDBytesAvailable + [sslPreBuffer availableBytes];
+        
+        size_t sslInternalBufSize = 0;
+        SSLGetBufferedReadSize(sslContext, &sslInternalBufSize);
+        
+        estimatedBytesAvailable += sslInternalBufSize;
+    };
+    
+    updateEstimatedBytesAvailable();
+    
+    if (estimatedBytesAvailable > 0)
+    {
+        LogVerbose(@"%@ - Flushing ssl buffers into prebuffer...", THIS_METHOD);
+        
+        BOOL done = NO;
+        do
+        {
+            LogVerbose(@"%@ - estimatedBytesAvailable = %lu", THIS_METHOD, (unsigned long)estimatedBytesAvailable);
+            
+            // Make sure there's enough room in the prebuffer
+            
+            [preBuffer ensureCapacityForWrite:estimatedBytesAvailable];
+            
+            // Read data into prebuffer
+            
+            uint8_t *buffer = [preBuffer writeBuffer];
+            size_t bytesRead = 0;
+            
+            OSStatus result = SSLRead(sslContext, buffer, (size_t)estimatedBytesAvailable, &bytesRead);
+            LogVerbose(@"%@ - read from secure socket = %u", THIS_METHOD, (unsigned)bytesRead);
+            
+            if (bytesRead > 0)
+            {
+                [preBuffer didWrite:bytesRead];
+            }
+            
+            LogVerbose(@"%@ - prebuffer.length = %zu", THIS_METHOD, [preBuffer availableBytes]);
+            
+            if (result != noErr)
+            {
+                done = YES;
+            }
+            else
+            {
+                updateEstimatedBytesAvailable();
+            }
+            
+        } while (!done && estimatedBytesAvailable > 0);
+    }
 }
 
 - (void)doReadData
 {
-	LogTrace();
-	
-	// This method is called on the socketQueue.
-	// It might be called directly, or via the readSource when data is available to be read.
-	
-	if ((currentRead == nil) || (flags & kReadsPaused))
-	{
-		LogVerbose(@"No currentRead or kReadsPaused");
-		
-		// Unable to read at this time
-		
-		if (flags & kSocketSecure)
-		{
-			// Here's the situation:
-			// 
-			// We have an established secure connection.
-			// There may not be a currentRead, but there might be encrypted data sitting around for us.
-			// When the user does get around to issuing a read, that encrypted data will need to be decrypted.
-			// 
-			// So why make the user wait?
-			// We might as well get a head start on decrypting some data now.
-			// 
-			// The other reason we do this has to do with detecting a socket disconnection.
-			// The SSL/TLS protocol has it's own disconnection handshake.
-			// So when a secure socket is closed, a "goodbye" packet comes across the wire.
-			// We want to make sure we read the "goodbye" packet so we can properly detect the TCP disconnection.
-			
-			[self flushSSLBuffers];
-		}
-		
-		if ([self usingCFStreamForTLS])
-		{
-			// CFReadStream only fires once when there is available data.
-			// It won't fire again until we've invoked CFReadStreamRead.
-		}
-		else
-		{
-			// If the readSource is firing, we need to pause it
-			// or else it will continue to fire over and over again.
-			// 
-			// If the readSource is not firing,
-			// we want it to continue monitoring the socket.
-			
-			if (socketFDBytesAvailable > 0)
-			{
-				[self suspendReadSource];
-			}
-		}
-		return;
-	}
-	
-	BOOL hasBytesAvailable = NO;
-	unsigned long estimatedBytesAvailable = 0;
-	
-	if ([self usingCFStreamForTLS])
-	{
-		#if TARGET_OS_IPHONE
-		
-		// Relegated to using CFStream... :( Boo! Give us a full SecureTransport stack Apple!
-		
-		estimatedBytesAvailable = 0;
-		if ((flags & kSecureSocketHasBytesAvailable) && CFReadStreamHasBytesAvailable(readStream))
-			hasBytesAvailable = YES;
-		else
-			hasBytesAvailable = NO;
-		
-		#endif
-	}
-	else
-	{
-		estimatedBytesAvailable = socketFDBytesAvailable;
-		
-		#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-		
-		if (flags & kSocketSecure)
-		{
-			// There are 2 buffers to be aware of here.
-			// 
-			// We are using SecureTransport, a TLS/SSL security layer which sits atop TCP.
-			// We issue a read to the SecureTranport API, which in turn issues a read to our SSLReadFunction.
-			// Our SSLReadFunction then reads from the BSD socket and returns the encrypted data to SecureTransport.
-			// SecureTransport then decrypts the data, and finally returns the decrypted data back to us.
-			// 
-			// The first buffer is one we create.
-			// SecureTransport often requests small amounts of data.
-			// This has to do with the encypted packets that are coming across the TCP stream.
-			// But it's non-optimal to do a bunch of small reads from the BSD socket.
-			// So our SSLReadFunction reads all available data from the socket (optimizing the sys call)
-			// and may store excess in the sslPreBuffer.
-			
-			estimatedBytesAvailable += [sslPreBuffer availableBytes];
-			
-			// The second buffer is within SecureTransport.
-			// As mentioned earlier, there are encrypted packets coming across the TCP stream.
-			// SecureTransport needs the entire packet to decrypt it.
-			// But if the entire packet produces X bytes of decrypted data,
-			// and we only asked SecureTransport for X/2 bytes of data,
-			// it must store the extra X/2 bytes of decrypted data for the next read.
-			// 
-			// The SSLGetBufferedReadSize function will tell us the size of this internal buffer.
-			// From the documentation:
-			// 
-			// "This function does not block or cause any low-level read operations to occur."
-			
-			size_t sslInternalBufSize = 0;
-			SSLGetBufferedReadSize(sslContext, &sslInternalBufSize);
-			
-			estimatedBytesAvailable += sslInternalBufSize;
-		}
-		
-		#endif
-		
-		hasBytesAvailable = (estimatedBytesAvailable > 0);
-	}
-	
-	if ((hasBytesAvailable == NO) && ([preBuffer availableBytes] == 0))
-	{
-		LogVerbose(@"No data available to read...");
-		
-		// No data available to read.
-		
-		if (![self usingCFStreamForTLS])
-		{
-			// Need to wait for readSource to fire and notify us of
-			// available data in the socket's internal read buffer.
-			
-			[self resumeReadSource];
-		}
-		return;
-	}
-	
-	if (flags & kStartingReadTLS)
-	{
-		LogVerbose(@"Waiting for SSL/TLS handshake to complete");
-		
-		// The readQueue is waiting for SSL/TLS handshake to complete.
-		
-		if (flags & kStartingWriteTLS)
-		{
-			if ([self usingSecureTransportForTLS])
-			{
-				#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-			
-				// We are in the process of a SSL Handshake.
-				// We were waiting for incoming data which has just arrived.
-				
-				[self ssl_continueSSLHandshake];
-			
-				#endif
-			}
-		}
-		else
-		{
-			// We are still waiting for the writeQueue to drain and start the SSL/TLS process.
-			// We now know data is available to read.
-			
-			if (![self usingCFStreamForTLS])
-			{
-				// Suspend the read source or else it will continue to fire nonstop.
-				
-				[self suspendReadSource];
-			}
-		}
-		
-		return;
-	}
-	
-	BOOL done        = NO;  // Completed read operation
-	NSError *error   = nil; // Error occured
-	
-	NSUInteger totalBytesReadForCurrentRead = 0;
-	
-	// 
-	// STEP 1 - READ FROM PREBUFFER
-	// 
-	
-	if ([preBuffer availableBytes] > 0)
-	{
-		// There are 3 types of read packets:
-		// 
-		// 1) Read all available data.
-		// 2) Read a specific length of data.
-		// 3) Read up to a particular terminator.
-		
-		NSUInteger bytesToCopy;
-		
-		if (currentRead->term != nil)
-		{
-			// Read type #3 - read up to a terminator
-			
-			bytesToCopy = [currentRead readLengthForTermWithPreBuffer:preBuffer found:&done];
-		}
-		else
-		{
-			// Read type #1 or #2
-			
-			bytesToCopy = [currentRead readLengthForNonTermWithHint:[preBuffer availableBytes]];
-		}
-		
-		// Make sure we have enough room in the buffer for our read.
-		
-		[currentRead ensureCapacityForAdditionalDataOfLength:bytesToCopy];
-		
-		// Copy bytes from prebuffer into packet buffer
-		
-		uint8_t *buffer = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset +
-		                                                                  currentRead->bytesDone;
-		
-		memcpy(buffer, [preBuffer readBuffer], bytesToCopy);
-		
-		// Remove the copied bytes from the preBuffer
-		[preBuffer didRead:bytesToCopy];
-		
-		LogVerbose(@"copied(%lu) preBufferLength(%zu)", (unsigned long)bytesToCopy, [preBuffer availableBytes]);
-		
-		// Update totals
-		
-		currentRead->bytesDone += bytesToCopy;
-		totalBytesReadForCurrentRead += bytesToCopy;
-		
-		// Check to see if the read operation is done
-		
-		if (currentRead->readLength > 0)
-		{
-			// Read type #2 - read a specific length of data
-			
-			done = (currentRead->bytesDone == currentRead->readLength);
-		}
-		else if (currentRead->term != nil)
-		{
-			// Read type #3 - read up to a terminator
-			
-			// Our 'done' variable was updated via the readLengthForTermWithPreBuffer:found: method
-			
-			if (!done && currentRead->maxLength > 0)
-			{
-				// We're not done and there's a set maxLength.
-				// Have we reached that maxLength yet?
-				
-				if (currentRead->bytesDone >= currentRead->maxLength)
-				{
-					error = [self readMaxedOutError];
-				}
-			}
-		}
-		else
-		{
-			// Read type #1 - read all available data
-			// 
-			// We're done as soon as
-			// - we've read all available data (in prebuffer and socket)
-			// - we've read the maxLength of read packet.
-			
-			done = ((currentRead->maxLength > 0) && (currentRead->bytesDone == currentRead->maxLength));
-		}
-		
-	}
-	
-	// 
-	// STEP 2 - READ FROM SOCKET
-	// 
-	
-	BOOL socketEOF = (flags & kSocketHasReadEOF) ? YES : NO;  // Nothing more to via socket (end of file)
-	BOOL waiting   = !done && !error && !socketEOF && !hasBytesAvailable; // Ran out of data, waiting for more
-	
-	if (!done && !error && !socketEOF && !waiting && hasBytesAvailable)
-	{
-		NSAssert(([preBuffer availableBytes] == 0), @"Invalid logic");
-		
-		// There are 3 types of read packets:
-		// 
-		// 1) Read all available data.
-		// 2) Read a specific length of data.
-		// 3) Read up to a particular terminator.
-		
-		BOOL readIntoPreBuffer = NO;
-		NSUInteger bytesToRead;
-		
-		if ([self usingCFStreamForTLS])
-		{
-			// Since Apple hasn't made the full power of SecureTransport available on iOS,
-			// we are relegated to using the slower, less powerful, RunLoop based CFStream API.
-			// 
-			// This API doesn't tell us how much data is available on the socket to be read.
-			// If we had that information we could optimize our memory allocations, and sys calls.
-			// 
-			// But alas...
-			// So we do it old school, and just read as much data from the socket as we can.
-			
-			NSUInteger defaultReadLength = (1024 * 32);
-			
-			bytesToRead = [currentRead optimalReadLengthWithDefault:defaultReadLength
-			                                        shouldPreBuffer:&readIntoPreBuffer];
-		}
-		else
-		{
-			if (currentRead->term != nil)
-			{
-				// Read type #3 - read up to a terminator
-				
-				bytesToRead = [currentRead readLengthForTermWithHint:estimatedBytesAvailable
-													 shouldPreBuffer:&readIntoPreBuffer];
-			}
-			else
-			{
-				// Read type #1 or #2
-				
-				bytesToRead = [currentRead readLengthForNonTermWithHint:estimatedBytesAvailable];
-			}
-		}
-		
-		if (bytesToRead > SIZE_MAX) // NSUInteger may be bigger than size_t (read param 3)
-		{
-			bytesToRead = SIZE_MAX;
-		}
-		
-		// Make sure we have enough room in the buffer for our read.
-		// 
-		// We are either reading directly into the currentRead->buffer,
-		// or we're reading into the temporary preBuffer.
-		
-		uint8_t *buffer;
-		
-		if (readIntoPreBuffer)
-		{
-			[preBuffer ensureCapacityForWrite:bytesToRead];
-						
-			buffer = [preBuffer writeBuffer];
-		}
-		else
-		{
-			[currentRead ensureCapacityForAdditionalDataOfLength:bytesToRead];
-			
-			buffer = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset + currentRead->bytesDone;
-		}
-		
-		// Read data into buffer
-		
-		size_t bytesRead = 0;
-		
-		if (flags & kSocketSecure)
-		{
-			if ([self usingCFStreamForTLS])
-			{
-				#if TARGET_OS_IPHONE
-				
-				CFIndex result = CFReadStreamRead(readStream, buffer, (CFIndex)bytesToRead);
-				LogVerbose(@"CFReadStreamRead(): result = %i", (int)result);
-				
-				if (result < 0)
-				{
-					error = (__bridge_transfer NSError *)CFReadStreamCopyError(readStream);
-				}
-				else if (result == 0)
-				{
-					socketEOF = YES;
-				}
-				else
-				{
-					waiting = YES;
-					bytesRead = (size_t)result;
-				}
-				
-				// We only know how many decrypted bytes were read.
-				// The actual number of bytes read was likely more due to the overhead of the encryption.
-				// So we reset our flag, and rely on the next callback to alert us of more data.
-				flags &= ~kSecureSocketHasBytesAvailable;
-				
-				#endif
-			}
-			else
-			{
-				#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-					
-				// The documentation from Apple states:
-				// 
-				//     "a read operation might return errSSLWouldBlock,
-				//      indicating that less data than requested was actually transferred"
-				// 
-				// However, starting around 10.7, the function will sometimes return noErr,
-				// even if it didn't read as much data as requested. So we need to watch out for that.
-				
-				OSStatus result;
-				do
-				{
-					void *loop_buffer = buffer + bytesRead;
-					size_t loop_bytesToRead = (size_t)bytesToRead - bytesRead;
-					size_t loop_bytesRead = 0;
-					
-					result = SSLRead(sslContext, loop_buffer, loop_bytesToRead, &loop_bytesRead);
-					LogVerbose(@"read from secure socket = %u", (unsigned)loop_bytesRead);
-					
-					bytesRead += loop_bytesRead;
-					
-				} while ((result == noErr) && (bytesRead < bytesToRead));
-				
-				
-				if (result != noErr)
-				{
-					if (result == errSSLWouldBlock)
-						waiting = YES;
-					else
-					{
-						if (result == errSSLClosedGraceful || result == errSSLClosedAbort)
-						{
-							// We've reached the end of the stream.
-							// Handle this the same way we would an EOF from the socket.
-							socketEOF = YES;
-							sslErrCode = result;
-						}
-						else
-						{
-							error = [self sslError:result];
-						}
-					}
-					// It's possible that bytesRead > 0, even if the result was errSSLWouldBlock.
-					// This happens when the SSLRead function is able to read some data,
-					// but not the entire amount we requested.
-					
-					if (bytesRead <= 0)
-					{
-						bytesRead = 0;
-					}
-				}
-				
-				// Do not modify socketFDBytesAvailable.
-				// It will be updated via the SSLReadFunction().
-				
-				#endif
-			}
-		}
-		else
-		{
-			int socketFD = (socket4FD == SOCKET_NULL) ? socket6FD : socket4FD;
-			
-			ssize_t result = read(socketFD, buffer, (size_t)bytesToRead);
-			LogVerbose(@"read from socket = %i", (int)result);
-			
-			if (result < 0)
-			{
-				if (errno == EWOULDBLOCK)
-					waiting = YES;
-				else
-					error = [self errnoErrorWithReason:@"Error in read() function"];
-				
-				socketFDBytesAvailable = 0;
-			}
-			else if (result == 0)
-			{
-				socketEOF = YES;
-				socketFDBytesAvailable = 0;
-			}
-			else
-			{
-				bytesRead = result;
-				
-				if (bytesRead < bytesToRead)
-				{
-					// The read returned less data than requested.
-					// This means socketFDBytesAvailable was a bit off due to timing,
-					// because we read from the socket right when the readSource event was firing.
-					socketFDBytesAvailable = 0;
-				}
-				else
-				{
-					if (socketFDBytesAvailable <= bytesRead)
-						socketFDBytesAvailable = 0;
-					else
-						socketFDBytesAvailable -= bytesRead;
-				}
-				
-				if (socketFDBytesAvailable == 0)
-				{
-					waiting = YES;
-				}
-			}
-		}
-		
-		if (bytesRead > 0)
-		{
-			// Check to see if the read operation is done
-			
-			if (currentRead->readLength > 0)
-			{
-				// Read type #2 - read a specific length of data
-				// 
-				// Note: We should never be using a prebuffer when we're reading a specific length of data.
-				
-				NSAssert(readIntoPreBuffer == NO, @"Invalid logic");
-				
-				currentRead->bytesDone += bytesRead;
-				totalBytesReadForCurrentRead += bytesRead;
-				
-				done = (currentRead->bytesDone == currentRead->readLength);
-			}
-			else if (currentRead->term != nil)
-			{
-				// Read type #3 - read up to a terminator
-				
-				if (readIntoPreBuffer)
-				{
-					// We just read a big chunk of data into the preBuffer
-					
-					[preBuffer didWrite:bytesRead];
-					LogVerbose(@"read data into preBuffer - preBuffer.length = %zu", [preBuffer availableBytes]);
-					
-					// Search for the terminating sequence
-					
-					bytesToRead = [currentRead readLengthForTermWithPreBuffer:preBuffer found:&done];
-					LogVerbose(@"copying %lu bytes from preBuffer", (unsigned long)bytesToRead);
-					
-					// Ensure there's room on the read packet's buffer
-					
-					[currentRead ensureCapacityForAdditionalDataOfLength:bytesToRead];
-					
-					// Copy bytes from prebuffer into read buffer
-					
-					uint8_t *readBuf = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset
-					                                                                 + currentRead->bytesDone;
-					
-					memcpy(readBuf, [preBuffer readBuffer], bytesToRead);
-					
-					// Remove the copied bytes from the prebuffer
-					[preBuffer didRead:bytesToRead];
-					LogVerbose(@"preBuffer.length = %zu", [preBuffer availableBytes]);
-					
-					// Update totals
-					currentRead->bytesDone += bytesToRead;
-					totalBytesReadForCurrentRead += bytesToRead;
-					
-					// Our 'done' variable was updated via the readLengthForTermWithPreBuffer:found: method above
-				}
-				else
-				{
-					// We just read a big chunk of data directly into the packet's buffer.
-					// We need to move any overflow into the prebuffer.
-					
-					NSInteger overflow = [currentRead searchForTermAfterPreBuffering:bytesRead];
-					
-					if (overflow == 0)
-					{
-						// Perfect match!
-						// Every byte we read stays in the read buffer,
-						// and the last byte we read was the last byte of the term.
-						
-						currentRead->bytesDone += bytesRead;
-						totalBytesReadForCurrentRead += bytesRead;
-						done = YES;
-					}
-					else if (overflow > 0)
-					{
-						// The term was found within the data that we read,
-						// and there are extra bytes that extend past the end of the term.
-						// We need to move these excess bytes out of the read packet and into the prebuffer.
-						
-						NSInteger underflow = bytesRead - overflow;
-						
-						// Copy excess data into preBuffer
-						
-						LogVerbose(@"copying %ld overflow bytes into preBuffer", (long)overflow);
-						[preBuffer ensureCapacityForWrite:overflow];
-						
-						uint8_t *overflowBuffer = buffer + underflow;
-						memcpy([preBuffer writeBuffer], overflowBuffer, overflow);
-						
-						[preBuffer didWrite:overflow];
-						LogVerbose(@"preBuffer.length = %zu", [preBuffer availableBytes]);
-						
-						// Note: The completeCurrentRead method will trim the buffer for us.
-						
-						currentRead->bytesDone += underflow;
-						totalBytesReadForCurrentRead += underflow;
-						done = YES;
-					}
-					else
-					{
-						// The term was not found within the data that we read.
-						
-						currentRead->bytesDone += bytesRead;
-						totalBytesReadForCurrentRead += bytesRead;
-						done = NO;
-					}
-				}
-				
-				if (!done && currentRead->maxLength > 0)
-				{
-					// We're not done and there's a set maxLength.
-					// Have we reached that maxLength yet?
-					
-					if (currentRead->bytesDone >= currentRead->maxLength)
-					{
-						error = [self readMaxedOutError];
-					}
-				}
-			}
-			else
-			{
-				// Read type #1 - read all available data
-				
-				if (readIntoPreBuffer)
-				{
-					// We just read a chunk of data into the preBuffer
-					
-					[preBuffer didWrite:bytesRead];
-					
-					// Now copy the data into the read packet.
-					// 
-					// Recall that we didn't read directly into the packet's buffer to avoid
-					// over-allocating memory since we had no clue how much data was available to be read.
-					// 
-					// Ensure there's room on the read packet's buffer
-					
-					[currentRead ensureCapacityForAdditionalDataOfLength:bytesRead];
-					
-					// Copy bytes from prebuffer into read buffer
-					
-					uint8_t *readBuf = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset
-					                                                                 + currentRead->bytesDone;
-					
-					memcpy(readBuf, [preBuffer readBuffer], bytesRead);
-					
-					// Remove the copied bytes from the prebuffer
-					[preBuffer didRead:bytesRead];
-					
-					// Update totals
-					currentRead->bytesDone += bytesRead;
-					totalBytesReadForCurrentRead += bytesRead;
-				}
-				else
-				{
-					currentRead->bytesDone += bytesRead;
-					totalBytesReadForCurrentRead += bytesRead;
-				}
-				
-				done = YES;
-			}
-			
-		} // if (bytesRead > 0)
-		
-	} // if (!done && !error && !socketEOF && !waiting && hasBytesAvailable)
-	
-	
-	if (!done && currentRead->readLength == 0 && currentRead->term == nil)
-	{
-		// Read type #1 - read all available data
-		// 
-		// We might arrive here if we read data from the prebuffer but not from the socket.
-		
-		done = (totalBytesReadForCurrentRead > 0);
-	}
-	
-	// Check to see if we're done, or if we've made progress
-	
-	if (done)
-	{
-		[self completeCurrentRead];
-		
-		if (!error && (!socketEOF || [preBuffer availableBytes] > 0))
-		{
-			[self maybeDequeueRead];
-		}
-	}
-	else if (totalBytesReadForCurrentRead > 0)
-	{
-		// We're not done read type #2 or #3 yet, but we have read in some bytes
-
-		__strong id theDelegate = delegate;
-		
-		if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didReadPartialDataOfLength:tag:)])
-		{
-			long theReadTag = currentRead->tag;
-			
-			dispatch_async(delegateQueue, ^{ @autoreleasepool {
-				
-				[theDelegate socket:self didReadPartialDataOfLength:totalBytesReadForCurrentRead tag:theReadTag];
-			}});
-		}
-	}
-	
-	// Check for errors
-	
-	if (error)
-	{
-		[self closeWithError:error];
-	}
-	else if (socketEOF)
-	{
-		[self doReadEOF];
-	}
-	else if (waiting)
-	{
-		if (![self usingCFStreamForTLS])
-		{
-			// Monitor the socket for readability (if we're not already doing so)
-			[self resumeReadSource];
-		}
-	}
-	
-	// Do not add any code here without first adding return statements in the error cases above.
+    LogTrace();
+    
+    // This method is called on the socketQueue.
+    // It might be called directly, or via the readSource when data is available to be read.
+    
+    if ((currentRead == nil) || (flags & kReadsPaused))
+    {
+        LogVerbose(@"No currentRead or kReadsPaused");
+        
+        // Unable to read at this time
+        
+        if (flags & kSocketSecure)
+        {
+            // Here's the situation:
+            //
+            // We have an established secure connection.
+            // There may not be a currentRead, but there might be encrypted data sitting around for us.
+            // When the user does get around to issuing a read, that encrypted data will need to be decrypted.
+            //
+            // So why make the user wait?
+            // We might as well get a head start on decrypting some data now.
+            //
+            // The other reason we do this has to do with detecting a socket disconnection.
+            // The SSL/TLS protocol has it's own disconnection handshake.
+            // So when a secure socket is closed, a "goodbye" packet comes across the wire.
+            // We want to make sure we read the "goodbye" packet so we can properly detect the TCP disconnection.
+            
+            [self flushSSLBuffers];
+        }
+        
+        if ([self usingCFStreamForTLS])
+        {
+            // CFReadStream only fires once when there is available data.
+            // It won't fire again until we've invoked CFReadStreamRead.
+        }
+        else
+        {
+            // If the readSource is firing, we need to pause it
+            // or else it will continue to fire over and over again.
+            //
+            // If the readSource is not firing,
+            // we want it to continue monitoring the socket.
+            
+            if (socketFDBytesAvailable > 0)
+            {
+                [self suspendReadSource];
+            }
+        }
+        return;
+    }
+    
+    BOOL hasBytesAvailable = NO;
+    unsigned long estimatedBytesAvailable = 0;
+    
+    if ([self usingCFStreamForTLS])
+    {
+#if TARGET_OS_IPHONE
+        
+        // Requested CFStream, rather than SecureTransport, for TLS (via GCDAsyncSocketUseCFStreamForTLS)
+        
+        estimatedBytesAvailable = 0;
+        if ((flags & kSecureSocketHasBytesAvailable) && CFReadStreamHasBytesAvailable(readStream))
+            hasBytesAvailable = YES;
+        else
+            hasBytesAvailable = NO;
+        
+#endif
+    }
+    else
+    {
+        estimatedBytesAvailable = socketFDBytesAvailable;
+        
+        if (flags & kSocketSecure)
+        {
+            // There are 2 buffers to be aware of here.
+            //
+            // We are using SecureTransport, a TLS/SSL security layer which sits atop TCP.
+            // We issue a read to the SecureTranport API, which in turn issues a read to our SSLReadFunction.
+            // Our SSLReadFunction then reads from the BSD socket and returns the encrypted data to SecureTransport.
+            // SecureTransport then decrypts the data, and finally returns the decrypted data back to us.
+            //
+            // The first buffer is one we create.
+            // SecureTransport often requests small amounts of data.
+            // This has to do with the encypted packets that are coming across the TCP stream.
+            // But it's non-optimal to do a bunch of small reads from the BSD socket.
+            // So our SSLReadFunction reads all available data from the socket (optimizing the sys call)
+            // and may store excess in the sslPreBuffer.
+            
+            estimatedBytesAvailable += [sslPreBuffer availableBytes];
+            
+            // The second buffer is within SecureTransport.
+            // As mentioned earlier, there are encrypted packets coming across the TCP stream.
+            // SecureTransport needs the entire packet to decrypt it.
+            // But if the entire packet produces X bytes of decrypted data,
+            // and we only asked SecureTransport for X/2 bytes of data,
+            // it must store the extra X/2 bytes of decrypted data for the next read.
+            //
+            // The SSLGetBufferedReadSize function will tell us the size of this internal buffer.
+            // From the documentation:
+            //
+            // "This function does not block or cause any low-level read operations to occur."
+            
+            size_t sslInternalBufSize = 0;
+            SSLGetBufferedReadSize(sslContext, &sslInternalBufSize);
+            
+            estimatedBytesAvailable += sslInternalBufSize;
+        }
+        
+        hasBytesAvailable = (estimatedBytesAvailable > 0);
+    }
+    
+    if ((hasBytesAvailable == NO) && ([preBuffer availableBytes] == 0))
+    {
+        LogVerbose(@"No data available to read...");
+        
+        // No data available to read.
+        
+        if (![self usingCFStreamForTLS])
+        {
+            // Need to wait for readSource to fire and notify us of
+            // available data in the socket's internal read buffer.
+            
+            [self resumeReadSource];
+        }
+        return;
+    }
+    
+    if (flags & kStartingReadTLS)
+    {
+        LogVerbose(@"Waiting for SSL/TLS handshake to complete");
+        
+        // The readQueue is waiting for SSL/TLS handshake to complete.
+        
+        if (flags & kStartingWriteTLS)
+        {
+            if ([self usingSecureTransportForTLS])
+            {
+                // We are in the process of a SSL Handshake.
+                // We were waiting for incoming data which has just arrived.
+                
+                [self ssl_continueSSLHandshake];
+            }
+        }
+        else
+        {
+            // We are still waiting for the writeQueue to drain and start the SSL/TLS process.
+            // We now know data is available to read.
+            
+            if (![self usingCFStreamForTLS])
+            {
+                // Suspend the read source or else it will continue to fire nonstop.
+                
+                [self suspendReadSource];
+            }
+        }
+        
+        return;
+    }
+    
+    BOOL done        = NO;  // Completed read operation
+    NSError *error   = nil; // Error occured
+    
+    NSUInteger totalBytesReadForCurrentRead = 0;
+    
+    //
+    // STEP 1 - READ FROM PREBUFFER
+    //
+    
+    if ([preBuffer availableBytes] > 0)
+    {
+        // There are 3 types of read packets:
+        //
+        // 1) Read all available data.
+        // 2) Read a specific length of data.
+        // 3) Read up to a particular terminator.
+        
+        NSUInteger bytesToCopy;
+        
+        if (currentRead->term != nil)
+        {
+            // Read type #3 - read up to a terminator
+            
+            bytesToCopy = [currentRead readLengthForTermWithPreBuffer:preBuffer found:&done];
+        }
+        else
+        {
+            // Read type #1 or #2
+            
+            bytesToCopy = [currentRead readLengthForNonTermWithHint:[preBuffer availableBytes]];
+        }
+        
+        // Make sure we have enough room in the buffer for our read.
+        
+        [currentRead ensureCapacityForAdditionalDataOfLength:bytesToCopy];
+        
+        // Copy bytes from prebuffer into packet buffer
+        
+        uint8_t *buffer = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset +
+        currentRead->bytesDone;
+        
+        memcpy(buffer, [preBuffer readBuffer], bytesToCopy);
+        
+        // Remove the copied bytes from the preBuffer
+        [preBuffer didRead:bytesToCopy];
+        
+        LogVerbose(@"copied(%lu) preBufferLength(%zu)", (unsigned long)bytesToCopy, [preBuffer availableBytes]);
+        
+        // Update totals
+        
+        currentRead->bytesDone += bytesToCopy;
+        totalBytesReadForCurrentRead += bytesToCopy;
+        
+        // Check to see if the read operation is done
+        
+        if (currentRead->readLength > 0)
+        {
+            // Read type #2 - read a specific length of data
+            
+            done = (currentRead->bytesDone == currentRead->readLength);
+        }
+        else if (currentRead->term != nil)
+        {
+            // Read type #3 - read up to a terminator
+            
+            // Our 'done' variable was updated via the readLengthForTermWithPreBuffer:found: method
+            
+            if (!done && currentRead->maxLength > 0)
+            {
+                // We're not done and there's a set maxLength.
+                // Have we reached that maxLength yet?
+                
+                if (currentRead->bytesDone >= currentRead->maxLength)
+                {
+                    error = [self readMaxedOutError];
+                }
+            }
+        }
+        else
+        {
+            // Read type #1 - read all available data
+            //
+            // We're done as soon as
+            // - we've read all available data (in prebuffer and socket)
+            // - we've read the maxLength of read packet.
+            
+            done = ((currentRead->maxLength > 0) && (currentRead->bytesDone == currentRead->maxLength));
+        }
+        
+    }
+    
+    //
+    // STEP 2 - READ FROM SOCKET
+    //
+    
+    BOOL socketEOF = (flags & kSocketHasReadEOF) ? YES : NO;  // Nothing more to read via socket (end of file)
+    BOOL waiting   = !done && !error && !socketEOF && !hasBytesAvailable; // Ran out of data, waiting for more
+    
+    if (!done && !error && !socketEOF && hasBytesAvailable)
+    {
+        NSAssert(([preBuffer availableBytes] == 0), @"Invalid logic");
+        
+        BOOL readIntoPreBuffer = NO;
+        uint8_t *buffer = NULL;
+        size_t bytesRead = 0;
+        
+        if (flags & kSocketSecure)
+        {
+            if ([self usingCFStreamForTLS])
+            {
+#if TARGET_OS_IPHONE
+                
+                // Using CFStream, rather than SecureTransport, for TLS
+                
+                NSUInteger defaultReadLength = (1024 * 32);
+                
+                NSUInteger bytesToRead = [currentRead optimalReadLengthWithDefault:defaultReadLength
+                                                                   shouldPreBuffer:&readIntoPreBuffer];
+                
+                // Make sure we have enough room in the buffer for our read.
+                //
+                // We are either reading directly into the currentRead->buffer,
+                // or we're reading into the temporary preBuffer.
+                
+                if (readIntoPreBuffer)
+                {
+                    [preBuffer ensureCapacityForWrite:bytesToRead];
+                    
+                    buffer = [preBuffer writeBuffer];
+                }
+                else
+                {
+                    [currentRead ensureCapacityForAdditionalDataOfLength:bytesToRead];
+                    
+                    buffer = (uint8_t *)[currentRead->buffer mutableBytes]
+                    + currentRead->startOffset
+                    + currentRead->bytesDone;
+                }
+                
+                // Read data into buffer
+                
+                CFIndex result = CFReadStreamRead(readStream, buffer, (CFIndex)bytesToRead);
+                LogVerbose(@"CFReadStreamRead(): result = %i", (int)result);
+                
+                if (result < 0)
+                {
+                    error = (__bridge_transfer NSError *)CFReadStreamCopyError(readStream);
+                }
+                else if (result == 0)
+                {
+                    socketEOF = YES;
+                }
+                else
+                {
+                    waiting = YES;
+                    bytesRead = (size_t)result;
+                }
+                
+                // We only know how many decrypted bytes were read.
+                // The actual number of bytes read was likely more due to the overhead of the encryption.
+                // So we reset our flag, and rely on the next callback to alert us of more data.
+                flags &= ~kSecureSocketHasBytesAvailable;
+                
+#endif
+            }
+            else
+            {
+                // Using SecureTransport for TLS
+                //
+                // We know:
+                // - how many bytes are available on the socket
+                // - how many encrypted bytes are sitting in the sslPreBuffer
+                // - how many decypted bytes are sitting in the sslContext
+                //
+                // But we do NOT know:
+                // - how many encypted bytes are sitting in the sslContext
+                //
+                // So we play the regular game of using an upper bound instead.
+                
+                NSUInteger defaultReadLength = (1024 * 32);
+                
+                if (defaultReadLength < estimatedBytesAvailable) {
+                    defaultReadLength = estimatedBytesAvailable + (1024 * 16);
+                }
+                
+                NSUInteger bytesToRead = [currentRead optimalReadLengthWithDefault:defaultReadLength
+                                                                   shouldPreBuffer:&readIntoPreBuffer];
+                
+                if (bytesToRead > SIZE_MAX) { // NSUInteger may be bigger than size_t
+                    bytesToRead = SIZE_MAX;
+                }
+                
+                // Make sure we have enough room in the buffer for our read.
+                //
+                // We are either reading directly into the currentRead->buffer,
+                // or we're reading into the temporary preBuffer.
+                
+                if (readIntoPreBuffer)
+                {
+                    [preBuffer ensureCapacityForWrite:bytesToRead];
+                    
+                    buffer = [preBuffer writeBuffer];
+                }
+                else
+                {
+                    [currentRead ensureCapacityForAdditionalDataOfLength:bytesToRead];
+                    
+                    buffer = (uint8_t *)[currentRead->buffer mutableBytes]
+                    + currentRead->startOffset
+                    + currentRead->bytesDone;
+                }
+                
+                // The documentation from Apple states:
+                //
+                //     "a read operation might return errSSLWouldBlock,
+                //      indicating that less data than requested was actually transferred"
+                //
+                // However, starting around 10.7, the function will sometimes return noErr,
+                // even if it didn't read as much data as requested. So we need to watch out for that.
+                
+                OSStatus result;
+                do
+                {
+                    void *loop_buffer = buffer + bytesRead;
+                    size_t loop_bytesToRead = (size_t)bytesToRead - bytesRead;
+                    size_t loop_bytesRead = 0;
+                    
+                    result = SSLRead(sslContext, loop_buffer, loop_bytesToRead, &loop_bytesRead);
+                    LogVerbose(@"read from secure socket = %u", (unsigned)loop_bytesRead);
+                    
+                    bytesRead += loop_bytesRead;
+                    
+                } while ((result == noErr) && (bytesRead < bytesToRead));
+                
+                
+                if (result != noErr)
+                {
+                    if (result == errSSLWouldBlock)
+                        waiting = YES;
+                    else
+                    {
+                        if (result == errSSLClosedGraceful || result == errSSLClosedAbort)
+                        {
+                            // We've reached the end of the stream.
+                            // Handle this the same way we would an EOF from the socket.
+                            socketEOF = YES;
+                            sslErrCode = result;
+                        }
+                        else
+                        {
+                            error = [self sslError:result];
+                        }
+                    }
+                    // It's possible that bytesRead > 0, even if the result was errSSLWouldBlock.
+                    // This happens when the SSLRead function is able to read some data,
+                    // but not the entire amount we requested.
+                    
+                    if (bytesRead <= 0)
+                    {
+                        bytesRead = 0;
+                    }
+                }
+                
+                // Do not modify socketFDBytesAvailable.
+                // It will be updated via the SSLReadFunction().
+            }
+        }
+        else
+        {
+            // Normal socket operation
+            
+            NSUInteger bytesToRead;
+            
+            // There are 3 types of read packets:
+            //
+            // 1) Read all available data.
+            // 2) Read a specific length of data.
+            // 3) Read up to a particular terminator.
+            
+            if (currentRead->term != nil)
+            {
+                // Read type #3 - read up to a terminator
+                
+                bytesToRead = [currentRead readLengthForTermWithHint:estimatedBytesAvailable
+                                                     shouldPreBuffer:&readIntoPreBuffer];
+            }
+            else
+            {
+                // Read type #1 or #2
+                
+                bytesToRead = [currentRead readLengthForNonTermWithHint:estimatedBytesAvailable];
+            }
+            
+            if (bytesToRead > SIZE_MAX) { // NSUInteger may be bigger than size_t (read param 3)
+                bytesToRead = SIZE_MAX;
+            }
+            
+            // Make sure we have enough room in the buffer for our read.
+            //
+            // We are either reading directly into the currentRead->buffer,
+            // or we're reading into the temporary preBuffer.
+            
+            if (readIntoPreBuffer)
+            {
+                [preBuffer ensureCapacityForWrite:bytesToRead];
+                
+                buffer = [preBuffer writeBuffer];
+            }
+            else
+            {
+                [currentRead ensureCapacityForAdditionalDataOfLength:bytesToRead];
+                
+                buffer = (uint8_t *)[currentRead->buffer mutableBytes]
+                + currentRead->startOffset
+                + currentRead->bytesDone;
+            }
+            
+            // Read data into buffer
+            
+            int socketFD = (socket4FD == SOCKET_NULL) ? socket6FD : socket4FD;
+            
+            ssize_t result = read(socketFD, buffer, (size_t)bytesToRead);
+            LogVerbose(@"read from socket = %i", (int)result);
+            
+            if (result < 0)
+            {
+                if (errno == EWOULDBLOCK)
+                    waiting = YES;
+                else
+                    error = [self errnoErrorWithReason:@"Error in read() function"];
+                
+                socketFDBytesAvailable = 0;
+            }
+            else if (result == 0)
+            {
+                socketEOF = YES;
+                socketFDBytesAvailable = 0;
+            }
+            else
+            {
+                bytesRead = result;
+                
+                if (bytesRead < bytesToRead)
+                {
+                    // The read returned less data than requested.
+                    // This means socketFDBytesAvailable was a bit off due to timing,
+                    // because we read from the socket right when the readSource event was firing.
+                    socketFDBytesAvailable = 0;
+                }
+                else
+                {
+                    if (socketFDBytesAvailable <= bytesRead)
+                        socketFDBytesAvailable = 0;
+                    else
+                        socketFDBytesAvailable -= bytesRead;
+                }
+                
+                if (socketFDBytesAvailable == 0)
+                {
+                    waiting = YES;
+                }
+            }
+        }
+        
+        if (bytesRead > 0)
+        {
+            // Check to see if the read operation is done
+            
+            if (currentRead->readLength > 0)
+            {
+                // Read type #2 - read a specific length of data
+                //
+                // Note: We should never be using a prebuffer when we're reading a specific length of data.
+                
+                NSAssert(readIntoPreBuffer == NO, @"Invalid logic");
+                
+                currentRead->bytesDone += bytesRead;
+                totalBytesReadForCurrentRead += bytesRead;
+                
+                done = (currentRead->bytesDone == currentRead->readLength);
+            }
+            else if (currentRead->term != nil)
+            {
+                // Read type #3 - read up to a terminator
+                
+                if (readIntoPreBuffer)
+                {
+                    // We just read a big chunk of data into the preBuffer
+                    
+                    [preBuffer didWrite:bytesRead];
+                    LogVerbose(@"read data into preBuffer - preBuffer.length = %zu", [preBuffer availableBytes]);
+                    
+                    // Search for the terminating sequence
+                    
+                    NSUInteger bytesToCopy = [currentRead readLengthForTermWithPreBuffer:preBuffer found:&done];
+                    LogVerbose(@"copying %lu bytes from preBuffer", (unsigned long)bytesToCopy);
+                    
+                    // Ensure there's room on the read packet's buffer
+                    
+                    [currentRead ensureCapacityForAdditionalDataOfLength:bytesToCopy];
+                    
+                    // Copy bytes from prebuffer into read buffer
+                    
+                    uint8_t *readBuf = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset
+                    + currentRead->bytesDone;
+                    
+                    memcpy(readBuf, [preBuffer readBuffer], bytesToCopy);
+                    
+                    // Remove the copied bytes from the prebuffer
+                    [preBuffer didRead:bytesToCopy];
+                    LogVerbose(@"preBuffer.length = %zu", [preBuffer availableBytes]);
+                    
+                    // Update totals
+                    currentRead->bytesDone += bytesToCopy;
+                    totalBytesReadForCurrentRead += bytesToCopy;
+                    
+                    // Our 'done' variable was updated via the readLengthForTermWithPreBuffer:found: method above
+                }
+                else
+                {
+                    // We just read a big chunk of data directly into the packet's buffer.
+                    // We need to move any overflow into the prebuffer.
+                    
+                    NSInteger overflow = [currentRead searchForTermAfterPreBuffering:bytesRead];
+                    
+                    if (overflow == 0)
+                    {
+                        // Perfect match!
+                        // Every byte we read stays in the read buffer,
+                        // and the last byte we read was the last byte of the term.
+                        
+                        currentRead->bytesDone += bytesRead;
+                        totalBytesReadForCurrentRead += bytesRead;
+                        done = YES;
+                    }
+                    else if (overflow > 0)
+                    {
+                        // The term was found within the data that we read,
+                        // and there are extra bytes that extend past the end of the term.
+                        // We need to move these excess bytes out of the read packet and into the prebuffer.
+                        
+                        NSInteger underflow = bytesRead - overflow;
+                        
+                        // Copy excess data into preBuffer
+                        
+                        LogVerbose(@"copying %ld overflow bytes into preBuffer", (long)overflow);
+                        [preBuffer ensureCapacityForWrite:overflow];
+                        
+                        uint8_t *overflowBuffer = buffer + underflow;
+                        memcpy([preBuffer writeBuffer], overflowBuffer, overflow);
+                        
+                        [preBuffer didWrite:overflow];
+                        LogVerbose(@"preBuffer.length = %zu", [preBuffer availableBytes]);
+                        
+                        // Note: The completeCurrentRead method will trim the buffer for us.
+                        
+                        currentRead->bytesDone += underflow;
+                        totalBytesReadForCurrentRead += underflow;
+                        done = YES;
+                    }
+                    else
+                    {
+                        // The term was not found within the data that we read.
+                        
+                        currentRead->bytesDone += bytesRead;
+                        totalBytesReadForCurrentRead += bytesRead;
+                        done = NO;
+                    }
+                }
+                
+                if (!done && currentRead->maxLength > 0)
+                {
+                    // We're not done and there's a set maxLength.
+                    // Have we reached that maxLength yet?
+                    
+                    if (currentRead->bytesDone >= currentRead->maxLength)
+                    {
+                        error = [self readMaxedOutError];
+                    }
+                }
+            }
+            else
+            {
+                // Read type #1 - read all available data
+                
+                if (readIntoPreBuffer)
+                {
+                    // We just read a chunk of data into the preBuffer
+                    
+                    [preBuffer didWrite:bytesRead];
+                    
+                    // Now copy the data into the read packet.
+                    //
+                    // Recall that we didn't read directly into the packet's buffer to avoid
+                    // over-allocating memory since we had no clue how much data was available to be read.
+                    //
+                    // Ensure there's room on the read packet's buffer
+                    
+                    [currentRead ensureCapacityForAdditionalDataOfLength:bytesRead];
+                    
+                    // Copy bytes from prebuffer into read buffer
+                    
+                    uint8_t *readBuf = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset
+                    + currentRead->bytesDone;
+                    
+                    memcpy(readBuf, [preBuffer readBuffer], bytesRead);
+                    
+                    // Remove the copied bytes from the prebuffer
+                    [preBuffer didRead:bytesRead];
+                    
+                    // Update totals
+                    currentRead->bytesDone += bytesRead;
+                    totalBytesReadForCurrentRead += bytesRead;
+                }
+                else
+                {
+                    currentRead->bytesDone += bytesRead;
+                    totalBytesReadForCurrentRead += bytesRead;
+                }
+                
+                done = YES;
+            }
+            
+        } // if (bytesRead > 0)
+        
+    } // if (!done && !error && !socketEOF && hasBytesAvailable)
+    
+    
+    if (!done && currentRead->readLength == 0 && currentRead->term == nil)
+    {
+        // Read type #1 - read all available data
+        //
+        // We might arrive here if we read data from the prebuffer but not from the socket.
+        
+        done = (totalBytesReadForCurrentRead > 0);
+    }
+    
+    // Check to see if we're done, or if we've made progress
+    
+    if (done)
+    {
+        [self completeCurrentRead];
+        
+        if (!error && (!socketEOF || [preBuffer availableBytes] > 0))
+        {
+            [self maybeDequeueRead];
+        }
+    }
+    else if (totalBytesReadForCurrentRead > 0)
+    {
+        // We're not done read type #2 or #3 yet, but we have read in some bytes
+        
+        __strong id theDelegate = delegate;
+        
+        if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didReadPartialDataOfLength:tag:)])
+        {
+            long theReadTag = currentRead->tag;
+            
+            dispatch_async(delegateQueue, ^{ @autoreleasepool {
+                
+                [theDelegate socket:self didReadPartialDataOfLength:totalBytesReadForCurrentRead tag:theReadTag];
+            }});
+        }
+    }
+    
+    // Check for errors
+    
+    if (error)
+    {
+        [self closeWithError:error];
+    }
+    else if (socketEOF)
+    {
+        [self doReadEOF];
+    }
+    else if (waiting)
+    {
+        if (![self usingCFStreamForTLS])
+        {
+            // Monitor the socket for readability (if we're not already doing so)
+            [self resumeReadSource];
+        }
+    }
+    
+    // Do not add any code here without first adding return statements in the error cases above.
 }
 
 - (void)doReadEOF
 {
-	LogTrace();
-	
-	// This method may be called more than once.
-	// If the EOF is read while there is still data in the preBuffer,
-	// then this method may be called continually after invocations of doReadData to see if it's time to disconnect.
-	
-	flags |= kSocketHasReadEOF;
-	
-	if (flags & kSocketSecure)
-	{
-		// If the SSL layer has any buffered data, flush it into the preBuffer now.
-		
-		[self flushSSLBuffers];
-	}
-	
-	BOOL shouldDisconnect = NO;
-	NSError *error = nil;
-	
-	if ((flags & kStartingReadTLS) || (flags & kStartingWriteTLS))
-	{
-		// We received an EOF during or prior to startTLS.
-		// The SSL/TLS handshake is now impossible, so this is an unrecoverable situation.
-		
-		shouldDisconnect = YES;
-		
-		if ([self usingSecureTransportForTLS])
-		{
-			#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-			error = [self sslError:errSSLClosedAbort];
-			#endif
-		}
-	}
-	else if (flags & kReadStreamClosed)
-	{
-		// The preBuffer has already been drained.
-		// The config allows half-duplex connections.
-		// We've previously checked the socket, and it appeared writeable.
-		// So we marked the read stream as closed and notified the delegate.
-		// 
-		// As per the half-duplex contract, the socket will be closed when a write fails,
-		// or when the socket is manually closed.
-		
-		shouldDisconnect = NO;
-	}
-	else if ([preBuffer availableBytes] > 0)
-	{
-		LogVerbose(@"Socket reached EOF, but there is still data available in prebuffer");
-		
-		// Although we won't be able to read any more data from the socket,
-		// there is existing data that has been prebuffered that we can read.
-		
-		shouldDisconnect = NO;
-	}
-	else if (config & kAllowHalfDuplexConnection)
-	{
-		// We just received an EOF (end of file) from the socket's read stream.
-		// This means the remote end of the socket (the peer we're connected to)
-		// has explicitly stated that it will not be sending us any more data.
-		// 
-		// Query the socket to see if it is still writeable. (Perhaps the peer will continue reading data from us)
-		
-		int socketFD = (socket4FD == SOCKET_NULL) ? socket6FD : socket4FD;
-		
-		struct pollfd pfd[1];
-		pfd[0].fd = socketFD;
-		pfd[0].events = POLLOUT;
-		pfd[0].revents = 0;
-		
-		poll(pfd, 1, 0);
-		
-		if (pfd[0].revents & POLLOUT)
-		{
-			// Socket appears to still be writeable
-			
-			shouldDisconnect = NO;
-			flags |= kReadStreamClosed;
-			
-			// Notify the delegate that we're going half-duplex
-			
-			__strong id theDelegate = delegate;
-
-			if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidCloseReadStream:)])
-			{
-				dispatch_async(delegateQueue, ^{ @autoreleasepool {
-					
-					[theDelegate socketDidCloseReadStream:self];
-				}});
-			}
-		}
-		else
-		{
-			shouldDisconnect = YES;
-		}
-	}
-	else
-	{
-		shouldDisconnect = YES;
-	}
-	
-	
-	if (shouldDisconnect)
-	{
-		if (error == nil)
-		{
-			#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-				if ([self usingSecureTransportForTLS])
-				{
-					if (sslErrCode != noErr && sslErrCode != errSSLClosedGraceful)
-					{
-						error = [self sslError:sslErrCode];
-					}
-					else
-					{
-						error = [self connectionClosedError];
-					}
-				}
-				else
-				{
-					error = [self connectionClosedError];
-				}
-			#else
-					error = [self connectionClosedError];
-			#endif
-		}
-		[self closeWithError:error];
-	}
-	else
-	{
-		if (![self usingCFStreamForTLS])
-		{
-			// Suspend the read source (if needed)
-			
-			[self suspendReadSource];
-		}
-	}
+    LogTrace();
+    
+    // This method may be called more than once.
+    // If the EOF is read while there is still data in the preBuffer,
+    // then this method may be called continually after invocations of doReadData to see if it's time to disconnect.
+    
+    flags |= kSocketHasReadEOF;
+    
+    if (flags & kSocketSecure)
+    {
+        // If the SSL layer has any buffered data, flush it into the preBuffer now.
+        
+        [self flushSSLBuffers];
+    }
+    
+    BOOL shouldDisconnect = NO;
+    NSError *error = nil;
+    
+    if ((flags & kStartingReadTLS) || (flags & kStartingWriteTLS))
+    {
+        // We received an EOF during or prior to startTLS.
+        // The SSL/TLS handshake is now impossible, so this is an unrecoverable situation.
+        
+        shouldDisconnect = YES;
+        
+        if ([self usingSecureTransportForTLS])
+        {
+            error = [self sslError:errSSLClosedAbort];
+        }
+    }
+    else if (flags & kReadStreamClosed)
+    {
+        // The preBuffer has already been drained.
+        // The config allows half-duplex connections.
+        // We've previously checked the socket, and it appeared writeable.
+        // So we marked the read stream as closed and notified the delegate.
+        //
+        // As per the half-duplex contract, the socket will be closed when a write fails,
+        // or when the socket is manually closed.
+        
+        shouldDisconnect = NO;
+    }
+    else if ([preBuffer availableBytes] > 0)
+    {
+        LogVerbose(@"Socket reached EOF, but there is still data available in prebuffer");
+        
+        // Although we won't be able to read any more data from the socket,
+        // there is existing data that has been prebuffered that we can read.
+        
+        shouldDisconnect = NO;
+    }
+    else if (config & kAllowHalfDuplexConnection)
+    {
+        // We just received an EOF (end of file) from the socket's read stream.
+        // This means the remote end of the socket (the peer we're connected to)
+        // has explicitly stated that it will not be sending us any more data.
+        //
+        // Query the socket to see if it is still writeable. (Perhaps the peer will continue reading data from us)
+        
+        int socketFD = (socket4FD == SOCKET_NULL) ? socket6FD : socket4FD;
+        
+        struct pollfd pfd[1];
+        pfd[0].fd = socketFD;
+        pfd[0].events = POLLOUT;
+        pfd[0].revents = 0;
+        
+        poll(pfd, 1, 0);
+        
+        if (pfd[0].revents & POLLOUT)
+        {
+            // Socket appears to still be writeable
+            
+            shouldDisconnect = NO;
+            flags |= kReadStreamClosed;
+            
+            // Notify the delegate that we're going half-duplex
+            
+            __strong id theDelegate = delegate;
+            
+            if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidCloseReadStream:)])
+            {
+                dispatch_async(delegateQueue, ^{ @autoreleasepool {
+                    
+                    [theDelegate socketDidCloseReadStream:self];
+                }});
+            }
+        }
+        else
+        {
+            shouldDisconnect = YES;
+        }
+    }
+    else
+    {
+        shouldDisconnect = YES;
+    }
+    
+    
+    if (shouldDisconnect)
+    {
+        if (error == nil)
+        {
+            if ([self usingSecureTransportForTLS])
+            {
+                if (sslErrCode != noErr && sslErrCode != errSSLClosedGraceful)
+                {
+                    error = [self sslError:sslErrCode];
+                }
+                else
+                {
+                    error = [self connectionClosedError];
+                }
+            }
+            else
+            {
+                error = [self connectionClosedError];
+            }
+        }
+        [self closeWithError:error];
+    }
+    else
+    {
+        if (![self usingCFStreamForTLS])
+        {
+            // Suspend the read source (if needed)
+            
+            [self suspendReadSource];
+        }
+    }
 }
 
 - (void)completeCurrentRead
 {
-	LogTrace();
-	
-	NSAssert(currentRead, @"Trying to complete current read when there is no current read.");
-	
-	
-	NSData *result = nil;
-	
-	if (currentRead->bufferOwner)
-	{
-		// We created the buffer on behalf of the user.
-		// Trim our buffer to be the proper size.
-		[currentRead->buffer setLength:currentRead->bytesDone];
-		
-		result = currentRead->buffer;
-	}
-	else
-	{
-		// We did NOT create the buffer.
-		// The buffer is owned by the caller.
-		// Only trim the buffer if we had to increase its size.
-		
-		if ([currentRead->buffer length] > currentRead->originalBufferLength)
-		{
-			NSUInteger readSize = currentRead->startOffset + currentRead->bytesDone;
-			NSUInteger origSize = currentRead->originalBufferLength;
-			
-			NSUInteger buffSize = MAX(readSize, origSize);
-			
-			[currentRead->buffer setLength:buffSize];
-		}
-		
-		uint8_t *buffer = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset;
-		
-		result = [NSData dataWithBytesNoCopy:buffer length:currentRead->bytesDone freeWhenDone:NO];
-	}
-	
-	__strong id theDelegate = delegate;
-
-	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didReadData:withTag:)])
-	{
-		GCDAsyncReadPacket *theRead = currentRead; // Ensure currentRead retained since result may not own buffer
-		
-		dispatch_async(delegateQueue, ^{ @autoreleasepool {
-			
-			[theDelegate socket:self didReadData:result withTag:theRead->tag];
-		}});
-	}
-	
-	[self endCurrentRead];
+    LogTrace();
+    
+    NSAssert(currentRead, @"Trying to complete current read when there is no current read.");
+    
+    
+    NSData *result = nil;
+    
+    if (currentRead->bufferOwner)
+    {
+        // We created the buffer on behalf of the user.
+        // Trim our buffer to be the proper size.
+        [currentRead->buffer setLength:currentRead->bytesDone];
+        
+        result = currentRead->buffer;
+    }
+    else
+    {
+        // We did NOT create the buffer.
+        // The buffer is owned by the caller.
+        // Only trim the buffer if we had to increase its size.
+        
+        if ([currentRead->buffer length] > currentRead->originalBufferLength)
+        {
+            NSUInteger readSize = currentRead->startOffset + currentRead->bytesDone;
+            NSUInteger origSize = currentRead->originalBufferLength;
+            
+            NSUInteger buffSize = MAX(readSize, origSize);
+            
+            [currentRead->buffer setLength:buffSize];
+        }
+        
+        uint8_t *buffer = (uint8_t *)[currentRead->buffer mutableBytes] + currentRead->startOffset;
+        
+        result = [NSData dataWithBytesNoCopy:buffer length:currentRead->bytesDone freeWhenDone:NO];
+    }
+    
+    __strong id theDelegate = delegate;
+    
+    if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didReadData:withTag:)])
+    {
+        GCDAsyncReadPacket *theRead = currentRead; // Ensure currentRead retained since result may not own buffer
+        
+        dispatch_async(delegateQueue, ^{ @autoreleasepool {
+            
+            [theDelegate socket:self didReadData:result withTag:theRead->tag];
+        }});
+    }
+    
+    [self endCurrentRead];
 }
 
 - (void)endCurrentRead
 {
-	if (readTimer)
-	{
-		dispatch_source_cancel(readTimer);
-		readTimer = NULL;
-	}
-	
-	currentRead = nil;
+    if (readTimer)
+    {
+        dispatch_source_cancel(readTimer);
+        readTimer = NULL;
+    }
+    
+    currentRead = nil;
 }
 
 - (void)setupReadTimerWithTimeout:(NSTimeInterval)timeout
 {
-	if (timeout >= 0.0)
-	{
-		readTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
-		
-		__weak GCDAsyncSocket *weakSelf = self;
-		
-		dispatch_source_set_event_handler(readTimer, ^{ @autoreleasepool {
-		#pragma clang diagnostic push
-		#pragma clang diagnostic warning "-Wimplicit-retain-self"
-			
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
-			if (strongSelf == nil) return_from_block;
-			
-			[strongSelf doReadTimeout];
-			
-		#pragma clang diagnostic pop
-		}});
-		
-		#if !OS_OBJECT_USE_OBJC
-		dispatch_source_t theReadTimer = readTimer;
-		dispatch_source_set_cancel_handler(readTimer, ^{
-		#pragma clang diagnostic push
-		#pragma clang diagnostic warning "-Wimplicit-retain-self"
-			
-			LogVerbose(@"dispatch_release(readTimer)");
-			dispatch_release(theReadTimer);
-			
-		#pragma clang diagnostic pop
-		});
-		#endif
-		
-		dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
-		
-		dispatch_source_set_timer(readTimer, tt, DISPATCH_TIME_FOREVER, 0);
-		dispatch_resume(readTimer);
-	}
+    if (timeout >= 0.0)
+    {
+        readTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
+        
+        __weak GCDAsyncSocket *weakSelf = self;
+        
+        dispatch_source_set_event_handler(readTimer, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+            
+            __strong GCDAsyncSocket *strongSelf = weakSelf;
+            if (strongSelf == nil) return_from_block;
+            
+            [strongSelf doReadTimeout];
+            
+#pragma clang diagnostic pop
+        }});
+        
+#if !OS_OBJECT_USE_OBJC
+        dispatch_source_t theReadTimer = readTimer;
+        dispatch_source_set_cancel_handler(readTimer, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+            
+            LogVerbose(@"dispatch_release(readTimer)");
+            dispatch_release(theReadTimer);
+            
+#pragma clang diagnostic pop
+        });
+#endif
+        
+        dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
+        
+        dispatch_source_set_timer(readTimer, tt, DISPATCH_TIME_FOREVER, 0);
+        dispatch_resume(readTimer);
+    }
 }
 
 - (void)doReadTimeout
 {
-	// This is a little bit tricky.
-	// Ideally we'd like to synchronously query the delegate about a timeout extension.
-	// But if we do so synchronously we risk a possible deadlock.
-	// So instead we have to do so asynchronously, and callback to ourselves from within the delegate block.
-	
-	flags |= kReadsPaused;
-	
-	__strong id theDelegate = delegate;
-
-	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:shouldTimeoutReadWithTag:elapsed:bytesDone:)])
-	{
-		GCDAsyncReadPacket *theRead = currentRead;
-		
-		dispatch_async(delegateQueue, ^{ @autoreleasepool {
-			
-			NSTimeInterval timeoutExtension = 0.0;
-			
-			timeoutExtension = [theDelegate socket:self shouldTimeoutReadWithTag:theRead->tag
-			                                                             elapsed:theRead->timeout
-			                                                           bytesDone:theRead->bytesDone];
-			
-			dispatch_async(socketQueue, ^{ @autoreleasepool {
-				
-				[self doReadTimeoutWithExtension:timeoutExtension];
-			}});
-		}});
-	}
-	else
-	{
-		[self doReadTimeoutWithExtension:0.0];
-	}
+    // This is a little bit tricky.
+    // Ideally we'd like to synchronously query the delegate about a timeout extension.
+    // But if we do so synchronously we risk a possible deadlock.
+    // So instead we have to do so asynchronously, and callback to ourselves from within the delegate block.
+    
+    flags |= kReadsPaused;
+    
+    __strong id theDelegate = delegate;
+    
+    if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:shouldTimeoutReadWithTag:elapsed:bytesDone:)])
+    {
+        GCDAsyncReadPacket *theRead = currentRead;
+        
+        dispatch_async(delegateQueue, ^{ @autoreleasepool {
+            
+            NSTimeInterval timeoutExtension = 0.0;
+            
+            timeoutExtension = [theDelegate socket:self shouldTimeoutReadWithTag:theRead->tag
+                                           elapsed:theRead->timeout
+                                         bytesDone:theRead->bytesDone];
+            
+            dispatch_async(socketQueue, ^{ @autoreleasepool {
+                
+                [self doReadTimeoutWithExtension:timeoutExtension];
+            }});
+        }});
+    }
+    else
+    {
+        [self doReadTimeoutWithExtension:0.0];
+    }
 }
 
 - (void)doReadTimeoutWithExtension:(NSTimeInterval)timeoutExtension
 {
-	if (currentRead)
-	{
-		if (timeoutExtension > 0.0)
-		{
-			currentRead->timeout += timeoutExtension;
-			
-			// Reschedule the timer
-			dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeoutExtension * NSEC_PER_SEC));
-			dispatch_source_set_timer(readTimer, tt, DISPATCH_TIME_FOREVER, 0);
-			
-			// Unpause reads, and continue
-			flags &= ~kReadsPaused;
-			[self doReadData];
-		}
-		else
-		{
-			LogVerbose(@"ReadTimeout");
-			
-			[self closeWithError:[self readTimeoutError]];
-		}
-	}
+    if (currentRead)
+    {
+        if (timeoutExtension > 0.0)
+        {
+            currentRead->timeout += timeoutExtension;
+            
+            // Reschedule the timer
+            dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeoutExtension * NSEC_PER_SEC));
+            dispatch_source_set_timer(readTimer, tt, DISPATCH_TIME_FOREVER, 0);
+            
+            // Unpause reads, and continue
+            flags &= ~kReadsPaused;
+            [self doReadData];
+        }
+        else
+        {
+            LogVerbose(@"ReadTimeout");
+            
+            [self closeWithError:[self readTimeoutError]];
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -5097,649 +5139,641 @@ enum GCDAsyncSocketConfig
 
 - (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag
 {
-	if ([data length] == 0) return;
-	
-	GCDAsyncWritePacket *packet = [[GCDAsyncWritePacket alloc] initWithData:data timeout:timeout tag:tag];
-	
-	dispatch_async(socketQueue, ^{ @autoreleasepool {
-		
-		LogTrace();
-		
-		if ((flags & kSocketStarted) && !(flags & kForbidReadsWrites))
-		{
-			[writeQueue addObject:packet];
-			[self maybeDequeueWrite];
-		}
-	}});
-	
-	// Do not rely on the block being run in order to release the packet,
-	// as the queue might get released without the block completing.
+    if ([data length] == 0) return;
+    
+    GCDAsyncWritePacket *packet = [[GCDAsyncWritePacket alloc] initWithData:data timeout:timeout tag:tag];
+    
+    dispatch_async(socketQueue, ^{ @autoreleasepool {
+        
+        LogTrace();
+        
+        if ((flags & kSocketStarted) && !(flags & kForbidReadsWrites))
+        {
+            [writeQueue addObject:packet];
+            [self maybeDequeueWrite];
+        }
+    }});
+    
+    // Do not rely on the block being run in order to release the packet,
+    // as the queue might get released without the block completing.
 }
 
 - (float)progressOfWriteReturningTag:(long *)tagPtr bytesDone:(NSUInteger *)donePtr total:(NSUInteger *)totalPtr
 {
-	__block float result = 0.0F;
-	
-	dispatch_block_t block = ^{
-		
-		if (!currentWrite || ![currentWrite isKindOfClass:[GCDAsyncWritePacket class]])
-		{
-			// We're not writing anything right now.
-			
-			if (tagPtr != NULL)   *tagPtr = 0;
-			if (donePtr != NULL)  *donePtr = 0;
-			if (totalPtr != NULL) *totalPtr = 0;
-			
-			result = NAN;
-		}
-		else
-		{
-			NSUInteger done = currentWrite->bytesDone;
-			NSUInteger total = [currentWrite->buffer length];
-			
-			if (tagPtr != NULL)   *tagPtr = currentWrite->tag;
-			if (donePtr != NULL)  *donePtr = done;
-			if (totalPtr != NULL) *totalPtr = total;
-			
-			result = (float)done / (float)total;
-		}
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
-	
-	return result;
+    __block float result = 0.0F;
+    
+    dispatch_block_t block = ^{
+        
+        if (!currentWrite || ![currentWrite isKindOfClass:[GCDAsyncWritePacket class]])
+        {
+            // We're not writing anything right now.
+            
+            if (tagPtr != NULL)   *tagPtr = 0;
+            if (donePtr != NULL)  *donePtr = 0;
+            if (totalPtr != NULL) *totalPtr = 0;
+            
+            result = NAN;
+        }
+        else
+        {
+            NSUInteger done = currentWrite->bytesDone;
+            NSUInteger total = [currentWrite->buffer length];
+            
+            if (tagPtr != NULL)   *tagPtr = currentWrite->tag;
+            if (donePtr != NULL)  *donePtr = done;
+            if (totalPtr != NULL) *totalPtr = total;
+            
+            result = (float)done / (float)total;
+        }
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
+    
+    return result;
 }
 
 /**
  * Conditionally starts a new write.
- * 
+ *
  * It is called when:
  * - a user requests a write
  * - after a write request has finished (to handle the next request)
  * - immediately after the socket opens to handle any pending requests
- * 
+ *
  * This method also handles auto-disconnect post read/write completion.
-**/
+ **/
 - (void)maybeDequeueWrite
 {
-	LogTrace();
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	
-	// If we're not currently processing a write AND we have an available write stream
-	if ((currentWrite == nil) && (flags & kConnected))
-	{
-		if ([writeQueue count] > 0)
-		{
-			// Dequeue the next object in the write queue
-			currentWrite = [writeQueue objectAtIndex:0];
-			[writeQueue removeObjectAtIndex:0];
-			
-			
-			if ([currentWrite isKindOfClass:[GCDAsyncSpecialPacket class]])
-			{
-				LogVerbose(@"Dequeued GCDAsyncSpecialPacket");
-				
-				// Attempt to start TLS
-				flags |= kStartingWriteTLS;
-				
-				// This method won't do anything unless both kStartingReadTLS and kStartingWriteTLS are set
-				[self maybeStartTLS];
-			}
-			else
-			{
-				LogVerbose(@"Dequeued GCDAsyncWritePacket");
-				
-				// Setup write timer (if needed)
-				[self setupWriteTimerWithTimeout:currentWrite->timeout];
-				
-				// Immediately write, if possible
-				[self doWriteData];
-			}
-		}
-		else if (flags & kDisconnectAfterWrites)
-		{
-			if (flags & kDisconnectAfterReads)
-			{
-				if (([readQueue count] == 0) && (currentRead == nil))
-				{
-					[self closeWithError:nil];
-				}
-			}
-			else
-			{
-				[self closeWithError:nil];
-			}
-		}
-	}
+    LogTrace();
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    
+    // If we're not currently processing a write AND we have an available write stream
+    if ((currentWrite == nil) && (flags & kConnected))
+    {
+        if ([writeQueue count] > 0)
+        {
+            // Dequeue the next object in the write queue
+            currentWrite = [writeQueue objectAtIndex:0];
+            [writeQueue removeObjectAtIndex:0];
+            
+            
+            if ([currentWrite isKindOfClass:[GCDAsyncSpecialPacket class]])
+            {
+                LogVerbose(@"Dequeued GCDAsyncSpecialPacket");
+                
+                // Attempt to start TLS
+                flags |= kStartingWriteTLS;
+                
+                // This method won't do anything unless both kStartingReadTLS and kStartingWriteTLS are set
+                [self maybeStartTLS];
+            }
+            else
+            {
+                LogVerbose(@"Dequeued GCDAsyncWritePacket");
+                
+                // Setup write timer (if needed)
+                [self setupWriteTimerWithTimeout:currentWrite->timeout];
+                
+                // Immediately write, if possible
+                [self doWriteData];
+            }
+        }
+        else if (flags & kDisconnectAfterWrites)
+        {
+            if (flags & kDisconnectAfterReads)
+            {
+                if (([readQueue count] == 0) && (currentRead == nil))
+                {
+                    [self closeWithError:nil];
+                }
+            }
+            else
+            {
+                [self closeWithError:nil];
+            }
+        }
+    }
 }
 
 - (void)doWriteData
 {
-	LogTrace();
-	
-	// This method is called by the writeSource via the socketQueue
-	
-	if ((currentWrite == nil) || (flags & kWritesPaused))
-	{
-		LogVerbose(@"No currentWrite or kWritesPaused");
-		
-		// Unable to write at this time
-		
-		if ([self usingCFStreamForTLS])
-		{
-			// CFWriteStream only fires once when there is available data.
-			// It won't fire again until we've invoked CFWriteStreamWrite.
-		}
-		else
-		{
-			// If the writeSource is firing, we need to pause it
-			// or else it will continue to fire over and over again.
-			
-			if (flags & kSocketCanAcceptBytes)
-			{
-				[self suspendWriteSource];
-			}
-		}
-		return;
-	}
-	
-	if (!(flags & kSocketCanAcceptBytes))
-	{
-		LogVerbose(@"No space available to write...");
-		
-		// No space available to write.
-		
-		if (![self usingCFStreamForTLS])
-		{
-			// Need to wait for writeSource to fire and notify us of
-			// available space in the socket's internal write buffer.
-			
-			[self resumeWriteSource];
-		}
-		return;
-	}
-	
-	if (flags & kStartingWriteTLS)
-	{
-		LogVerbose(@"Waiting for SSL/TLS handshake to complete");
-		
-		// The writeQueue is waiting for SSL/TLS handshake to complete.
-		
-		if (flags & kStartingReadTLS)
-		{
-			if ([self usingSecureTransportForTLS])
-			{
-				#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-			
-				// We are in the process of a SSL Handshake.
-				// We were waiting for available space in the socket's internal OS buffer to continue writing.
-			
-				[self ssl_continueSSLHandshake];
-			
-				#endif
-			}
-		}
-		else
-		{
-			// We are still waiting for the readQueue to drain and start the SSL/TLS process.
-			// We now know we can write to the socket.
-			
-			if (![self usingCFStreamForTLS])
-			{
-				// Suspend the write source or else it will continue to fire nonstop.
-				
-				[self suspendWriteSource];
-			}
-		}
-		
-		return;
-	}
-	
-	// Note: This method is not called if currentWrite is a GCDAsyncSpecialPacket (startTLS packet)
-	
-	BOOL waiting = NO;
-	NSError *error = nil;
-	size_t bytesWritten = 0;
-	
-	if (flags & kSocketSecure)
-	{
-		if ([self usingCFStreamForTLS])
-		{
-			#if TARGET_OS_IPHONE
-			
-			// 
-			// Writing data using CFStream (over internal TLS)
-			// 
-			
-			const uint8_t *buffer = (const uint8_t *)[currentWrite->buffer bytes] + currentWrite->bytesDone;
-			
-			NSUInteger bytesToWrite = [currentWrite->buffer length] - currentWrite->bytesDone;
-			
-			if (bytesToWrite > SIZE_MAX) // NSUInteger may be bigger than size_t (write param 3)
-			{
-				bytesToWrite = SIZE_MAX;
-			}
-		
-			CFIndex result = CFWriteStreamWrite(writeStream, buffer, (CFIndex)bytesToWrite);
-			LogVerbose(@"CFWriteStreamWrite(%lu) = %li", (unsigned long)bytesToWrite, result);
-		
-			if (result < 0)
-			{
-				error = (__bridge_transfer NSError *)CFWriteStreamCopyError(writeStream);
-			}
-			else
-			{
-				bytesWritten = (size_t)result;
-				
-				// We always set waiting to true in this scenario.
-				// CFStream may have altered our underlying socket to non-blocking.
-				// Thus if we attempt to write without a callback, we may end up blocking our queue.
-				waiting = YES;
-			}
-			
-			#endif
-		}
-		else
-		{
-			#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-			
-			// We're going to use the SSLWrite function.
-			// 
-			// OSStatus SSLWrite(SSLContextRef context, const void *data, size_t dataLength, size_t *processed)
-			// 
-			// Parameters:
-			// context     - An SSL session context reference.
-			// data        - A pointer to the buffer of data to write.
-			// dataLength  - The amount, in bytes, of data to write.
-			// processed   - On return, the length, in bytes, of the data actually written.
-			// 
-			// It sounds pretty straight-forward,
-			// but there are a few caveats you should be aware of.
-			// 
-			// The SSLWrite method operates in a non-obvious (and rather annoying) manner.
-			// According to the documentation:
-			// 
-			//   Because you may configure the underlying connection to operate in a non-blocking manner,
-			//   a write operation might return errSSLWouldBlock, indicating that less data than requested
-			//   was actually transferred. In this case, you should repeat the call to SSLWrite until some
-			//   other result is returned.
-			// 
-			// This sounds perfect, but when our SSLWriteFunction returns errSSLWouldBlock,
-			// then the SSLWrite method returns (with the proper errSSLWouldBlock return value),
-			// but it sets processed to dataLength !!
-			// 
-			// In other words, if the SSLWrite function doesn't completely write all the data we tell it to,
-			// then it doesn't tell us how many bytes were actually written. So, for example, if we tell it to
-			// write 256 bytes then it might actually write 128 bytes, but then report 0 bytes written.
-			// 
-			// You might be wondering:
-			// If the SSLWrite function doesn't tell us how many bytes were written,
-			// then how in the world are we supposed to update our parameters (buffer & bytesToWrite)
-			// for the next time we invoke SSLWrite?
-			// 
-			// The answer is that SSLWrite cached all the data we told it to write,
-			// and it will push out that data next time we call SSLWrite.
-			// If we call SSLWrite with new data, it will push out the cached data first, and then the new data.
-			// If we call SSLWrite with empty data, then it will simply push out the cached data.
-			// 
-			// For this purpose we're going to break large writes into a series of smaller writes.
-			// This allows us to report progress back to the delegate.
-			
-			OSStatus result;
-			
-			BOOL hasCachedDataToWrite = (sslWriteCachedLength > 0);
-			BOOL hasNewDataToWrite = YES;
-			
-			if (hasCachedDataToWrite)
-			{
-				size_t processed = 0;
-				
-				result = SSLWrite(sslContext, NULL, 0, &processed);
-				
-				if (result == noErr)
-				{
-					bytesWritten = sslWriteCachedLength;
-					sslWriteCachedLength = 0;
-					
-					if ([currentWrite->buffer length] == (currentWrite->bytesDone + bytesWritten))
-					{
-						// We've written all data for the current write.
-						hasNewDataToWrite = NO;
-					}
-				}
-				else
-				{
-					if (result == errSSLWouldBlock)
-					{
-						waiting = YES;
-					}
-					else
-					{
-						error = [self sslError:result];
-					}
-					
-					// Can't write any new data since we were unable to write the cached data.
-					hasNewDataToWrite = NO;
-				}
-			}
-			
-			if (hasNewDataToWrite)
-			{
-				const uint8_t *buffer = (const uint8_t *)[currentWrite->buffer bytes]
-				                                        + currentWrite->bytesDone
-				                                        + bytesWritten;
-				
-				NSUInteger bytesToWrite = [currentWrite->buffer length] - currentWrite->bytesDone - bytesWritten;
-				
-				if (bytesToWrite > SIZE_MAX) // NSUInteger may be bigger than size_t (write param 3)
-				{
-					bytesToWrite = SIZE_MAX;
-				}
-				
-				size_t bytesRemaining = bytesToWrite;
-				
-				BOOL keepLooping = YES;
-				while (keepLooping)
-				{
-					const size_t sslMaxBytesToWrite = 32768;
-					size_t sslBytesToWrite = MIN(bytesRemaining, sslMaxBytesToWrite);
-					size_t sslBytesWritten = 0;
-					
-					result = SSLWrite(sslContext, buffer, sslBytesToWrite, &sslBytesWritten);
-					
-					if (result == noErr)
-					{
-						buffer += sslBytesWritten;
-						bytesWritten += sslBytesWritten;
-						bytesRemaining -= sslBytesWritten;
-						
-						keepLooping = (bytesRemaining > 0);
-					}
-					else
-					{
-						if (result == errSSLWouldBlock)
-						{
-							waiting = YES;
-							sslWriteCachedLength = sslBytesToWrite;
-						}
-						else
-						{
-							error = [self sslError:result];
-						}
-						
-						keepLooping = NO;
-					}
-					
-				} // while (keepLooping)
-				
-			} // if (hasNewDataToWrite)
-		
-			#endif
-		}
-	}
-	else
-	{
-		// 
-		// Writing data directly over raw socket
-		// 
-		
-		int socketFD = (socket4FD == SOCKET_NULL) ? socket6FD : socket4FD;
-		
-		const uint8_t *buffer = (const uint8_t *)[currentWrite->buffer bytes] + currentWrite->bytesDone;
-		
-		NSUInteger bytesToWrite = [currentWrite->buffer length] - currentWrite->bytesDone;
-		
-		if (bytesToWrite > SIZE_MAX) // NSUInteger may be bigger than size_t (write param 3)
-		{
-			bytesToWrite = SIZE_MAX;
-		}
-		
-		ssize_t result = write(socketFD, buffer, (size_t)bytesToWrite);
-		LogVerbose(@"wrote to socket = %zd", result);
-		
-		// Check results
-		if (result < 0)
-		{
-			if (errno == EWOULDBLOCK)
-			{
-				waiting = YES;
-			}
-			else
-			{
-				error = [self errnoErrorWithReason:@"Error in write() function"];
-			}
-		}
-		else
-		{
-			bytesWritten = result;
-		}
-	}
-	
-	// We're done with our writing.
-	// If we explictly ran into a situation where the socket told us there was no room in the buffer,
-	// then we immediately resume listening for notifications.
-	// 
-	// We must do this before we dequeue another write,
-	// as that may in turn invoke this method again.
-	// 
-	// Note that if CFStream is involved, it may have maliciously put our socket in blocking mode.
-	
-	if (waiting)
-	{
-		flags &= ~kSocketCanAcceptBytes;
-		
-		if (![self usingCFStreamForTLS])
-		{
-			[self resumeWriteSource];
-		}
-	}
-	
-	// Check our results
-	
-	BOOL done = NO;
-	
-	if (bytesWritten > 0)
-	{
-		// Update total amount read for the current write
-		currentWrite->bytesDone += bytesWritten;
-		LogVerbose(@"currentWrite->bytesDone = %lu", (unsigned long)currentWrite->bytesDone);
-		
-		// Is packet done?
-		done = (currentWrite->bytesDone == [currentWrite->buffer length]);
-	}
-	
-	if (done)
-	{
-		[self completeCurrentWrite];
-		
-		if (!error)
-		{
-			dispatch_async(socketQueue, ^{ @autoreleasepool{
-				
-				[self maybeDequeueWrite];
-			}});
-		}
-	}
-	else
-	{
-		// We were unable to finish writing the data,
-		// so we're waiting for another callback to notify us of available space in the lower-level output buffer.
-		
-		if (!waiting && !error)
-		{
-			// This would be the case if our write was able to accept some data, but not all of it.
-			
-			flags &= ~kSocketCanAcceptBytes;
-			
-			if (![self usingCFStreamForTLS])
-			{
-				[self resumeWriteSource];
-			}
-		}
-		
-		if (bytesWritten > 0)
-		{
-			// We're not done with the entire write, but we have written some bytes
-			
-			__strong id theDelegate = delegate;
-
-			if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didWritePartialDataOfLength:tag:)])
-			{
-				long theWriteTag = currentWrite->tag;
-				
-				dispatch_async(delegateQueue, ^{ @autoreleasepool {
-					
-					[theDelegate socket:self didWritePartialDataOfLength:bytesWritten tag:theWriteTag];
-				}});
-			}
-		}
-	}
-	
-	// Check for errors
-	
-	if (error)
-	{
-		[self closeWithError:[self errnoErrorWithReason:@"Error in write() function"]];
-	}
-	
-	// Do not add any code here without first adding a return statement in the error case above.
+    LogTrace();
+    
+    // This method is called by the writeSource via the socketQueue
+    
+    if ((currentWrite == nil) || (flags & kWritesPaused))
+    {
+        LogVerbose(@"No currentWrite or kWritesPaused");
+        
+        // Unable to write at this time
+        
+        if ([self usingCFStreamForTLS])
+        {
+            // CFWriteStream only fires once when there is available data.
+            // It won't fire again until we've invoked CFWriteStreamWrite.
+        }
+        else
+        {
+            // If the writeSource is firing, we need to pause it
+            // or else it will continue to fire over and over again.
+            
+            if (flags & kSocketCanAcceptBytes)
+            {
+                [self suspendWriteSource];
+            }
+        }
+        return;
+    }
+    
+    if (!(flags & kSocketCanAcceptBytes))
+    {
+        LogVerbose(@"No space available to write...");
+        
+        // No space available to write.
+        
+        if (![self usingCFStreamForTLS])
+        {
+            // Need to wait for writeSource to fire and notify us of
+            // available space in the socket's internal write buffer.
+            
+            [self resumeWriteSource];
+        }
+        return;
+    }
+    
+    if (flags & kStartingWriteTLS)
+    {
+        LogVerbose(@"Waiting for SSL/TLS handshake to complete");
+        
+        // The writeQueue is waiting for SSL/TLS handshake to complete.
+        
+        if (flags & kStartingReadTLS)
+        {
+            if ([self usingSecureTransportForTLS])
+            {
+                // We are in the process of a SSL Handshake.
+                // We were waiting for available space in the socket's internal OS buffer to continue writing.
+                
+                [self ssl_continueSSLHandshake];
+            }
+        }
+        else
+        {
+            // We are still waiting for the readQueue to drain and start the SSL/TLS process.
+            // We now know we can write to the socket.
+            
+            if (![self usingCFStreamForTLS])
+            {
+                // Suspend the write source or else it will continue to fire nonstop.
+                
+                [self suspendWriteSource];
+            }
+        }
+        
+        return;
+    }
+    
+    // Note: This method is not called if currentWrite is a GCDAsyncSpecialPacket (startTLS packet)
+    
+    BOOL waiting = NO;
+    NSError *error = nil;
+    size_t bytesWritten = 0;
+    
+    if (flags & kSocketSecure)
+    {
+        if ([self usingCFStreamForTLS])
+        {
+#if TARGET_OS_IPHONE
+            
+            //
+            // Writing data using CFStream (over internal TLS)
+            //
+            
+            const uint8_t *buffer = (const uint8_t *)[currentWrite->buffer bytes] + currentWrite->bytesDone;
+            
+            NSUInteger bytesToWrite = [currentWrite->buffer length] - currentWrite->bytesDone;
+            
+            if (bytesToWrite > SIZE_MAX) // NSUInteger may be bigger than size_t (write param 3)
+            {
+                bytesToWrite = SIZE_MAX;
+            }
+            
+            CFIndex result = CFWriteStreamWrite(writeStream, buffer, (CFIndex)bytesToWrite);
+            LogVerbose(@"CFWriteStreamWrite(%lu) = %li", (unsigned long)bytesToWrite, result);
+            
+            if (result < 0)
+            {
+                error = (__bridge_transfer NSError *)CFWriteStreamCopyError(writeStream);
+            }
+            else
+            {
+                bytesWritten = (size_t)result;
+                
+                // We always set waiting to true in this scenario.
+                // CFStream may have altered our underlying socket to non-blocking.
+                // Thus if we attempt to write without a callback, we may end up blocking our queue.
+                waiting = YES;
+            }
+            
+#endif
+        }
+        else
+        {
+            // We're going to use the SSLWrite function.
+            //
+            // OSStatus SSLWrite(SSLContextRef context, const void *data, size_t dataLength, size_t *processed)
+            //
+            // Parameters:
+            // context     - An SSL session context reference.
+            // data        - A pointer to the buffer of data to write.
+            // dataLength  - The amount, in bytes, of data to write.
+            // processed   - On return, the length, in bytes, of the data actually written.
+            //
+            // It sounds pretty straight-forward,
+            // but there are a few caveats you should be aware of.
+            //
+            // The SSLWrite method operates in a non-obvious (and rather annoying) manner.
+            // According to the documentation:
+            //
+            //   Because you may configure the underlying connection to operate in a non-blocking manner,
+            //   a write operation might return errSSLWouldBlock, indicating that less data than requested
+            //   was actually transferred. In this case, you should repeat the call to SSLWrite until some
+            //   other result is returned.
+            //
+            // This sounds perfect, but when our SSLWriteFunction returns errSSLWouldBlock,
+            // then the SSLWrite method returns (with the proper errSSLWouldBlock return value),
+            // but it sets processed to dataLength !!
+            //
+            // In other words, if the SSLWrite function doesn't completely write all the data we tell it to,
+            // then it doesn't tell us how many bytes were actually written. So, for example, if we tell it to
+            // write 256 bytes then it might actually write 128 bytes, but then report 0 bytes written.
+            //
+            // You might be wondering:
+            // If the SSLWrite function doesn't tell us how many bytes were written,
+            // then how in the world are we supposed to update our parameters (buffer & bytesToWrite)
+            // for the next time we invoke SSLWrite?
+            //
+            // The answer is that SSLWrite cached all the data we told it to write,
+            // and it will push out that data next time we call SSLWrite.
+            // If we call SSLWrite with new data, it will push out the cached data first, and then the new data.
+            // If we call SSLWrite with empty data, then it will simply push out the cached data.
+            //
+            // For this purpose we're going to break large writes into a series of smaller writes.
+            // This allows us to report progress back to the delegate.
+            
+            OSStatus result;
+            
+            BOOL hasCachedDataToWrite = (sslWriteCachedLength > 0);
+            BOOL hasNewDataToWrite = YES;
+            
+            if (hasCachedDataToWrite)
+            {
+                size_t processed = 0;
+                
+                result = SSLWrite(sslContext, NULL, 0, &processed);
+                
+                if (result == noErr)
+                {
+                    bytesWritten = sslWriteCachedLength;
+                    sslWriteCachedLength = 0;
+                    
+                    if ([currentWrite->buffer length] == (currentWrite->bytesDone + bytesWritten))
+                    {
+                        // We've written all data for the current write.
+                        hasNewDataToWrite = NO;
+                    }
+                }
+                else
+                {
+                    if (result == errSSLWouldBlock)
+                    {
+                        waiting = YES;
+                    }
+                    else
+                    {
+                        error = [self sslError:result];
+                    }
+                    
+                    // Can't write any new data since we were unable to write the cached data.
+                    hasNewDataToWrite = NO;
+                }
+            }
+            
+            if (hasNewDataToWrite)
+            {
+                const uint8_t *buffer = (const uint8_t *)[currentWrite->buffer bytes]
+                + currentWrite->bytesDone
+                + bytesWritten;
+                
+                NSUInteger bytesToWrite = [currentWrite->buffer length] - currentWrite->bytesDone - bytesWritten;
+                
+                if (bytesToWrite > SIZE_MAX) // NSUInteger may be bigger than size_t (write param 3)
+                {
+                    bytesToWrite = SIZE_MAX;
+                }
+                
+                size_t bytesRemaining = bytesToWrite;
+                
+                BOOL keepLooping = YES;
+                while (keepLooping)
+                {
+                    const size_t sslMaxBytesToWrite = 32768;
+                    size_t sslBytesToWrite = MIN(bytesRemaining, sslMaxBytesToWrite);
+                    size_t sslBytesWritten = 0;
+                    
+                    result = SSLWrite(sslContext, buffer, sslBytesToWrite, &sslBytesWritten);
+                    
+                    if (result == noErr)
+                    {
+                        buffer += sslBytesWritten;
+                        bytesWritten += sslBytesWritten;
+                        bytesRemaining -= sslBytesWritten;
+                        
+                        keepLooping = (bytesRemaining > 0);
+                    }
+                    else
+                    {
+                        if (result == errSSLWouldBlock)
+                        {
+                            waiting = YES;
+                            sslWriteCachedLength = sslBytesToWrite;
+                        }
+                        else
+                        {
+                            error = [self sslError:result];
+                        }
+                        
+                        keepLooping = NO;
+                    }
+                    
+                } // while (keepLooping)
+                
+            } // if (hasNewDataToWrite)
+        }
+    }
+    else
+    {
+        //
+        // Writing data directly over raw socket
+        //
+        
+        int socketFD = (socket4FD == SOCKET_NULL) ? socket6FD : socket4FD;
+        
+        const uint8_t *buffer = (const uint8_t *)[currentWrite->buffer bytes] + currentWrite->bytesDone;
+        
+        NSUInteger bytesToWrite = [currentWrite->buffer length] - currentWrite->bytesDone;
+        
+        if (bytesToWrite > SIZE_MAX) // NSUInteger may be bigger than size_t (write param 3)
+        {
+            bytesToWrite = SIZE_MAX;
+        }
+        
+        ssize_t result = write(socketFD, buffer, (size_t)bytesToWrite);
+        LogVerbose(@"wrote to socket = %zd", result);
+        
+        // Check results
+        if (result < 0)
+        {
+            if (errno == EWOULDBLOCK)
+            {
+                waiting = YES;
+            }
+            else
+            {
+                error = [self errnoErrorWithReason:@"Error in write() function"];
+            }
+        }
+        else
+        {
+            bytesWritten = result;
+        }
+    }
+    
+    // We're done with our writing.
+    // If we explictly ran into a situation where the socket told us there was no room in the buffer,
+    // then we immediately resume listening for notifications.
+    //
+    // We must do this before we dequeue another write,
+    // as that may in turn invoke this method again.
+    //
+    // Note that if CFStream is involved, it may have maliciously put our socket in blocking mode.
+    
+    if (waiting)
+    {
+        flags &= ~kSocketCanAcceptBytes;
+        
+        if (![self usingCFStreamForTLS])
+        {
+            [self resumeWriteSource];
+        }
+    }
+    
+    // Check our results
+    
+    BOOL done = NO;
+    
+    if (bytesWritten > 0)
+    {
+        // Update total amount read for the current write
+        currentWrite->bytesDone += bytesWritten;
+        LogVerbose(@"currentWrite->bytesDone = %lu", (unsigned long)currentWrite->bytesDone);
+        
+        // Is packet done?
+        done = (currentWrite->bytesDone == [currentWrite->buffer length]);
+    }
+    
+    if (done)
+    {
+        [self completeCurrentWrite];
+        
+        if (!error)
+        {
+            dispatch_async(socketQueue, ^{ @autoreleasepool{
+                
+                [self maybeDequeueWrite];
+            }});
+        }
+    }
+    else
+    {
+        // We were unable to finish writing the data,
+        // so we're waiting for another callback to notify us of available space in the lower-level output buffer.
+        
+        if (!waiting && !error)
+        {
+            // This would be the case if our write was able to accept some data, but not all of it.
+            
+            flags &= ~kSocketCanAcceptBytes;
+            
+            if (![self usingCFStreamForTLS])
+            {
+                [self resumeWriteSource];
+            }
+        }
+        
+        if (bytesWritten > 0)
+        {
+            // We're not done with the entire write, but we have written some bytes
+            
+            __strong id theDelegate = delegate;
+            
+            if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didWritePartialDataOfLength:tag:)])
+            {
+                long theWriteTag = currentWrite->tag;
+                
+                dispatch_async(delegateQueue, ^{ @autoreleasepool {
+                    
+                    [theDelegate socket:self didWritePartialDataOfLength:bytesWritten tag:theWriteTag];
+                }});
+            }
+        }
+    }
+    
+    // Check for errors
+    
+    if (error)
+    {
+        [self closeWithError:[self errnoErrorWithReason:@"Error in write() function"]];
+    }
+    
+    // Do not add any code here without first adding a return statement in the error case above.
 }
 
 - (void)completeCurrentWrite
 {
-	LogTrace();
-	
-	NSAssert(currentWrite, @"Trying to complete current write when there is no current write.");
-	
-
-	__strong id theDelegate = delegate;
-	
-	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didWriteDataWithTag:)])
-	{
-		long theWriteTag = currentWrite->tag;
-		
-		dispatch_async(delegateQueue, ^{ @autoreleasepool {
-			
-			[theDelegate socket:self didWriteDataWithTag:theWriteTag];
-		}});
-	}
-	
-	[self endCurrentWrite];
+    LogTrace();
+    
+    NSAssert(currentWrite, @"Trying to complete current write when there is no current write.");
+    
+    
+    __strong id theDelegate = delegate;
+    
+    if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didWriteDataWithTag:)])
+    {
+        long theWriteTag = currentWrite->tag;
+        
+        dispatch_async(delegateQueue, ^{ @autoreleasepool {
+            
+            [theDelegate socket:self didWriteDataWithTag:theWriteTag];
+        }});
+    }
+    
+    [self endCurrentWrite];
 }
 
 - (void)endCurrentWrite
 {
-	if (writeTimer)
-	{
-		dispatch_source_cancel(writeTimer);
-		writeTimer = NULL;
-	}
-	
-	currentWrite = nil;
+    if (writeTimer)
+    {
+        dispatch_source_cancel(writeTimer);
+        writeTimer = NULL;
+    }
+    
+    currentWrite = nil;
 }
 
 - (void)setupWriteTimerWithTimeout:(NSTimeInterval)timeout
 {
-	if (timeout >= 0.0)
-	{
-		writeTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
-		
-		__weak GCDAsyncSocket *weakSelf = self;
-		
-		dispatch_source_set_event_handler(writeTimer, ^{ @autoreleasepool {
-		#pragma clang diagnostic push
-		#pragma clang diagnostic warning "-Wimplicit-retain-self"
-			
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
-			if (strongSelf == nil) return_from_block;
-			
-			[strongSelf doWriteTimeout];
-			
-		#pragma clang diagnostic pop
-		}});
-		
-		#if !OS_OBJECT_USE_OBJC
-		dispatch_source_t theWriteTimer = writeTimer;
-		dispatch_source_set_cancel_handler(writeTimer, ^{
-		#pragma clang diagnostic push
-		#pragma clang diagnostic warning "-Wimplicit-retain-self"
-			
-			LogVerbose(@"dispatch_release(writeTimer)");
-			dispatch_release(theWriteTimer);
-			
-		#pragma clang diagnostic pop
-		});
-		#endif
-		
-		dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
-		
-		dispatch_source_set_timer(writeTimer, tt, DISPATCH_TIME_FOREVER, 0);
-		dispatch_resume(writeTimer);
-	}
+    if (timeout >= 0.0)
+    {
+        writeTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
+        
+        __weak GCDAsyncSocket *weakSelf = self;
+        
+        dispatch_source_set_event_handler(writeTimer, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+            
+            __strong GCDAsyncSocket *strongSelf = weakSelf;
+            if (strongSelf == nil) return_from_block;
+            
+            [strongSelf doWriteTimeout];
+            
+#pragma clang diagnostic pop
+        }});
+        
+#if !OS_OBJECT_USE_OBJC
+        dispatch_source_t theWriteTimer = writeTimer;
+        dispatch_source_set_cancel_handler(writeTimer, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+            
+            LogVerbose(@"dispatch_release(writeTimer)");
+            dispatch_release(theWriteTimer);
+            
+#pragma clang diagnostic pop
+        });
+#endif
+        
+        dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
+        
+        dispatch_source_set_timer(writeTimer, tt, DISPATCH_TIME_FOREVER, 0);
+        dispatch_resume(writeTimer);
+    }
 }
 
 - (void)doWriteTimeout
 {
-	// This is a little bit tricky.
-	// Ideally we'd like to synchronously query the delegate about a timeout extension.
-	// But if we do so synchronously we risk a possible deadlock.
-	// So instead we have to do so asynchronously, and callback to ourselves from within the delegate block.
-	
-	flags |= kWritesPaused;
-	
-	__strong id theDelegate = delegate;
-
-	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:shouldTimeoutWriteWithTag:elapsed:bytesDone:)])
-	{
-		GCDAsyncWritePacket *theWrite = currentWrite;
-		
-		dispatch_async(delegateQueue, ^{ @autoreleasepool {
-			
-			NSTimeInterval timeoutExtension = 0.0;
-			
-			timeoutExtension = [theDelegate socket:self shouldTimeoutWriteWithTag:theWrite->tag
-			                                                              elapsed:theWrite->timeout
-			                                                            bytesDone:theWrite->bytesDone];
-			
-			dispatch_async(socketQueue, ^{ @autoreleasepool {
-				
-				[self doWriteTimeoutWithExtension:timeoutExtension];
-			}});
-		}});
-	}
-	else
-	{
-		[self doWriteTimeoutWithExtension:0.0];
-	}
+    // This is a little bit tricky.
+    // Ideally we'd like to synchronously query the delegate about a timeout extension.
+    // But if we do so synchronously we risk a possible deadlock.
+    // So instead we have to do so asynchronously, and callback to ourselves from within the delegate block.
+    
+    flags |= kWritesPaused;
+    
+    __strong id theDelegate = delegate;
+    
+    if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:shouldTimeoutWriteWithTag:elapsed:bytesDone:)])
+    {
+        GCDAsyncWritePacket *theWrite = currentWrite;
+        
+        dispatch_async(delegateQueue, ^{ @autoreleasepool {
+            
+            NSTimeInterval timeoutExtension = 0.0;
+            
+            timeoutExtension = [theDelegate socket:self shouldTimeoutWriteWithTag:theWrite->tag
+                                           elapsed:theWrite->timeout
+                                         bytesDone:theWrite->bytesDone];
+            
+            dispatch_async(socketQueue, ^{ @autoreleasepool {
+                
+                [self doWriteTimeoutWithExtension:timeoutExtension];
+            }});
+        }});
+    }
+    else
+    {
+        [self doWriteTimeoutWithExtension:0.0];
+    }
 }
 
 - (void)doWriteTimeoutWithExtension:(NSTimeInterval)timeoutExtension
 {
-	if (currentWrite)
-	{
-		if (timeoutExtension > 0.0)
-		{
-			currentWrite->timeout += timeoutExtension;
-			
-			// Reschedule the timer
-			dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeoutExtension * NSEC_PER_SEC));
-			dispatch_source_set_timer(writeTimer, tt, DISPATCH_TIME_FOREVER, 0);
-			
-			// Unpause writes, and continue
-			flags &= ~kWritesPaused;
-			[self doWriteData];
-		}
-		else
-		{
-			LogVerbose(@"WriteTimeout");
-			
-			[self closeWithError:[self writeTimeoutError]];
-		}
-	}
+    if (currentWrite)
+    {
+        if (timeoutExtension > 0.0)
+        {
+            currentWrite->timeout += timeoutExtension;
+            
+            // Reschedule the timer
+            dispatch_time_t tt = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeoutExtension * NSEC_PER_SEC));
+            dispatch_source_set_timer(writeTimer, tt, DISPATCH_TIME_FOREVER, 0);
+            
+            // Unpause writes, and continue
+            flags &= ~kWritesPaused;
+            [self doWriteData];
+        }
+        else
+        {
+            LogVerbose(@"WriteTimeout");
+            
+            [self closeWithError:[self writeTimeoutError]];
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -5748,760 +5782,893 @@ enum GCDAsyncSocketConfig
 
 - (void)startTLS:(NSDictionary *)tlsSettings
 {
-	LogTrace();
-	
-	if (tlsSettings == nil)
+    LogTrace();
+    
+    if (tlsSettings == nil)
     {
         // Passing nil/NULL to CFReadStreamSetProperty will appear to work the same as passing an empty dictionary,
         // but causes problems if we later try to fetch the remote host's certificate.
-        // 
+        //
         // To be exact, it causes the following to return NULL instead of the normal result:
         // CFReadStreamCopyProperty(readStream, kCFStreamPropertySSLPeerCertificates)
-        // 
+        //
         // So we use an empty dictionary instead, which works perfectly.
         
         tlsSettings = [NSDictionary dictionary];
     }
-	
-	GCDAsyncSpecialPacket *packet = [[GCDAsyncSpecialPacket alloc] initWithTLSSettings:tlsSettings];
-	
-	dispatch_async(socketQueue, ^{ @autoreleasepool {
-		
-		if ((flags & kSocketStarted) && !(flags & kQueuedTLS) && !(flags & kForbidReadsWrites))
-		{
-			[readQueue addObject:packet];
-			[writeQueue addObject:packet];
-			
-			flags |= kQueuedTLS;
-			
-			[self maybeDequeueRead];
-			[self maybeDequeueWrite];
-		}
-	}});
-	
+    
+    GCDAsyncSpecialPacket *packet = [[GCDAsyncSpecialPacket alloc] initWithTLSSettings:tlsSettings];
+    
+    dispatch_async(socketQueue, ^{ @autoreleasepool {
+        
+        if ((flags & kSocketStarted) && !(flags & kQueuedTLS) && !(flags & kForbidReadsWrites))
+        {
+            [readQueue addObject:packet];
+            [writeQueue addObject:packet];
+            
+            flags |= kQueuedTLS;
+            
+            [self maybeDequeueRead];
+            [self maybeDequeueWrite];
+        }
+    }});
+    
 }
 
 - (void)maybeStartTLS
 {
-	// We can't start TLS until:
-	// - All queued reads prior to the user calling startTLS are complete
-	// - All queued writes prior to the user calling startTLS are complete
-	// 
-	// We'll know these conditions are met when both kStartingReadTLS and kStartingWriteTLS are set
-	
-	if ((flags & kStartingReadTLS) && (flags & kStartingWriteTLS))
-	{
-		BOOL canUseSecureTransport = YES;
-		
-		#if TARGET_OS_IPHONE
-		{
-			GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
-			NSDictionary *tlsSettings = tlsPacket->tlsSettings;
-			
-			NSNumber *value;
-			
-			value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsAnyRoot];
-			if (value && [value boolValue] == YES)
-				canUseSecureTransport = NO;
-			
-			value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsExpiredRoots];
-			if (value && [value boolValue] == YES)
-				canUseSecureTransport = NO;
-			
-			value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLValidatesCertificateChain];
-			if (value && [value boolValue] == NO)
-				canUseSecureTransport = NO;
-			
-			value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsExpiredCertificates];
-			if (value && [value boolValue] == YES)
-				canUseSecureTransport = NO;
-		}
-		#endif
-		
-		if (IS_SECURE_TRANSPORT_AVAILABLE && canUseSecureTransport)
-		{
-		#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-			[self ssl_startTLS];
-		#endif
-		}
-		else
-		{
-		#if TARGET_OS_IPHONE
-			[self cf_startTLS];
-		#endif
-		}
-	}
+    // We can't start TLS until:
+    // - All queued reads prior to the user calling startTLS are complete
+    // - All queued writes prior to the user calling startTLS are complete
+    //
+    // We'll know these conditions are met when both kStartingReadTLS and kStartingWriteTLS are set
+    
+    if ((flags & kStartingReadTLS) && (flags & kStartingWriteTLS))
+    {
+        BOOL useSecureTransport = YES;
+        
+#if TARGET_OS_IPHONE
+        {
+            GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
+            NSDictionary *tlsSettings = tlsPacket->tlsSettings;
+            
+            NSNumber *value = [tlsSettings objectForKey:GCDAsyncSocketUseCFStreamForTLS];
+            if (value && [value boolValue] == YES)
+                useSecureTransport = NO;
+        }
+#endif
+        
+        if (useSecureTransport)
+        {
+            [self ssl_startTLS];
+        }
+        else
+        {
+#if TARGET_OS_IPHONE
+            [self cf_startTLS];
+#endif
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Security via SecureTransport
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-
 - (OSStatus)sslReadWithBuffer:(void *)buffer length:(size_t *)bufferLength
 {
-	LogVerbose(@"sslReadWithBuffer:%p length:%lu", buffer, (unsigned long)*bufferLength);
-	
-	if ((socketFDBytesAvailable == 0) && ([sslPreBuffer availableBytes] == 0))
-	{
-		LogVerbose(@"%@ - No data available to read...", THIS_METHOD);
-		
-		// No data available to read.
-		// 
-		// Need to wait for readSource to fire and notify us of
-		// available data in the socket's internal read buffer.
-		
-		[self resumeReadSource];
-		
-		*bufferLength = 0;
-		return errSSLWouldBlock;
-	}
-	
-	size_t totalBytesRead = 0;
-	size_t totalBytesLeftToBeRead = *bufferLength;
-	
-	BOOL done = NO;
-	BOOL socketError = NO;
-	
-	// 
-	// STEP 1 : READ FROM SSL PRE BUFFER
-	// 
-	
-	size_t sslPreBufferLength = [sslPreBuffer availableBytes];
-	
-	if (sslPreBufferLength > 0)
-	{
-		LogVerbose(@"%@: Reading from SSL pre buffer...", THIS_METHOD);
-		
-		size_t bytesToCopy;
-		if (sslPreBufferLength > totalBytesLeftToBeRead)
-			bytesToCopy = totalBytesLeftToBeRead;
-		else
-			bytesToCopy = sslPreBufferLength;
-		
-		LogVerbose(@"%@: Copying %zu bytes from sslPreBuffer", THIS_METHOD, bytesToCopy);
-		
-		memcpy(buffer, [sslPreBuffer readBuffer], bytesToCopy);
-		[sslPreBuffer didRead:bytesToCopy];
-		
-		LogVerbose(@"%@: sslPreBuffer.length = %zu", THIS_METHOD, [sslPreBuffer availableBytes]);
-		
-		totalBytesRead += bytesToCopy;
-		totalBytesLeftToBeRead -= bytesToCopy;
-		
-		done = (totalBytesLeftToBeRead == 0);
-		
-		if (done) LogVerbose(@"%@: Complete", THIS_METHOD);
-	}
-	
-	// 
-	// STEP 2 : READ FROM SOCKET
-	// 
-	
-	if (!done && (socketFDBytesAvailable > 0))
-	{
-		LogVerbose(@"%@: Reading from socket...", THIS_METHOD);
-		
-		int socketFD = (socket6FD == SOCKET_NULL) ? socket4FD : socket6FD;
-		
-		BOOL readIntoPreBuffer;
-		size_t bytesToRead;
-		uint8_t *buf;
-		
-		if (socketFDBytesAvailable > totalBytesLeftToBeRead)
-		{
-			// Read all available data from socket into sslPreBuffer.
-			// Then copy requested amount into dataBuffer.
-			
-			LogVerbose(@"%@: Reading into sslPreBuffer...", THIS_METHOD);
-			
-			[sslPreBuffer ensureCapacityForWrite:socketFDBytesAvailable];
-			
-			readIntoPreBuffer = YES;
-			bytesToRead = (size_t)socketFDBytesAvailable;
-			buf = [sslPreBuffer writeBuffer];
-		}
-		else
-		{
-			// Read available data from socket directly into dataBuffer.
-			
-			LogVerbose(@"%@: Reading directly into dataBuffer...", THIS_METHOD);
-			
-			readIntoPreBuffer = NO;
-			bytesToRead = totalBytesLeftToBeRead;
-			buf = (uint8_t *)buffer + totalBytesRead;
-		}
-		
-		ssize_t result = read(socketFD, buf, bytesToRead);
-		LogVerbose(@"%@: read from socket = %zd", THIS_METHOD, result);
-		
-		if (result < 0)
-		{
-			LogVerbose(@"%@: read errno = %i", THIS_METHOD, errno);
-			
-			if (errno != EWOULDBLOCK)
-			{
-				socketError = YES;
-			}
-			
-			socketFDBytesAvailable = 0;
-		}
-		else if (result == 0)
-		{
-			LogVerbose(@"%@: read EOF", THIS_METHOD);
-			
-			socketError = YES;
-			socketFDBytesAvailable = 0;
-		}
-		else
-		{
-			size_t bytesReadFromSocket = result;
-			
-			if (socketFDBytesAvailable > bytesReadFromSocket)
-				socketFDBytesAvailable -= bytesReadFromSocket;
-			else
-				socketFDBytesAvailable = 0;
-			
-			if (readIntoPreBuffer)
-			{
-				[sslPreBuffer didWrite:bytesReadFromSocket];
-				
-				size_t bytesToCopy = MIN(totalBytesLeftToBeRead, bytesReadFromSocket);
-				
-				LogVerbose(@"%@: Copying %zu bytes out of sslPreBuffer", THIS_METHOD, bytesToCopy);
-				
-				memcpy((uint8_t *)buffer + totalBytesRead, [sslPreBuffer readBuffer], bytesToCopy);
-				[sslPreBuffer didRead:bytesToCopy];
-				
-				totalBytesRead += bytesToCopy;
-				totalBytesLeftToBeRead -= bytesToCopy;
-				
-				LogVerbose(@"%@: sslPreBuffer.length = %zu", THIS_METHOD, [sslPreBuffer availableBytes]);
-			}
-			else
-			{
-				totalBytesRead += bytesReadFromSocket;
-				totalBytesLeftToBeRead -= bytesReadFromSocket;
-			}
-			
-			done = (totalBytesLeftToBeRead == 0);
-			
-			if (done) LogVerbose(@"%@: Complete", THIS_METHOD);
-		}
-	}
-	
-	*bufferLength = totalBytesRead;
-	
-	if (done)
-		return noErr;
-	
-	if (socketError)
-		return errSSLClosedAbort;
-	
-	return errSSLWouldBlock;
+    LogVerbose(@"sslReadWithBuffer:%p length:%lu", buffer, (unsigned long)*bufferLength);
+    
+    if ((socketFDBytesAvailable == 0) && ([sslPreBuffer availableBytes] == 0))
+    {
+        LogVerbose(@"%@ - No data available to read...", THIS_METHOD);
+        
+        // No data available to read.
+        //
+        // Need to wait for readSource to fire and notify us of
+        // available data in the socket's internal read buffer.
+        
+        [self resumeReadSource];
+        
+        *bufferLength = 0;
+        return errSSLWouldBlock;
+    }
+    
+    size_t totalBytesRead = 0;
+    size_t totalBytesLeftToBeRead = *bufferLength;
+    
+    BOOL done = NO;
+    BOOL socketError = NO;
+    
+    //
+    // STEP 1 : READ FROM SSL PRE BUFFER
+    //
+    
+    size_t sslPreBufferLength = [sslPreBuffer availableBytes];
+    
+    if (sslPreBufferLength > 0)
+    {
+        LogVerbose(@"%@: Reading from SSL pre buffer...", THIS_METHOD);
+        
+        size_t bytesToCopy;
+        if (sslPreBufferLength > totalBytesLeftToBeRead)
+            bytesToCopy = totalBytesLeftToBeRead;
+        else
+            bytesToCopy = sslPreBufferLength;
+        
+        LogVerbose(@"%@: Copying %zu bytes from sslPreBuffer", THIS_METHOD, bytesToCopy);
+        
+        memcpy(buffer, [sslPreBuffer readBuffer], bytesToCopy);
+        [sslPreBuffer didRead:bytesToCopy];
+        
+        LogVerbose(@"%@: sslPreBuffer.length = %zu", THIS_METHOD, [sslPreBuffer availableBytes]);
+        
+        totalBytesRead += bytesToCopy;
+        totalBytesLeftToBeRead -= bytesToCopy;
+        
+        done = (totalBytesLeftToBeRead == 0);
+        
+        if (done) LogVerbose(@"%@: Complete", THIS_METHOD);
+    }
+    
+    //
+    // STEP 2 : READ FROM SOCKET
+    //
+    
+    if (!done && (socketFDBytesAvailable > 0))
+    {
+        LogVerbose(@"%@: Reading from socket...", THIS_METHOD);
+        
+        int socketFD = (socket6FD == SOCKET_NULL) ? socket4FD : socket6FD;
+        
+        BOOL readIntoPreBuffer;
+        size_t bytesToRead;
+        uint8_t *buf;
+        
+        if (socketFDBytesAvailable > totalBytesLeftToBeRead)
+        {
+            // Read all available data from socket into sslPreBuffer.
+            // Then copy requested amount into dataBuffer.
+            
+            LogVerbose(@"%@: Reading into sslPreBuffer...", THIS_METHOD);
+            
+            [sslPreBuffer ensureCapacityForWrite:socketFDBytesAvailable];
+            
+            readIntoPreBuffer = YES;
+            bytesToRead = (size_t)socketFDBytesAvailable;
+            buf = [sslPreBuffer writeBuffer];
+        }
+        else
+        {
+            // Read available data from socket directly into dataBuffer.
+            
+            LogVerbose(@"%@: Reading directly into dataBuffer...", THIS_METHOD);
+            
+            readIntoPreBuffer = NO;
+            bytesToRead = totalBytesLeftToBeRead;
+            buf = (uint8_t *)buffer + totalBytesRead;
+        }
+        
+        ssize_t result = read(socketFD, buf, bytesToRead);
+        LogVerbose(@"%@: read from socket = %zd", THIS_METHOD, result);
+        
+        if (result < 0)
+        {
+            LogVerbose(@"%@: read errno = %i", THIS_METHOD, errno);
+            
+            if (errno != EWOULDBLOCK)
+            {
+                socketError = YES;
+            }
+            
+            socketFDBytesAvailable = 0;
+        }
+        else if (result == 0)
+        {
+            LogVerbose(@"%@: read EOF", THIS_METHOD);
+            
+            socketError = YES;
+            socketFDBytesAvailable = 0;
+        }
+        else
+        {
+            size_t bytesReadFromSocket = result;
+            
+            if (socketFDBytesAvailable > bytesReadFromSocket)
+                socketFDBytesAvailable -= bytesReadFromSocket;
+            else
+                socketFDBytesAvailable = 0;
+            
+            if (readIntoPreBuffer)
+            {
+                [sslPreBuffer didWrite:bytesReadFromSocket];
+                
+                size_t bytesToCopy = MIN(totalBytesLeftToBeRead, bytesReadFromSocket);
+                
+                LogVerbose(@"%@: Copying %zu bytes out of sslPreBuffer", THIS_METHOD, bytesToCopy);
+                
+                memcpy((uint8_t *)buffer + totalBytesRead, [sslPreBuffer readBuffer], bytesToCopy);
+                [sslPreBuffer didRead:bytesToCopy];
+                
+                totalBytesRead += bytesToCopy;
+                totalBytesLeftToBeRead -= bytesToCopy;
+                
+                LogVerbose(@"%@: sslPreBuffer.length = %zu", THIS_METHOD, [sslPreBuffer availableBytes]);
+            }
+            else
+            {
+                totalBytesRead += bytesReadFromSocket;
+                totalBytesLeftToBeRead -= bytesReadFromSocket;
+            }
+            
+            done = (totalBytesLeftToBeRead == 0);
+            
+            if (done) LogVerbose(@"%@: Complete", THIS_METHOD);
+        }
+    }
+    
+    *bufferLength = totalBytesRead;
+    
+    if (done)
+        return noErr;
+    
+    if (socketError)
+        return errSSLClosedAbort;
+    
+    return errSSLWouldBlock;
 }
 
 - (OSStatus)sslWriteWithBuffer:(const void *)buffer length:(size_t *)bufferLength
 {
-	if (!(flags & kSocketCanAcceptBytes))
-	{
-		// Unable to write.
-		// 
-		// Need to wait for writeSource to fire and notify us of
-		// available space in the socket's internal write buffer.
-		
-		[self resumeWriteSource];
-		
-		*bufferLength = 0;
-		return errSSLWouldBlock;
-	}
-	
-	size_t bytesToWrite = *bufferLength;
-	size_t bytesWritten = 0;
-	
-	BOOL done = NO;
-	BOOL socketError = NO;
-	
-	int socketFD = (socket4FD == SOCKET_NULL) ? socket6FD : socket4FD;
-	
-	ssize_t result = write(socketFD, buffer, bytesToWrite);
-	
-	if (result < 0)
-	{
-		if (errno != EWOULDBLOCK)
-		{
-			socketError = YES;
-		}
-		
-		flags &= ~kSocketCanAcceptBytes;
-	}
-	else if (result == 0)
-	{
-		flags &= ~kSocketCanAcceptBytes;
-	}
-	else
-	{
-		bytesWritten = result;
-		
-		done = (bytesWritten == bytesToWrite);
-	}
-	
-	*bufferLength = bytesWritten;
-	
-	if (done)
-		return noErr;
-	
-	if (socketError)
-		return errSSLClosedAbort;
-	
-	return errSSLWouldBlock;
+    if (!(flags & kSocketCanAcceptBytes))
+    {
+        // Unable to write.
+        //
+        // Need to wait for writeSource to fire and notify us of
+        // available space in the socket's internal write buffer.
+        
+        [self resumeWriteSource];
+        
+        *bufferLength = 0;
+        return errSSLWouldBlock;
+    }
+    
+    size_t bytesToWrite = *bufferLength;
+    size_t bytesWritten = 0;
+    
+    BOOL done = NO;
+    BOOL socketError = NO;
+    
+    int socketFD = (socket4FD == SOCKET_NULL) ? socket6FD : socket4FD;
+    
+    ssize_t result = write(socketFD, buffer, bytesToWrite);
+    
+    if (result < 0)
+    {
+        if (errno != EWOULDBLOCK)
+        {
+            socketError = YES;
+        }
+        
+        flags &= ~kSocketCanAcceptBytes;
+    }
+    else if (result == 0)
+    {
+        flags &= ~kSocketCanAcceptBytes;
+    }
+    else
+    {
+        bytesWritten = result;
+        
+        done = (bytesWritten == bytesToWrite);
+    }
+    
+    *bufferLength = bytesWritten;
+    
+    if (done)
+        return noErr;
+    
+    if (socketError)
+        return errSSLClosedAbort;
+    
+    return errSSLWouldBlock;
 }
 
 static OSStatus SSLReadFunction(SSLConnectionRef connection, void *data, size_t *dataLength)
 {
-	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)connection;
-	
-	NSCAssert(dispatch_get_specific(asyncSocket->IsOnSocketQueueOrTargetQueueKey), @"What the deuce?");
-	
-	return [asyncSocket sslReadWithBuffer:data length:dataLength];
+    GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)connection;
+    
+    NSCAssert(dispatch_get_specific(asyncSocket->IsOnSocketQueueOrTargetQueueKey), @"What the deuce?");
+    
+    return [asyncSocket sslReadWithBuffer:data length:dataLength];
 }
 
 static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, size_t *dataLength)
 {
-	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)connection;
-	
-	NSCAssert(dispatch_get_specific(asyncSocket->IsOnSocketQueueOrTargetQueueKey), @"What the deuce?");
-	
-	return [asyncSocket sslWriteWithBuffer:data length:dataLength];
+    GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)connection;
+    
+    NSCAssert(dispatch_get_specific(asyncSocket->IsOnSocketQueueOrTargetQueueKey), @"What the deuce?");
+    
+    return [asyncSocket sslWriteWithBuffer:data length:dataLength];
 }
 
 - (void)ssl_startTLS
 {
-	LogTrace();
-	
-	LogVerbose(@"Starting TLS (via SecureTransport)...");
-		
-	OSStatus status;
-	
-	GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
-	NSDictionary *tlsSettings = tlsPacket->tlsSettings;
-	
-	// Create SSLContext, and setup IO callbacks and connection ref
-	
-	BOOL isServer = [[tlsSettings objectForKey:(NSString *)kCFStreamSSLIsServer] boolValue];
-	
-	#if TARGET_OS_IPHONE
-	{
-		if (isServer)
-			sslContext = SSLCreateContext(kCFAllocatorDefault, kSSLServerSide, kSSLStreamType);
-		else
-			sslContext = SSLCreateContext(kCFAllocatorDefault, kSSLClientSide, kSSLStreamType);
-		
-		if (sslContext == NULL)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLCreateContext"]];
-			return;
-		}
-	}
-	#else
-	{
-		status = SSLNewContext(isServer, &sslContext);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLNewContext"]];
-			return;
-		}
-	}
-	#endif
-	
-	status = SSLSetIOFuncs(sslContext, &SSLReadFunction, &SSLWriteFunction);
-	if (status != noErr)
-	{
-		[self closeWithError:[self otherError:@"Error in SSLSetIOFuncs"]];
-		return;
-	}
-	
-	status = SSLSetConnection(sslContext, (__bridge SSLConnectionRef)self);
-	if (status != noErr)
-	{
-		[self closeWithError:[self otherError:@"Error in SSLSetConnection"]];
-		return;
-	}
-	
-	// Configure SSLContext from given settings
-	// 
-	// Checklist:
-	// 1. kCFStreamSSLPeerName
-	// 2. kCFStreamSSLAllowsAnyRoot
-	// 3. kCFStreamSSLAllowsExpiredRoots
-	// 4. kCFStreamSSLValidatesCertificateChain
-	// 5. kCFStreamSSLAllowsExpiredCertificates
-	// 6. kCFStreamSSLCertificates
-	// 7. kCFStreamSSLLevel (GCDAsyncSocketSSLProtocolVersionMin / GCDAsyncSocketSSLProtocolVersionMax)
-	// 8. GCDAsyncSocketSSLCipherSuites
-	// 9. GCDAsyncSocketSSLDiffieHellmanParameters (Mac)
-	
-	id value;
-	
-	// 1. kCFStreamSSLPeerName
-	
-	value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLPeerName];
-	if ([value isKindOfClass:[NSString class]])
-	{
-		NSString *peerName = (NSString *)value;
-		
-		const char *peer = [peerName UTF8String];
-		size_t peerLen = strlen(peer);
-		
-		status = SSLSetPeerDomainName(sslContext, peer, peerLen);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLSetPeerDomainName"]];
-			return;
-		}
-	}
-	
-	// 2. kCFStreamSSLAllowsAnyRoot
-	
-	value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsAnyRoot];
-	if (value)
-	{
-		#if TARGET_OS_IPHONE
-		NSAssert(NO, @"Security option unavailable via SecureTransport in iOS - kCFStreamSSLAllowsAnyRoot");
-		#else
-		
-		BOOL allowsAnyRoot = [value boolValue];
-		
-		status = SSLSetAllowsAnyRoot(sslContext, allowsAnyRoot);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLSetAllowsAnyRoot"]];
-			return;
-		}
-		
-		#endif
-	}
-	
-	// 3. kCFStreamSSLAllowsExpiredRoots
-	
-	value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsExpiredRoots];
-	if (value)
-	{
-		#if TARGET_OS_IPHONE
-		NSAssert(NO, @"Security option unavailable via SecureTransport in iOS - kCFStreamSSLAllowsExpiredRoots");
-		#else
-		
-		BOOL allowsExpiredRoots = [value boolValue];
-		
-		status = SSLSetAllowsExpiredRoots(sslContext, allowsExpiredRoots);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLSetAllowsExpiredRoots"]];
-			return;
-		}
-		
-		#endif
-	}
-	
-	// 4. kCFStreamSSLValidatesCertificateChain
-	
-	value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLValidatesCertificateChain];
-	if (value)
-	{
-		#if TARGET_OS_IPHONE
-		NSAssert(NO, @"Security option unavailable via SecureTransport in iOS - kCFStreamSSLValidatesCertificateChain");
-		#else
-		
-		BOOL validatesCertChain = [value boolValue];
-		
-		status = SSLSetEnableCertVerify(sslContext, validatesCertChain);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLSetEnableCertVerify"]];
-			return;
-		}
-		
-		#endif
-	}
-	
-	// 5. kCFStreamSSLAllowsExpiredCertificates
-	
-	value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsExpiredCertificates];
-	if (value)
-	{
-		#if TARGET_OS_IPHONE
-		NSAssert(NO, @"Security option unavailable via SecureTransport in iOS - kCFStreamSSLAllowsExpiredCertificates");
-		#else
-		
-		BOOL allowsExpiredCerts = [value boolValue];
-		
-		status = SSLSetAllowsExpiredCerts(sslContext, allowsExpiredCerts);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLSetAllowsExpiredCerts"]];
-			return;
-		}
-		
-		#endif
-	}
-	
-	// 6. kCFStreamSSLCertificates
-	
-	value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLCertificates];
-	if (value)
-	{
-		CFArrayRef certs = (__bridge CFArrayRef)value;
-		
-		status = SSLSetCertificate(sslContext, certs);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLSetCertificate"]];
-			return;
-		}
-	}
-	
-	// 7. kCFStreamSSLLevel
-	
-	#if TARGET_OS_IPHONE
-	{
-		NSString *sslLevel = [tlsSettings objectForKey:(NSString *)kCFStreamSSLLevel];
-		
-		NSString *sslMinLevel = [tlsSettings objectForKey:GCDAsyncSocketSSLProtocolVersionMin];
-		NSString *sslMaxLevel = [tlsSettings objectForKey:GCDAsyncSocketSSLProtocolVersionMax];
-		
-		if (sslLevel)
-		{
-			if (sslMinLevel || sslMaxLevel)
-			{
-				LogWarn(@"kCFStreamSSLLevel security option ignored. Overriden by "
-						@"GCDAsyncSocketSSLProtocolVersionMin and/or GCDAsyncSocketSSLProtocolVersionMax");
-			}
-			else
-			{
-				if ([sslLevel isEqualToString:(NSString *)kCFStreamSocketSecurityLevelSSLv3])
-				{
-					sslMinLevel = sslMaxLevel = @"kSSLProtocol3";
-				}
-				else if ([sslLevel isEqualToString:(NSString *)kCFStreamSocketSecurityLevelTLSv1])
-				{
-					sslMinLevel = sslMaxLevel = @"kTLSProtocol1";
-				}
-				else
-				{
-					LogWarn(@"Unable to match kCFStreamSSLLevel security option to valid SSL protocol min/max");
-				}
-			}
-		}
-		
-		if (sslMinLevel || sslMaxLevel)
-		{
-			OSStatus status1 = noErr;
-			OSStatus status2 = noErr;
-			
-			SSLProtocol (^sslProtocolForString)(NSString*) = ^SSLProtocol (NSString *protocolStr) {
-				
-				if ([protocolStr isEqualToString:@"kSSLProtocol3"])  return kSSLProtocol3;
-				if ([protocolStr isEqualToString:@"kTLSProtocol1"])  return kTLSProtocol1;
-				if ([protocolStr isEqualToString:@"kTLSProtocol11"]) return kTLSProtocol11;
-				if ([protocolStr isEqualToString:@"kTLSProtocol12"]) return kTLSProtocol12;
-				
-				return kSSLProtocolUnknown;
-			};
-			
-			SSLProtocol minProtocol = sslProtocolForString(sslMinLevel);
-			SSLProtocol maxProtocol = sslProtocolForString(sslMaxLevel);
-			
-			if (minProtocol != kSSLProtocolUnknown)
-			{
-				status1 = SSLSetProtocolVersionMin(sslContext, minProtocol);
-			}
-			if (maxProtocol != kSSLProtocolUnknown)
-			{
-				status2 = SSLSetProtocolVersionMax(sslContext, maxProtocol);
-			}
-			
-			if (status1 != noErr || status2 != noErr)
-			{
-				[self closeWithError:[self otherError:@"Error in SSLSetProtocolVersionMinMax"]];
-				return;
-			}
-		}
-	}
-	#else
-	{
-		value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLLevel];
-		if (value)
-		{
-			NSString *sslLevel = (NSString *)value;
-			
-			OSStatus status1 = noErr;
-			OSStatus status2 = noErr;
-			OSStatus status3 = noErr;
-			
-			if ([sslLevel isEqualToString:(NSString *)kCFStreamSocketSecurityLevelSSLv2])
-			{
-				// kCFStreamSocketSecurityLevelSSLv2:
-				// 
-				// Specifies that SSL version 2 be set as the security protocol.
-				
-				status1 = SSLSetProtocolVersionEnabled(sslContext, kSSLProtocolAll, NO);
-				status2 = SSLSetProtocolVersionEnabled(sslContext, kSSLProtocol2,   YES);
-			}
-			else if ([sslLevel isEqualToString:(NSString *)kCFStreamSocketSecurityLevelSSLv3])
-			{
-				// kCFStreamSocketSecurityLevelSSLv3:
-				// 
-				// Specifies that SSL version 3 be set as the security protocol.
-				// If SSL version 3 is not available, specifies that SSL version 2 be set as the security protocol.
-				
-				status1 = SSLSetProtocolVersionEnabled(sslContext, kSSLProtocolAll, NO);
-				status2 = SSLSetProtocolVersionEnabled(sslContext, kSSLProtocol2,   YES);
-				status3 = SSLSetProtocolVersionEnabled(sslContext, kSSLProtocol3,   YES);
-			}
-			else if ([sslLevel isEqualToString:(NSString *)kCFStreamSocketSecurityLevelTLSv1])
-			{
-				// kCFStreamSocketSecurityLevelTLSv1:
-				// 
-				// Specifies that TLS version 1 be set as the security protocol.
-				
-				status1 = SSLSetProtocolVersionEnabled(sslContext, kSSLProtocolAll, NO);
-				status2 = SSLSetProtocolVersionEnabled(sslContext, kTLSProtocol1,   YES);
-			}
-			else if ([sslLevel isEqualToString:(NSString *)kCFStreamSocketSecurityLevelNegotiatedSSL])
-			{
-				// kCFStreamSocketSecurityLevelNegotiatedSSL:
-				// 
-				// Specifies that the highest level security protocol that can be negotiated be used.
-				
-				status1 = SSLSetProtocolVersionEnabled(sslContext, kSSLProtocolAll, YES);
-			}
-			
-			if (status1 != noErr || status2 != noErr || status3 != noErr)
-			{
-				[self closeWithError:[self otherError:@"Error in SSLSetProtocolVersionEnabled"]];
-				return;
-			}
-		}
-	}
-	#endif
-	
-	// 8. GCDAsyncSocketSSLCipherSuites
-	
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLCipherSuites];
-	if (value)
-	{
-		NSArray *cipherSuites = (NSArray *)value;
-		NSUInteger numberCiphers = [cipherSuites count];
-		SSLCipherSuite ciphers[numberCiphers];
-		
-		NSUInteger cipherIndex;
-		for (cipherIndex = 0; cipherIndex < numberCiphers; cipherIndex++)
-		{
-			NSNumber *cipherObject = [cipherSuites objectAtIndex:cipherIndex];
-			ciphers[cipherIndex] = [cipherObject shortValue];
-		}
-		
-		status = SSLSetEnabledCiphers(sslContext, ciphers, numberCiphers);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLSetEnabledCiphers"]];
-			return;
-		}
-	}
-	
-	// 9. GCDAsyncSocketSSLDiffieHellmanParameters
-	
-	#if !TARGET_OS_IPHONE
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLDiffieHellmanParameters];
-	if (value)
-	{
-		NSData *diffieHellmanData = (NSData *)value;
-		
-		status = SSLSetDiffieHellmanParams(sslContext, [diffieHellmanData bytes], [diffieHellmanData length]);
-		if (status != noErr)
-		{
-			[self closeWithError:[self otherError:@"Error in SSLSetDiffieHellmanParams"]];
-			return;
-		}
-	}
-	#endif
-	
-	// Setup the sslPreBuffer
-	// 
-	// Any data in the preBuffer needs to be moved into the sslPreBuffer,
-	// as this data is now part of the secure read stream.
-	
-	sslPreBuffer = [[GCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
-	
-	size_t preBufferLength  = [preBuffer availableBytes];
-	
-	if (preBufferLength > 0)
-	{
-		[sslPreBuffer ensureCapacityForWrite:preBufferLength];
-		
-		memcpy([sslPreBuffer writeBuffer], [preBuffer readBuffer], preBufferLength);
-		[preBuffer didRead:preBufferLength];
-		[sslPreBuffer didWrite:preBufferLength];
-	}
-	
-	sslErrCode = noErr;
-	
-	// Start the SSL Handshake process
-	
-	[self ssl_continueSSLHandshake];
+    LogTrace();
+    
+    LogVerbose(@"Starting TLS (via SecureTransport)...");
+    
+    OSStatus status;
+    
+    GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
+    if (tlsPacket == nil) // Code to quiet the analyzer
+    {
+        NSAssert(NO, @"Logic error");
+        
+        [self closeWithError:[self otherError:@"Logic error"]];
+        return;
+    }
+    NSDictionary *tlsSettings = tlsPacket->tlsSettings;
+    
+    // Create SSLContext, and setup IO callbacks and connection ref
+    
+    BOOL isServer = [[tlsSettings objectForKey:(NSString *)kCFStreamSSLIsServer] boolValue];
+    
+#if TARGET_OS_IPHONE || (__MAC_OS_X_VERSION_MIN_REQUIRED >= 1080)
+    {
+        if (isServer)
+            sslContext = SSLCreateContext(kCFAllocatorDefault, kSSLServerSide, kSSLStreamType);
+        else
+            sslContext = SSLCreateContext(kCFAllocatorDefault, kSSLClientSide, kSSLStreamType);
+        
+        if (sslContext == NULL)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLCreateContext"]];
+            return;
+        }
+    }
+#else // (__MAC_OS_X_VERSION_MIN_REQUIRED < 1080)
+    {
+        status = SSLNewContext(isServer, &sslContext);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLNewContext"]];
+            return;
+        }
+    }
+#endif
+    
+    status = SSLSetIOFuncs(sslContext, &SSLReadFunction, &SSLWriteFunction);
+    if (status != noErr)
+    {
+        [self closeWithError:[self otherError:@"Error in SSLSetIOFuncs"]];
+        return;
+    }
+    
+    status = SSLSetConnection(sslContext, (__bridge SSLConnectionRef)self);
+    if (status != noErr)
+    {
+        [self closeWithError:[self otherError:@"Error in SSLSetConnection"]];
+        return;
+    }
+    
+    
+    BOOL shouldManuallyEvaluateTrust = [[tlsSettings objectForKey:GCDAsyncSocketManuallyEvaluateTrust] boolValue];
+    if (shouldManuallyEvaluateTrust)
+    {
+        if (isServer)
+        {
+            [self closeWithError:[self otherError:@"Manual trust validation is not supported for server sockets"]];
+            return;
+        }
+        
+        status = SSLSetSessionOption(sslContext, kSSLSessionOptionBreakOnServerAuth, true);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLSetSessionOption"]];
+            return;
+        }
+        
+#if !TARGET_OS_IPHONE && (__MAC_OS_X_VERSION_MIN_REQUIRED < 1080)
+        
+        // Note from Apple's documentation:
+        //
+        // It is only necessary to call SSLSetEnableCertVerify on the Mac prior to OS X 10.8.
+        // On OS X 10.8 and later setting kSSLSessionOptionBreakOnServerAuth always disables the
+        // built-in trust evaluation. All versions of iOS behave like OS X 10.8 and thus
+        // SSLSetEnableCertVerify is not available on that platform at all.
+        
+        status = SSLSetEnableCertVerify(sslContext, NO);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLSetEnableCertVerify"]];
+            return;
+        }
+        
+#endif
+    }
+    
+    // Configure SSLContext from given settings
+    //
+    // Checklist:
+    //  1. kCFStreamSSLPeerName
+    //  2. kCFStreamSSLCertificates
+    //  3. GCDAsyncSocketSSLPeerID
+    //  4. GCDAsyncSocketSSLProtocolVersionMin
+    //  5. GCDAsyncSocketSSLProtocolVersionMax
+    //  6. GCDAsyncSocketSSLSessionOptionFalseStart
+    //  7. GCDAsyncSocketSSLSessionOptionSendOneByteRecord
+    //  8. GCDAsyncSocketSSLCipherSuites
+    //  9. GCDAsyncSocketSSLDiffieHellmanParameters (Mac)
+    //
+    // Deprecated (throw error):
+    // 10. kCFStreamSSLAllowsAnyRoot
+    // 11. kCFStreamSSLAllowsExpiredRoots
+    // 12. kCFStreamSSLAllowsExpiredCertificates
+    // 13. kCFStreamSSLValidatesCertificateChain
+    // 14. kCFStreamSSLLevel
+    
+    id value;
+    
+    // 1. kCFStreamSSLPeerName
+    
+    value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLPeerName];
+    if ([value isKindOfClass:[NSString class]])
+    {
+        NSString *peerName = (NSString *)value;
+        
+        const char *peer = [peerName UTF8String];
+        size_t peerLen = strlen(peer);
+        
+        status = SSLSetPeerDomainName(sslContext, peer, peerLen);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLSetPeerDomainName"]];
+            return;
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for kCFStreamSSLPeerName. Value must be of type NSString.");
+        
+        [self closeWithError:[self otherError:@"Invalid value for kCFStreamSSLPeerName."]];
+        return;
+    }
+    
+    // 2. kCFStreamSSLCertificates
+    
+    value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLCertificates];
+    if ([value isKindOfClass:[NSArray class]])
+    {
+        CFArrayRef certs = (__bridge CFArrayRef)value;
+        
+        status = SSLSetCertificate(sslContext, certs);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLSetCertificate"]];
+            return;
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for kCFStreamSSLCertificates. Value must be of type NSArray.");
+        
+        [self closeWithError:[self otherError:@"Invalid value for kCFStreamSSLCertificates."]];
+        return;
+    }
+    
+    // 3. GCDAsyncSocketSSLPeerID
+    
+    value = [tlsSettings objectForKey:GCDAsyncSocketSSLPeerID];
+    if ([value isKindOfClass:[NSData class]])
+    {
+        NSData *peerIdData = (NSData *)value;
+        
+        status = SSLSetPeerID(sslContext, [peerIdData bytes], [peerIdData length]);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLSetPeerID"]];
+            return;
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLPeerID. Value must be of type NSData."
+                 @" (You can convert strings to data using a method like"
+                 @" [string dataUsingEncoding:NSUTF8StringEncoding])");
+        
+        [self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLPeerID."]];
+        return;
+    }
+    
+    // 4. GCDAsyncSocketSSLProtocolVersionMin
+    
+    value = [tlsSettings objectForKey:GCDAsyncSocketSSLProtocolVersionMin];
+    if ([value isKindOfClass:[NSNumber class]])
+    {
+        SSLProtocol minProtocol = (SSLProtocol)[(NSNumber *)value intValue];
+        if (minProtocol != kSSLProtocolUnknown)
+        {
+            status = SSLSetProtocolVersionMin(sslContext, minProtocol);
+            if (status != noErr)
+            {
+                [self closeWithError:[self otherError:@"Error in SSLSetProtocolVersionMin"]];
+                return;
+            }
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLProtocolVersionMin. Value must be of type NSNumber.");
+        
+        [self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLProtocolVersionMin."]];
+        return;
+    }
+    
+    // 5. GCDAsyncSocketSSLProtocolVersionMax
+    
+    value = [tlsSettings objectForKey:GCDAsyncSocketSSLProtocolVersionMax];
+    if ([value isKindOfClass:[NSNumber class]])
+    {
+        SSLProtocol maxProtocol = (SSLProtocol)[(NSNumber *)value intValue];
+        if (maxProtocol != kSSLProtocolUnknown)
+        {
+            status = SSLSetProtocolVersionMax(sslContext, maxProtocol);
+            if (status != noErr)
+            {
+                [self closeWithError:[self otherError:@"Error in SSLSetProtocolVersionMax"]];
+                return;
+            }
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLProtocolVersionMax. Value must be of type NSNumber.");
+        
+        [self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLProtocolVersionMax."]];
+        return;
+    }
+    
+    // 6. GCDAsyncSocketSSLSessionOptionFalseStart
+    
+    value = [tlsSettings objectForKey:GCDAsyncSocketSSLSessionOptionFalseStart];
+    if ([value isKindOfClass:[NSNumber class]])
+    {
+        status = SSLSetSessionOption(sslContext, kSSLSessionOptionFalseStart, [value boolValue]);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLSetSessionOption (kSSLSessionOptionFalseStart)"]];
+            return;
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLSessionOptionFalseStart. Value must be of type NSNumber.");
+        
+        [self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLSessionOptionFalseStart."]];
+        return;
+    }
+    
+    // 7. GCDAsyncSocketSSLSessionOptionSendOneByteRecord
+    
+    value = [tlsSettings objectForKey:GCDAsyncSocketSSLSessionOptionSendOneByteRecord];
+    if ([value isKindOfClass:[NSNumber class]])
+    {
+        status = SSLSetSessionOption(sslContext, kSSLSessionOptionSendOneByteRecord, [value boolValue]);
+        if (status != noErr)
+        {
+            [self closeWithError:
+             [self otherError:@"Error in SSLSetSessionOption (kSSLSessionOptionSendOneByteRecord)"]];
+            return;
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLSessionOptionSendOneByteRecord."
+                 @" Value must be of type NSNumber.");
+        
+        [self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLSessionOptionSendOneByteRecord."]];
+        return;
+    }
+    
+    // 8. GCDAsyncSocketSSLCipherSuites
+    
+    value = [tlsSettings objectForKey:GCDAsyncSocketSSLCipherSuites];
+    if ([value isKindOfClass:[NSArray class]])
+    {
+        NSArray *cipherSuites = (NSArray *)value;
+        NSUInteger numberCiphers = [cipherSuites count];
+        SSLCipherSuite ciphers[numberCiphers];
+        
+        NSUInteger cipherIndex;
+        for (cipherIndex = 0; cipherIndex < numberCiphers; cipherIndex++)
+        {
+            NSNumber *cipherObject = [cipherSuites objectAtIndex:cipherIndex];
+            ciphers[cipherIndex] = [cipherObject shortValue];
+        }
+        
+        status = SSLSetEnabledCiphers(sslContext, ciphers, numberCiphers);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLSetEnabledCiphers"]];
+            return;
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLCipherSuites. Value must be of type NSArray.");
+        
+        [self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLCipherSuites."]];
+        return;
+    }
+    
+    // 9. GCDAsyncSocketSSLDiffieHellmanParameters
+    
+#if !TARGET_OS_IPHONE
+    value = [tlsSettings objectForKey:GCDAsyncSocketSSLDiffieHellmanParameters];
+    if ([value isKindOfClass:[NSData class]])
+    {
+        NSData *diffieHellmanData = (NSData *)value;
+        
+        status = SSLSetDiffieHellmanParams(sslContext, [diffieHellmanData bytes], [diffieHellmanData length]);
+        if (status != noErr)
+        {
+            [self closeWithError:[self otherError:@"Error in SSLSetDiffieHellmanParams"]];
+            return;
+        }
+    }
+    else if (value)
+    {
+        NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLDiffieHellmanParameters. Value must be of type NSData.");
+        
+        [self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLDiffieHellmanParameters."]];
+        return;
+    }
+#endif
+    
+    // DEPRECATED checks
+    
+    // 10. kCFStreamSSLAllowsAnyRoot
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsAnyRoot];
+#pragma clang diagnostic pop
+    if (value)
+    {
+        NSAssert(NO, @"Security option unavailable - kCFStreamSSLAllowsAnyRoot"
+                 @" - You must use manual trust evaluation");
+        
+        [self closeWithError:[self otherError:@"Security option unavailable - kCFStreamSSLAllowsAnyRoot"]];
+        return;
+    }
+    
+    // 11. kCFStreamSSLAllowsExpiredRoots
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsExpiredRoots];
+#pragma clang diagnostic pop
+    if (value)
+    {
+        NSAssert(NO, @"Security option unavailable - kCFStreamSSLAllowsExpiredRoots"
+                 @" - You must use manual trust evaluation");
+        
+        [self closeWithError:[self otherError:@"Security option unavailable - kCFStreamSSLAllowsExpiredRoots"]];
+        return;
+    }
+    
+    // 12. kCFStreamSSLValidatesCertificateChain
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLValidatesCertificateChain];
+#pragma clang diagnostic pop
+    if (value)
+    {
+        NSAssert(NO, @"Security option unavailable - kCFStreamSSLValidatesCertificateChain"
+                 @" - You must use manual trust evaluation");
+        
+        [self closeWithError:[self otherError:@"Security option unavailable - kCFStreamSSLValidatesCertificateChain"]];
+        return;
+    }
+    
+    // 13. kCFStreamSSLAllowsExpiredCertificates
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLAllowsExpiredCertificates];
+#pragma clang diagnostic pop
+    if (value)
+    {
+        NSAssert(NO, @"Security option unavailable - kCFStreamSSLAllowsExpiredCertificates"
+                 @" - You must use manual trust evaluation");
+        
+        [self closeWithError:[self otherError:@"Security option unavailable - kCFStreamSSLAllowsExpiredCertificates"]];
+        return;
+    }
+    
+    // 14. kCFStreamSSLLevel
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    value = [tlsSettings objectForKey:(NSString *)kCFStreamSSLLevel];
+#pragma clang diagnostic pop
+    if (value)
+    {
+        NSAssert(NO, @"Security option unavailable - kCFStreamSSLLevel"
+                 @" - You must use GCDAsyncSocketSSLProtocolVersionMin & GCDAsyncSocketSSLProtocolVersionMax");
+        
+        [self closeWithError:[self otherError:@"Security option unavailable - kCFStreamSSLLevel"]];
+        return;
+    }
+    
+    // Setup the sslPreBuffer
+    // 
+    // Any data in the preBuffer needs to be moved into the sslPreBuffer,
+    // as this data is now part of the secure read stream.
+    
+    sslPreBuffer = [[GCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
+    
+    size_t preBufferLength  = [preBuffer availableBytes];
+    
+    if (preBufferLength > 0)
+    {
+        [sslPreBuffer ensureCapacityForWrite:preBufferLength];
+        
+        memcpy([sslPreBuffer writeBuffer], [preBuffer readBuffer], preBufferLength);
+        [preBuffer didRead:preBufferLength];
+        [sslPreBuffer didWrite:preBufferLength];
+    }
+    
+    sslErrCode = noErr;
+    
+    // Start the SSL Handshake process
+    
+    [self ssl_continueSSLHandshake];
 }
 
 - (void)ssl_continueSSLHandshake
 {
-	LogTrace();
-	
-	// If the return value is noErr, the session is ready for normal secure communication.
-	// If the return value is errSSLWouldBlock, the SSLHandshake function must be called again.
-	// Otherwise, the return value indicates an error code.
-	
-	OSStatus status = SSLHandshake(sslContext);
-	
-	if (status == noErr)
-	{
-		LogVerbose(@"SSLHandshake complete");
-		
-		flags &= ~kStartingReadTLS;
-		flags &= ~kStartingWriteTLS;
-		
-		flags |=  kSocketSecure;
-		
-		__strong id theDelegate = delegate;
-
-		if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidSecure:)])
-		{
-			dispatch_async(delegateQueue, ^{ @autoreleasepool {
-				
-				[theDelegate socketDidSecure:self];
-			}});
-		}
-		
-		[self endCurrentRead];
-		[self endCurrentWrite];
-		
-		[self maybeDequeueRead];
-		[self maybeDequeueWrite];
-	}
-	else if (status == errSSLWouldBlock)
-	{
-		LogVerbose(@"SSLHandshake continues...");
-		
-		// Handshake continues...
-		// 
-		// This method will be called again from doReadData or doWriteData.
-	}
-	else
-	{
-		[self closeWithError:[self sslError:status]];
-	}
+    LogTrace();
+    
+    // If the return value is noErr, the session is ready for normal secure communication.
+    // If the return value is errSSLWouldBlock, the SSLHandshake function must be called again.
+    // If the return value is errSSLServerAuthCompleted, we ask delegate if we should trust the
+    // server and then call SSLHandshake again to resume the handshake or close the connection
+    // errSSLPeerBadCert SSL error.
+    // Otherwise, the return value indicates an error code.
+    
+    OSStatus status = SSLHandshake(sslContext);
+    
+    if (status == noErr)
+    {
+        LogVerbose(@"SSLHandshake complete");
+        
+        flags &= ~kStartingReadTLS;
+        flags &= ~kStartingWriteTLS;
+        
+        flags |=  kSocketSecure;
+        
+        __strong id theDelegate = delegate;
+        
+        if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidSecure:)])
+        {
+            dispatch_async(delegateQueue, ^{ @autoreleasepool {
+                
+                [theDelegate socketDidSecure:self];
+            }});
+        }
+        
+        [self endCurrentRead];
+        [self endCurrentWrite];
+        
+        [self maybeDequeueRead];
+        [self maybeDequeueWrite];
+    }
+    else if (status == errSSLPeerAuthCompleted)
+    {
+        LogVerbose(@"SSLHandshake peerAuthCompleted - awaiting delegate approval");
+        
+        __block SecTrustRef trust = NULL;
+        status = SSLCopyPeerTrust(sslContext, &trust);
+        if (status != noErr)
+        {
+            [self closeWithError:[self sslError:status]];
+            return;
+        }
+        
+        int aStateIndex = stateIndex;
+        dispatch_queue_t theSocketQueue = socketQueue;
+        
+        __weak GCDAsyncSocket *weakSelf = self;
+        
+        void (^comletionHandler)(BOOL) = ^(BOOL shouldTrust){ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+            
+            dispatch_async(theSocketQueue, ^{ @autoreleasepool {
+                
+                if (trust) {
+                    CFRelease(trust);
+                    trust = NULL;
+                }
+                
+                __strong GCDAsyncSocket *strongSelf = weakSelf;
+                if (strongSelf)
+                {
+                    [strongSelf ssl_shouldTrustPeer:shouldTrust stateIndex:aStateIndex];
+                }
+            }});
+            
+#pragma clang diagnostic pop
+        }};
+        
+        __strong id theDelegate = delegate;
+        
+        if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didReceiveTrust:completionHandler:)])
+        {
+            dispatch_async(delegateQueue, ^{ @autoreleasepool {
+                
+                [theDelegate socket:self didReceiveTrust:trust completionHandler:comletionHandler];
+            }});
+        }
+        else
+        {
+            if (trust) {
+                CFRelease(trust);
+                trust = NULL;
+            }
+            
+            NSString *msg = @"GCDAsyncSocketManuallyEvaluateTrust specified in tlsSettings,"
+            @" but delegate doesn't implement socket:shouldTrustPeer:";
+            
+            [self closeWithError:[self otherError:msg]];
+            return;
+        }
+    }
+    else if (status == errSSLWouldBlock)
+    {
+        LogVerbose(@"SSLHandshake continues...");
+        
+        // Handshake continues...
+        // 
+        // This method will be called again from doReadData or doWriteData.
+    }
+    else
+    {
+        [self closeWithError:[self sslError:status]];
+    }
 }
 
-#endif
+- (void)ssl_shouldTrustPeer:(BOOL)shouldTrust stateIndex:(int)aStateIndex
+{
+    LogTrace();
+    
+    if (aStateIndex != stateIndex)
+    {
+        LogInfo(@"Ignoring ssl_shouldTrustPeer - invalid state (maybe disconnected)");
+        
+        // One of the following is true
+        // - the socket was disconnected
+        // - the startTLS operation timed out
+        // - the completionHandler was already invoked once
+        
+        return;
+    }
+    
+    // Increment stateIndex to ensure completionHandler can only be called once.
+    stateIndex++;
+    
+    if (shouldTrust)
+    {
+        [self ssl_continueSSLHandshake];
+    }
+    else
+    {
+        [self closeWithError:[self sslError:errSSLPeerBadCert]];
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Security via CFStream
@@ -6511,131 +6678,131 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 
 - (void)cf_finishSSLHandshake
 {
-	LogTrace();
-	
-	if ((flags & kStartingReadTLS) && (flags & kStartingWriteTLS))
-	{
-		flags &= ~kStartingReadTLS;
-		flags &= ~kStartingWriteTLS;
-		
-		flags |= kSocketSecure;
-		
-		__strong id theDelegate = delegate;
-
-		if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidSecure:)])
-		{
-			dispatch_async(delegateQueue, ^{ @autoreleasepool {
-				
-				[theDelegate socketDidSecure:self];
-			}});
-		}
-		
-		[self endCurrentRead];
-		[self endCurrentWrite];
-		
-		[self maybeDequeueRead];
-		[self maybeDequeueWrite];
-	}
+    LogTrace();
+    
+    if ((flags & kStartingReadTLS) && (flags & kStartingWriteTLS))
+    {
+        flags &= ~kStartingReadTLS;
+        flags &= ~kStartingWriteTLS;
+        
+        flags |= kSocketSecure;
+        
+        __strong id theDelegate = delegate;
+        
+        if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidSecure:)])
+        {
+            dispatch_async(delegateQueue, ^{ @autoreleasepool {
+                
+                [theDelegate socketDidSecure:self];
+            }});
+        }
+        
+        [self endCurrentRead];
+        [self endCurrentWrite];
+        
+        [self maybeDequeueRead];
+        [self maybeDequeueWrite];
+    }
 }
 
 - (void)cf_abortSSLHandshake:(NSError *)error
 {
-	LogTrace();
-	
-	if ((flags & kStartingReadTLS) && (flags & kStartingWriteTLS))
-	{
-		flags &= ~kStartingReadTLS;
-		flags &= ~kStartingWriteTLS;
-		
-		[self closeWithError:error];
-	}
+    LogTrace();
+    
+    if ((flags & kStartingReadTLS) && (flags & kStartingWriteTLS))
+    {
+        flags &= ~kStartingReadTLS;
+        flags &= ~kStartingWriteTLS;
+        
+        [self closeWithError:error];
+    }
 }
 
 - (void)cf_startTLS
 {
-	LogTrace();
-	
-	LogVerbose(@"Starting TLS (via CFStream)...");
-	
-	if ([preBuffer availableBytes] > 0)
-	{
-		NSString *msg = @"Invalid TLS transition. Handshake has already been read from socket.";
-		
-		[self closeWithError:[self otherError:msg]];
-		return;
-	}
-	
-	[self suspendReadSource];
-	[self suspendWriteSource];
-	
-	socketFDBytesAvailable = 0;
-	flags &= ~kSocketCanAcceptBytes;
-	flags &= ~kSecureSocketHasBytesAvailable;
-	
-	flags |=  kUsingCFStreamForTLS;
-	
-	if (![self createReadAndWriteStream])
-	{
-		[self closeWithError:[self otherError:@"Error in CFStreamCreatePairWithSocket"]];
-		return;
-	}
-	
-	if (![self registerForStreamCallbacksIncludingReadWrite:YES])
-	{
-		[self closeWithError:[self otherError:@"Error in CFStreamSetClient"]];
-		return;
-	}
-	
-	if (![self addStreamsToRunLoop])
-	{
-		[self closeWithError:[self otherError:@"Error in CFStreamScheduleWithRunLoop"]];
-		return;
-	}
-	
-	NSAssert([currentRead isKindOfClass:[GCDAsyncSpecialPacket class]], @"Invalid read packet for startTLS");
-	NSAssert([currentWrite isKindOfClass:[GCDAsyncSpecialPacket class]], @"Invalid write packet for startTLS");
-	
-	GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
-	CFDictionaryRef tlsSettings = (__bridge CFDictionaryRef)tlsPacket->tlsSettings;
-	
-	// Getting an error concerning kCFStreamPropertySSLSettings ?
-	// You need to add the CFNetwork framework to your iOS application.
-	
-	BOOL r1 = CFReadStreamSetProperty(readStream, kCFStreamPropertySSLSettings, tlsSettings);
-	BOOL r2 = CFWriteStreamSetProperty(writeStream, kCFStreamPropertySSLSettings, tlsSettings);
-	
-	// For some reason, starting around the time of iOS 4.3,
-	// the first call to set the kCFStreamPropertySSLSettings will return true,
-	// but the second will return false.
-	// 
-	// Order doesn't seem to matter.
-	// So you could call CFReadStreamSetProperty and then CFWriteStreamSetProperty, or you could reverse the order.
-	// Either way, the first call will return true, and the second returns false.
-	// 
-	// Interestingly, this doesn't seem to affect anything.
-	// Which is not altogether unusual, as the documentation seems to suggest that (for many settings)
-	// setting it on one side of the stream automatically sets it for the other side of the stream.
-	// 
-	// Although there isn't anything in the documentation to suggest that the second attempt would fail.
-	// 
-	// Furthermore, this only seems to affect streams that are negotiating a security upgrade.
-	// In other words, the socket gets connected, there is some back-and-forth communication over the unsecure
-	// connection, and then a startTLS is issued.
-	// So this mostly affects newer protocols (XMPP, IMAP) as opposed to older protocols (HTTPS).
-	
-	if (!r1 && !r2) // Yes, the && is correct - workaround for apple bug.
-	{
-		[self closeWithError:[self otherError:@"Error in CFStreamSetProperty"]];
-		return;
-	}
-	
-	if (![self openStreams])
-	{
-		[self closeWithError:[self otherError:@"Error in CFStreamOpen"]];
-		return;
-	}
-	
-	LogVerbose(@"Waiting for SSL Handshake to complete...");
+    LogTrace();
+    
+    LogVerbose(@"Starting TLS (via CFStream)...");
+    
+    if ([preBuffer availableBytes] > 0)
+    {
+        NSString *msg = @"Invalid TLS transition. Handshake has already been read from socket.";
+        
+        [self closeWithError:[self otherError:msg]];
+        return;
+    }
+    
+    [self suspendReadSource];
+    [self suspendWriteSource];
+    
+    socketFDBytesAvailable = 0;
+    flags &= ~kSocketCanAcceptBytes;
+    flags &= ~kSecureSocketHasBytesAvailable;
+    
+    flags |=  kUsingCFStreamForTLS;
+    
+    if (![self createReadAndWriteStream])
+    {
+        [self closeWithError:[self otherError:@"Error in CFStreamCreatePairWithSocket"]];
+        return;
+    }
+    
+    if (![self registerForStreamCallbacksIncludingReadWrite:YES])
+    {
+        [self closeWithError:[self otherError:@"Error in CFStreamSetClient"]];
+        return;
+    }
+    
+    if (![self addStreamsToRunLoop])
+    {
+        [self closeWithError:[self otherError:@"Error in CFStreamScheduleWithRunLoop"]];
+        return;
+    }
+    
+    NSAssert([currentRead isKindOfClass:[GCDAsyncSpecialPacket class]], @"Invalid read packet for startTLS");
+    NSAssert([currentWrite isKindOfClass:[GCDAsyncSpecialPacket class]], @"Invalid write packet for startTLS");
+    
+    GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
+    CFDictionaryRef tlsSettings = (__bridge CFDictionaryRef)tlsPacket->tlsSettings;
+    
+    // Getting an error concerning kCFStreamPropertySSLSettings ?
+    // You need to add the CFNetwork framework to your iOS application.
+    
+    BOOL r1 = CFReadStreamSetProperty(readStream, kCFStreamPropertySSLSettings, tlsSettings);
+    BOOL r2 = CFWriteStreamSetProperty(writeStream, kCFStreamPropertySSLSettings, tlsSettings);
+    
+    // For some reason, starting around the time of iOS 4.3,
+    // the first call to set the kCFStreamPropertySSLSettings will return true,
+    // but the second will return false.
+    // 
+    // Order doesn't seem to matter.
+    // So you could call CFReadStreamSetProperty and then CFWriteStreamSetProperty, or you could reverse the order.
+    // Either way, the first call will return true, and the second returns false.
+    // 
+    // Interestingly, this doesn't seem to affect anything.
+    // Which is not altogether unusual, as the documentation seems to suggest that (for many settings)
+    // setting it on one side of the stream automatically sets it for the other side of the stream.
+    // 
+    // Although there isn't anything in the documentation to suggest that the second attempt would fail.
+    // 
+    // Furthermore, this only seems to affect streams that are negotiating a security upgrade.
+    // In other words, the socket gets connected, there is some back-and-forth communication over the unsecure
+    // connection, and then a startTLS is issued.
+    // So this mostly affects newer protocols (XMPP, IMAP) as opposed to older protocols (HTTPS).
+    
+    if (!r1 && !r2) // Yes, the && is correct - workaround for apple bug.
+    {
+        [self closeWithError:[self otherError:@"Error in CFStreamSetProperty"]];
+        return;
+    }
+    
+    if (![self openStreams])
+    {
+        [self closeWithError:[self otherError:@"Error in CFStreamOpen"]];
+        return;
+    }
+    
+    LogVerbose(@"Waiting for SSL Handshake to complete...");
 }
 
 #endif
@@ -6651,361 +6818,420 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 
 + (void)startCFStreamThreadIfNeeded
 {
-	static dispatch_once_t predicate;
-	dispatch_once(&predicate, ^{
-		
-		cfstreamThread = [[NSThread alloc] initWithTarget:self
-		                                         selector:@selector(cfstreamThread)
-		                                           object:nil];
-		[cfstreamThread start];
-	});
+    LogTrace();
+    
+    static dispatch_once_t predicate;
+    dispatch_once(&predicate, ^{
+        
+        cfstreamThreadRetainCount = 0;
+        cfstreamThreadSetupQueue = dispatch_queue_create("GCDAsyncSocket-CFStreamThreadSetup", DISPATCH_QUEUE_SERIAL);
+    });
+    
+    dispatch_sync(cfstreamThreadSetupQueue, ^{ @autoreleasepool {
+        
+        if (++cfstreamThreadRetainCount == 1)
+        {
+            cfstreamThread = [[NSThread alloc] initWithTarget:self
+                                                     selector:@selector(cfstreamThread)
+                                                       object:nil];
+            [cfstreamThread start];
+        }
+    }});
+}
+
++ (void)stopCFStreamThreadIfNeeded
+{
+    LogTrace();
+    
+    // The creation of the cfstreamThread is relatively expensive.
+    // So we'd like to keep it available for recycling.
+    // However, there's a tradeoff here, because it shouldn't remain alive forever.
+    // So what we're going to do is use a little delay before taking it down.
+    // This way it can be reused properly in situations where multiple sockets are continually in flux.
+    
+    int delayInSeconds = 30;
+    dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+    dispatch_after(when, cfstreamThreadSetupQueue, ^{ @autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wimplicit-retain-self"
+        
+        if (cfstreamThreadRetainCount == 0)
+        {
+            LogWarn(@"Logic error concerning cfstreamThread start / stop");
+            return_from_block;
+        }
+        
+        if (--cfstreamThreadRetainCount == 0)
+        {
+            [cfstreamThread cancel]; // set isCancelled flag
+            
+            // wake up the thread
+            [GCDAsyncSocket performSelector:@selector(ignore:)
+                                   onThread:cfstreamThread
+                                 withObject:[NSNull null]
+                              waitUntilDone:NO];
+            
+            cfstreamThread = nil;
+        }
+        
+#pragma clang diagnostic pop
+    }});
 }
 
 + (void)cfstreamThread { @autoreleasepool
-{
-	[[NSThread currentThread] setName:GCDAsyncSocketThreadName];
-	
-	LogInfo(@"CFStreamThread: Started");
-	
-	// We can't run the run loop unless it has an associated input source or a timer.
-	// So we'll just create a timer that will never fire - unless the server runs for decades.
-	[NSTimer scheduledTimerWithTimeInterval:[[NSDate distantFuture] timeIntervalSinceNow]
-	                                 target:self
-	                               selector:@selector(ignore:)
-	                               userInfo:nil
-	                                repeats:YES];
-	
-	[[NSRunLoop currentRunLoop] run];
-	
-	LogInfo(@"CFStreamThread: Stopped");
-}}
+    {
+        [[NSThread currentThread] setName:GCDAsyncSocketThreadName];
+        
+        LogInfo(@"CFStreamThread: Started");
+        
+        // We can't run the run loop unless it has an associated input source or a timer.
+        // So we'll just create a timer that will never fire - unless the server runs for decades.
+        [NSTimer scheduledTimerWithTimeInterval:[[NSDate distantFuture] timeIntervalSinceNow]
+                                         target:self
+                                       selector:@selector(ignore:)
+                                       userInfo:nil
+                                        repeats:YES];
+        
+        NSThread *currentThread = [NSThread currentThread];
+        NSRunLoop *currentRunLoop = [NSRunLoop currentRunLoop];
+        
+        BOOL isCancelled = [currentThread isCancelled];
+        
+        while (!isCancelled && [currentRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]])
+        {
+            isCancelled = [currentThread isCancelled];
+        }
+        
+        LogInfo(@"CFStreamThread: Stopped");
+    }}
 
 + (void)scheduleCFStreams:(GCDAsyncSocket *)asyncSocket
 {
-	LogTrace();
-	NSAssert([NSThread currentThread] == cfstreamThread, @"Invoked on wrong thread");
-	
-	CFRunLoopRef runLoop = CFRunLoopGetCurrent();
-	
-	if (asyncSocket->readStream)
-		CFReadStreamScheduleWithRunLoop(asyncSocket->readStream, runLoop, kCFRunLoopDefaultMode);
-	
-	if (asyncSocket->writeStream)
-		CFWriteStreamScheduleWithRunLoop(asyncSocket->writeStream, runLoop, kCFRunLoopDefaultMode);
+    LogTrace();
+    NSAssert([NSThread currentThread] == cfstreamThread, @"Invoked on wrong thread");
+    
+    CFRunLoopRef runLoop = CFRunLoopGetCurrent();
+    
+    if (asyncSocket->readStream)
+        CFReadStreamScheduleWithRunLoop(asyncSocket->readStream, runLoop, kCFRunLoopDefaultMode);
+    
+    if (asyncSocket->writeStream)
+        CFWriteStreamScheduleWithRunLoop(asyncSocket->writeStream, runLoop, kCFRunLoopDefaultMode);
 }
 
 + (void)unscheduleCFStreams:(GCDAsyncSocket *)asyncSocket
 {
-	LogTrace();
-	NSAssert([NSThread currentThread] == cfstreamThread, @"Invoked on wrong thread");
-	
-	CFRunLoopRef runLoop = CFRunLoopGetCurrent();
-	
-	if (asyncSocket->readStream)
-		CFReadStreamUnscheduleFromRunLoop(asyncSocket->readStream, runLoop, kCFRunLoopDefaultMode);
-	
-	if (asyncSocket->writeStream)
-		CFWriteStreamUnscheduleFromRunLoop(asyncSocket->writeStream, runLoop, kCFRunLoopDefaultMode);
+    LogTrace();
+    NSAssert([NSThread currentThread] == cfstreamThread, @"Invoked on wrong thread");
+    
+    CFRunLoopRef runLoop = CFRunLoopGetCurrent();
+    
+    if (asyncSocket->readStream)
+        CFReadStreamUnscheduleFromRunLoop(asyncSocket->readStream, runLoop, kCFRunLoopDefaultMode);
+    
+    if (asyncSocket->writeStream)
+        CFWriteStreamUnscheduleFromRunLoop(asyncSocket->writeStream, runLoop, kCFRunLoopDefaultMode);
 }
 
 static void CFReadStreamCallback (CFReadStreamRef stream, CFStreamEventType type, void *pInfo)
 {
-	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)pInfo;
-	
-	switch(type)
-	{
-		case kCFStreamEventHasBytesAvailable:
-		{
-			dispatch_async(asyncSocket->socketQueue, ^{ @autoreleasepool {
-				
-				LogCVerbose(@"CFReadStreamCallback - HasBytesAvailable");
-				
-				if (asyncSocket->readStream != stream)
-					return_from_block;
-				
-				if ((asyncSocket->flags & kStartingReadTLS) && (asyncSocket->flags & kStartingWriteTLS))
-				{
-					// If we set kCFStreamPropertySSLSettings before we opened the streams, this might be a lie.
-					// (A callback related to the tcp stream, but not to the SSL layer).
-					
-					if (CFReadStreamHasBytesAvailable(asyncSocket->readStream))
-					{
-						asyncSocket->flags |= kSecureSocketHasBytesAvailable;
-						[asyncSocket cf_finishSSLHandshake];
-					}
-				}
-				else
-				{
-					asyncSocket->flags |= kSecureSocketHasBytesAvailable;
-					[asyncSocket doReadData];
-				}
-			}});
-			
-			break;
-		}
-		default:
-		{
-			NSError *error = (__bridge_transfer  NSError *)CFReadStreamCopyError(stream);
-			
-			if (error == nil && type == kCFStreamEventEndEncountered)
-			{
-				error = [asyncSocket connectionClosedError];
-			}
-			
-			dispatch_async(asyncSocket->socketQueue, ^{ @autoreleasepool {
-				
-				LogCVerbose(@"CFReadStreamCallback - Other");
-				
-				if (asyncSocket->readStream != stream)
-					return_from_block;
-				
-				if ((asyncSocket->flags & kStartingReadTLS) && (asyncSocket->flags & kStartingWriteTLS))
-				{
-					[asyncSocket cf_abortSSLHandshake:error];
-				}
-				else
-				{
-					[asyncSocket closeWithError:error];
-				}
-			}});
-			
-			break;
-		}
-	}
-	
+    GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)pInfo;
+    
+    switch(type)
+    {
+        case kCFStreamEventHasBytesAvailable:
+        {
+            dispatch_async(asyncSocket->socketQueue, ^{ @autoreleasepool {
+                
+                LogCVerbose(@"CFReadStreamCallback - HasBytesAvailable");
+                
+                if (asyncSocket->readStream != stream)
+                    return_from_block;
+                
+                if ((asyncSocket->flags & kStartingReadTLS) && (asyncSocket->flags & kStartingWriteTLS))
+                {
+                    // If we set kCFStreamPropertySSLSettings before we opened the streams, this might be a lie.
+                    // (A callback related to the tcp stream, but not to the SSL layer).
+                    
+                    if (CFReadStreamHasBytesAvailable(asyncSocket->readStream))
+                    {
+                        asyncSocket->flags |= kSecureSocketHasBytesAvailable;
+                        [asyncSocket cf_finishSSLHandshake];
+                    }
+                }
+                else
+                {
+                    asyncSocket->flags |= kSecureSocketHasBytesAvailable;
+                    [asyncSocket doReadData];
+                }
+            }});
+            
+            break;
+        }
+        default:
+        {
+            NSError *error = (__bridge_transfer  NSError *)CFReadStreamCopyError(stream);
+            
+            if (error == nil && type == kCFStreamEventEndEncountered)
+            {
+                error = [asyncSocket connectionClosedError];
+            }
+            
+            dispatch_async(asyncSocket->socketQueue, ^{ @autoreleasepool {
+                
+                LogCVerbose(@"CFReadStreamCallback - Other");
+                
+                if (asyncSocket->readStream != stream)
+                    return_from_block;
+                
+                if ((asyncSocket->flags & kStartingReadTLS) && (asyncSocket->flags & kStartingWriteTLS))
+                {
+                    [asyncSocket cf_abortSSLHandshake:error];
+                }
+                else
+                {
+                    [asyncSocket closeWithError:error];
+                }
+            }});
+            
+            break;
+        }
+    }
+    
 }
 
 static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType type, void *pInfo)
 {
-	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)pInfo;
-	
-	switch(type)
-	{
-		case kCFStreamEventCanAcceptBytes:
-		{
-			dispatch_async(asyncSocket->socketQueue, ^{ @autoreleasepool {
-				
-				LogCVerbose(@"CFWriteStreamCallback - CanAcceptBytes");
-				
-				if (asyncSocket->writeStream != stream)
-					return_from_block;
-				
-				if ((asyncSocket->flags & kStartingReadTLS) && (asyncSocket->flags & kStartingWriteTLS))
-				{
-					// If we set kCFStreamPropertySSLSettings before we opened the streams, this might be a lie.
-					// (A callback related to the tcp stream, but not to the SSL layer).
-					
-					if (CFWriteStreamCanAcceptBytes(asyncSocket->writeStream))
-					{
-						asyncSocket->flags |= kSocketCanAcceptBytes;
-						[asyncSocket cf_finishSSLHandshake];
-					}
-				}
-				else
-				{
-					asyncSocket->flags |= kSocketCanAcceptBytes;
-					[asyncSocket doWriteData];
-				}
-			}});
-			
-			break;
-		}
-		default:
-		{
-			NSError *error = (__bridge_transfer NSError *)CFWriteStreamCopyError(stream);
-			
-			if (error == nil && type == kCFStreamEventEndEncountered)
-			{
-				error = [asyncSocket connectionClosedError];
-			}
-			
-			dispatch_async(asyncSocket->socketQueue, ^{ @autoreleasepool {
-				
-				LogCVerbose(@"CFWriteStreamCallback - Other");
-				
-				if (asyncSocket->writeStream != stream)
-					return_from_block;
-				
-				if ((asyncSocket->flags & kStartingReadTLS) && (asyncSocket->flags & kStartingWriteTLS))
-				{
-					[asyncSocket cf_abortSSLHandshake:error];
-				}
-				else
-				{
-					[asyncSocket closeWithError:error];
-				}
-			}});
-			
-			break;
-		}
-	}
-	
+    GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)pInfo;
+    
+    switch(type)
+    {
+        case kCFStreamEventCanAcceptBytes:
+        {
+            dispatch_async(asyncSocket->socketQueue, ^{ @autoreleasepool {
+                
+                LogCVerbose(@"CFWriteStreamCallback - CanAcceptBytes");
+                
+                if (asyncSocket->writeStream != stream)
+                    return_from_block;
+                
+                if ((asyncSocket->flags & kStartingReadTLS) && (asyncSocket->flags & kStartingWriteTLS))
+                {
+                    // If we set kCFStreamPropertySSLSettings before we opened the streams, this might be a lie.
+                    // (A callback related to the tcp stream, but not to the SSL layer).
+                    
+                    if (CFWriteStreamCanAcceptBytes(asyncSocket->writeStream))
+                    {
+                        asyncSocket->flags |= kSocketCanAcceptBytes;
+                        [asyncSocket cf_finishSSLHandshake];
+                    }
+                }
+                else
+                {
+                    asyncSocket->flags |= kSocketCanAcceptBytes;
+                    [asyncSocket doWriteData];
+                }
+            }});
+            
+            break;
+        }
+        default:
+        {
+            NSError *error = (__bridge_transfer NSError *)CFWriteStreamCopyError(stream);
+            
+            if (error == nil && type == kCFStreamEventEndEncountered)
+            {
+                error = [asyncSocket connectionClosedError];
+            }
+            
+            dispatch_async(asyncSocket->socketQueue, ^{ @autoreleasepool {
+                
+                LogCVerbose(@"CFWriteStreamCallback - Other");
+                
+                if (asyncSocket->writeStream != stream)
+                    return_from_block;
+                
+                if ((asyncSocket->flags & kStartingReadTLS) && (asyncSocket->flags & kStartingWriteTLS))
+                {
+                    [asyncSocket cf_abortSSLHandshake:error];
+                }
+                else
+                {
+                    [asyncSocket closeWithError:error];
+                }
+            }});
+            
+            break;
+        }
+    }
+    
 }
 
 - (BOOL)createReadAndWriteStream
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	
-	
-	if (readStream || writeStream)
-	{
-		// Streams already created
-		return YES;
-	}
-	
-	int socketFD = (socket6FD == SOCKET_NULL) ? socket4FD : socket6FD;
-	
-	if (socketFD == SOCKET_NULL)
-	{
-		// Cannot create streams without a file descriptor
-		return NO;
-	}
-	
-	if (![self isConnected])
-	{
-		// Cannot create streams until file descriptor is connected
-		return NO;
-	}
-	
-	LogVerbose(@"Creating read and write stream...");
-	
-	CFStreamCreatePairWithSocket(NULL, (CFSocketNativeHandle)socketFD, &readStream, &writeStream);
-	
-	// The kCFStreamPropertyShouldCloseNativeSocket property should be false by default (for our case).
-	// But let's not take any chances.
-	
-	if (readStream)
-		CFReadStreamSetProperty(readStream, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanFalse);
-	if (writeStream)
-		CFWriteStreamSetProperty(writeStream, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanFalse);
-	
-	if ((readStream == NULL) || (writeStream == NULL))
-	{
-		LogWarn(@"Unable to create read and write stream...");
-		
-		if (readStream)
-		{
-			CFReadStreamClose(readStream);
-			CFRelease(readStream);
-			readStream = NULL;
-		}
-		if (writeStream)
-		{
-			CFWriteStreamClose(writeStream);
-			CFRelease(writeStream);
-			writeStream = NULL;
-		}
-		
-		return NO;
-	}
-	
-	return YES;
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    
+    
+    if (readStream || writeStream)
+    {
+        // Streams already created
+        return YES;
+    }
+    
+    int socketFD = (socket6FD == SOCKET_NULL) ? socket4FD : socket6FD;
+    
+    if (socketFD == SOCKET_NULL)
+    {
+        // Cannot create streams without a file descriptor
+        return NO;
+    }
+    
+    if (![self isConnected])
+    {
+        // Cannot create streams until file descriptor is connected
+        return NO;
+    }
+    
+    LogVerbose(@"Creating read and write stream...");
+    
+    CFStreamCreatePairWithSocket(NULL, (CFSocketNativeHandle)socketFD, &readStream, &writeStream);
+    
+    // The kCFStreamPropertyShouldCloseNativeSocket property should be false by default (for our case).
+    // But let's not take any chances.
+    
+    if (readStream)
+        CFReadStreamSetProperty(readStream, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanFalse);
+    if (writeStream)
+        CFWriteStreamSetProperty(writeStream, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanFalse);
+    
+    if ((readStream == NULL) || (writeStream == NULL))
+    {
+        LogWarn(@"Unable to create read and write stream...");
+        
+        if (readStream)
+        {
+            CFReadStreamClose(readStream);
+            CFRelease(readStream);
+            readStream = NULL;
+        }
+        if (writeStream)
+        {
+            CFWriteStreamClose(writeStream);
+            CFRelease(writeStream);
+            writeStream = NULL;
+        }
+        
+        return NO;
+    }
+    
+    return YES;
 }
 
 - (BOOL)registerForStreamCallbacksIncludingReadWrite:(BOOL)includeReadWrite
 {
-	LogVerbose(@"%@ %@", THIS_METHOD, (includeReadWrite ? @"YES" : @"NO"));
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
-	
-	streamContext.version = 0;
-	streamContext.info = (__bridge void *)(self);
-	streamContext.retain = nil;
-	streamContext.release = nil;
-	streamContext.copyDescription = nil;
-	
-	CFOptionFlags readStreamEvents = kCFStreamEventErrorOccurred | kCFStreamEventEndEncountered;
-	if (includeReadWrite)
-		readStreamEvents |= kCFStreamEventHasBytesAvailable;
-	
-	if (!CFReadStreamSetClient(readStream, readStreamEvents, &CFReadStreamCallback, &streamContext))
-	{
-		return NO;
-	}
-	
-	CFOptionFlags writeStreamEvents = kCFStreamEventErrorOccurred | kCFStreamEventEndEncountered;
-	if (includeReadWrite)
-		writeStreamEvents |= kCFStreamEventCanAcceptBytes;
-	
-	if (!CFWriteStreamSetClient(writeStream, writeStreamEvents, &CFWriteStreamCallback, &streamContext))
-	{
-		return NO;
-	}
-	
-	return YES;
+    LogVerbose(@"%@ %@", THIS_METHOD, (includeReadWrite ? @"YES" : @"NO"));
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
+    
+    streamContext.version = 0;
+    streamContext.info = (__bridge void *)(self);
+    streamContext.retain = nil;
+    streamContext.release = nil;
+    streamContext.copyDescription = nil;
+    
+    CFOptionFlags readStreamEvents = kCFStreamEventErrorOccurred | kCFStreamEventEndEncountered;
+    if (includeReadWrite)
+        readStreamEvents |= kCFStreamEventHasBytesAvailable;
+    
+    if (!CFReadStreamSetClient(readStream, readStreamEvents, &CFReadStreamCallback, &streamContext))
+    {
+        return NO;
+    }
+    
+    CFOptionFlags writeStreamEvents = kCFStreamEventErrorOccurred | kCFStreamEventEndEncountered;
+    if (includeReadWrite)
+        writeStreamEvents |= kCFStreamEventCanAcceptBytes;
+    
+    if (!CFWriteStreamSetClient(writeStream, writeStreamEvents, &CFWriteStreamCallback, &streamContext))
+    {
+        return NO;
+    }
+    
+    return YES;
 }
 
 - (BOOL)addStreamsToRunLoop
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
-	
-	if (!(flags & kAddedStreamsToRunLoop))
-	{
-		LogVerbose(@"Adding streams to runloop...");
-		
-		[[self class] startCFStreamThreadIfNeeded];
-		[[self class] performSelector:@selector(scheduleCFStreams:)
-		                     onThread:cfstreamThread
-		                   withObject:self
-		                waitUntilDone:YES];
-		
-		flags |= kAddedStreamsToRunLoop;
-	}
-	
-	return YES;
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
+    
+    if (!(flags & kAddedStreamsToRunLoop))
+    {
+        LogVerbose(@"Adding streams to runloop...");
+        
+        [[self class] startCFStreamThreadIfNeeded];
+        [[self class] performSelector:@selector(scheduleCFStreams:)
+                             onThread:cfstreamThread
+                           withObject:self
+                        waitUntilDone:YES];
+        
+        flags |= kAddedStreamsToRunLoop;
+    }
+    
+    return YES;
 }
 
 - (void)removeStreamsFromRunLoop
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
-	
-	if (flags & kAddedStreamsToRunLoop)
-	{
-		LogVerbose(@"Removing streams from runloop...");
-		
-		[[self class] performSelector:@selector(unscheduleCFStreams:)
-		                     onThread:cfstreamThread
-		                   withObject:self
-		                waitUntilDone:YES];
-		
-		flags &= ~kAddedStreamsToRunLoop;
-	}
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
+    
+    if (flags & kAddedStreamsToRunLoop)
+    {
+        LogVerbose(@"Removing streams from runloop...");
+        
+        [[self class] performSelector:@selector(unscheduleCFStreams:)
+                             onThread:cfstreamThread
+                           withObject:self
+                        waitUntilDone:YES];
+        [[self class] stopCFStreamThreadIfNeeded];
+        
+        flags &= ~kAddedStreamsToRunLoop;
+    }
 }
 
 - (BOOL)openStreams
 {
-	LogTrace();
-	
-	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
-	NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
-	
-	CFStreamStatus readStatus = CFReadStreamGetStatus(readStream);
-	CFStreamStatus writeStatus = CFWriteStreamGetStatus(writeStream);
-	
-	if ((readStatus == kCFStreamStatusNotOpen) || (writeStatus == kCFStreamStatusNotOpen))
-	{
-		LogVerbose(@"Opening read and write stream...");
-		
-		BOOL r1 = CFReadStreamOpen(readStream);
-		BOOL r2 = CFWriteStreamOpen(writeStream);
-		
-		if (!r1 || !r2)
-		{
-			LogError(@"Error in CFStreamOpen");
-			return NO;
-		}
-	}
-	
-	return YES;
+    LogTrace();
+    
+    NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
+    NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
+    
+    CFStreamStatus readStatus = CFReadStreamGetStatus(readStream);
+    CFStreamStatus writeStatus = CFWriteStreamGetStatus(writeStream);
+    
+    if ((readStatus == kCFStreamStatusNotOpen) || (writeStatus == kCFStreamStatusNotOpen))
+    {
+        LogVerbose(@"Opening read and write stream...");
+        
+        BOOL r1 = CFReadStreamOpen(readStream);
+        BOOL r2 = CFWriteStreamOpen(writeStream);
+        
+        if (!r1 || !r2)
+        {
+            LogError(@"Error in CFStreamOpen");
+            return NO;
+        }
+    }
+    
+    return YES;
 }
 
 #endif
@@ -7016,238 +7242,234 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 /**
  * See header file for big discussion of this method.
-**/
+ **/
 - (BOOL)autoDisconnectOnClosedReadStream
 {
-	// Note: YES means kAllowHalfDuplexConnection is OFF
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		return ((config & kAllowHalfDuplexConnection) == 0);
-	}
-	else
-	{
-		__block BOOL result;
-		
-		dispatch_sync(socketQueue, ^{
-			result = ((config & kAllowHalfDuplexConnection) == 0);
-		});
-		
-		return result;
-	}
+    // Note: YES means kAllowHalfDuplexConnection is OFF
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        return ((config & kAllowHalfDuplexConnection) == 0);
+    }
+    else
+    {
+        __block BOOL result;
+        
+        dispatch_sync(socketQueue, ^{
+            result = ((config & kAllowHalfDuplexConnection) == 0);
+        });
+        
+        return result;
+    }
 }
 
 /**
  * See header file for big discussion of this method.
-**/
+ **/
 - (void)setAutoDisconnectOnClosedReadStream:(BOOL)flag
 {
-	// Note: YES means kAllowHalfDuplexConnection is OFF
-	
-	dispatch_block_t block = ^{
-		
-		if (flag)
-			config &= ~kAllowHalfDuplexConnection;
-		else
-			config |= kAllowHalfDuplexConnection;
-	};
-	
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_async(socketQueue, block);
+    // Note: YES means kAllowHalfDuplexConnection is OFF
+    
+    dispatch_block_t block = ^{
+        
+        if (flag)
+            config &= ~kAllowHalfDuplexConnection;
+        else
+            config |= kAllowHalfDuplexConnection;
+    };
+    
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_async(socketQueue, block);
 }
 
 
 /**
  * See header file for big discussion of this method.
-**/
+ **/
 - (void)markSocketQueueTargetQueue:(dispatch_queue_t)socketNewTargetQueue
 {
-	void *nonNullUnusedPointer = (__bridge void *)self;
-	dispatch_queue_set_specific(socketNewTargetQueue, IsOnSocketQueueOrTargetQueueKey, nonNullUnusedPointer, NULL);
+    void *nonNullUnusedPointer = (__bridge void *)self;
+    dispatch_queue_set_specific(socketNewTargetQueue, IsOnSocketQueueOrTargetQueueKey, nonNullUnusedPointer, NULL);
 }
 
 /**
  * See header file for big discussion of this method.
-**/
+ **/
 - (void)unmarkSocketQueueTargetQueue:(dispatch_queue_t)socketOldTargetQueue
 {
-	dispatch_queue_set_specific(socketOldTargetQueue, IsOnSocketQueueOrTargetQueueKey, NULL, NULL);
+    dispatch_queue_set_specific(socketOldTargetQueue, IsOnSocketQueueOrTargetQueueKey, NULL, NULL);
 }
 
 /**
  * See header file for big discussion of this method.
-**/
+ **/
 - (void)performBlock:(dispatch_block_t)block
 {
-	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-		block();
-	else
-		dispatch_sync(socketQueue, block);
+    if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+        block();
+    else
+        dispatch_sync(socketQueue, block);
 }
 
 /**
  * Questions? Have you read the header file?
-**/
+ **/
 - (int)socketFD
 {
-	if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
-		return SOCKET_NULL;
-	}
-	
-	if (socket4FD != SOCKET_NULL)
-		return socket4FD;
-	else
-		return socket6FD;
+    if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
+        return SOCKET_NULL;
+    }
+    
+    if (socket4FD != SOCKET_NULL)
+        return socket4FD;
+    else
+        return socket6FD;
 }
 
 /**
  * Questions? Have you read the header file?
-**/
+ **/
 - (int)socket4FD
 {
-	if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
-		return SOCKET_NULL;
-	}
-	
-	return socket4FD;
+    if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
+        return SOCKET_NULL;
+    }
+    
+    return socket4FD;
 }
 
 /**
  * Questions? Have you read the header file?
-**/
+ **/
 - (int)socket6FD
 {
-	if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
-		return SOCKET_NULL;
-	}
-	
-	return socket6FD;
+    if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
+        return SOCKET_NULL;
+    }
+    
+    return socket6FD;
 }
 
 #if TARGET_OS_IPHONE
 
 /**
  * Questions? Have you read the header file?
-**/
+ **/
 - (CFReadStreamRef)readStream
 {
-	if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
-		return NULL;
-	}
-	
-	if (readStream == NULL)
-		[self createReadAndWriteStream];
-	
-	return readStream;
+    if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
+        return NULL;
+    }
+    
+    if (readStream == NULL)
+        [self createReadAndWriteStream];
+    
+    return readStream;
 }
 
 /**
  * Questions? Have you read the header file?
-**/
+ **/
 - (CFWriteStreamRef)writeStream
 {
-	if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
-		return NULL;
-	}
-	
-	if (writeStream == NULL)
-		[self createReadAndWriteStream];
-	
-	return writeStream;
+    if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
+        return NULL;
+    }
+    
+    if (writeStream == NULL)
+        [self createReadAndWriteStream];
+    
+    return writeStream;
 }
 
 - (BOOL)enableBackgroundingOnSocketWithCaveat:(BOOL)caveat
 {
-	if (![self createReadAndWriteStream])
-	{
-		// Error occured creating streams (perhaps socket isn't open)
-		return NO;
-	}
-	
-	BOOL r1, r2;
-	
-	LogVerbose(@"Enabling backgrouding on socket");
-	
-	r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
-	r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
-	
-	if (!r1 || !r2)
-	{
-		return NO;
-	}
-	
-	if (!caveat)
-	{
-		if (![self openStreams])
-		{
-			return NO;
-		}
-	}
-	
-	return YES;
+    if (![self createReadAndWriteStream])
+    {
+        // Error occured creating streams (perhaps socket isn't open)
+        return NO;
+    }
+    
+    BOOL r1, r2;
+    
+    LogVerbose(@"Enabling backgrouding on socket");
+    
+    r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+    r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+    
+    if (!r1 || !r2)
+    {
+        return NO;
+    }
+    
+    if (!caveat)
+    {
+        if (![self openStreams])
+        {
+            return NO;
+        }
+    }
+    
+    return YES;
 }
 
 /**
  * Questions? Have you read the header file?
-**/
+ **/
 - (BOOL)enableBackgroundingOnSocket
 {
-	LogTrace();
-	
-	if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
-		return NO;
-	}
-	
-	return [self enableBackgroundingOnSocketWithCaveat:NO];
+    LogTrace();
+    
+    if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
+        return NO;
+    }
+    
+    return [self enableBackgroundingOnSocketWithCaveat:NO];
 }
 
 - (BOOL)enableBackgroundingOnSocketWithCaveat // Deprecated in iOS 4.???
 {
-	// This method was created as a workaround for a bug in iOS.
-	// Apple has since fixed this bug.
-	// I'm not entirely sure which version of iOS they fixed it in...
-	
-	LogTrace();
-	
-	if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
-		return NO;
-	}
-	
-	return [self enableBackgroundingOnSocketWithCaveat:YES];
+    // This method was created as a workaround for a bug in iOS.
+    // Apple has since fixed this bug.
+    // I'm not entirely sure which version of iOS they fixed it in...
+    
+    LogTrace();
+    
+    if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
+        return NO;
+    }
+    
+    return [self enableBackgroundingOnSocketWithCaveat:YES];
 }
 
 #endif
-
-#if SECURE_TRANSPORT_MAYBE_AVAILABLE
 
 - (SSLContextRef)sslContext
 {
-	if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
-	{
-		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
-		return NULL;
-	}
-	
-	return sslContext;
+    if (!dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
+    {
+        LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
+        return NULL;
+    }
+    
+    return sslContext;
 }
-
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Class Utilities
@@ -7255,243 +7477,243 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 + (NSMutableArray *)lookupHost:(NSString *)host port:(uint16_t)port error:(NSError **)errPtr
 {
-	LogTrace();
-	
-	NSMutableArray *addresses = nil;
-	NSError *error = nil;
-	
-	if ([host isEqualToString:@"localhost"] || [host isEqualToString:@"loopback"])
-	{
-		// Use LOOPBACK address
-		struct sockaddr_in nativeAddr4;
-		nativeAddr4.sin_len         = sizeof(struct sockaddr_in);
-		nativeAddr4.sin_family      = AF_INET;
-		nativeAddr4.sin_port        = htons(port);
-		nativeAddr4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-		memset(&(nativeAddr4.sin_zero), 0, sizeof(nativeAddr4.sin_zero));
-		
-		struct sockaddr_in6 nativeAddr6;
-		nativeAddr6.sin6_len        = sizeof(struct sockaddr_in6);
-		nativeAddr6.sin6_family     = AF_INET6;
-		nativeAddr6.sin6_port       = htons(port);
-		nativeAddr6.sin6_flowinfo   = 0;
-		nativeAddr6.sin6_addr       = in6addr_loopback;
-		nativeAddr6.sin6_scope_id   = 0;
-		
-		// Wrap the native address structures
-		
-		NSData *address4 = [NSData dataWithBytes:&nativeAddr4 length:sizeof(nativeAddr4)];
-		NSData *address6 = [NSData dataWithBytes:&nativeAddr6 length:sizeof(nativeAddr6)];
-		
-		addresses = [NSMutableArray arrayWithCapacity:2];
-		[addresses addObject:address4];
-		[addresses addObject:address6];
-	}
-	else
-	{
-		NSString *portStr = [NSString stringWithFormat:@"%hu", port];
-		
-		struct addrinfo hints, *res, *res0;
-		
-		memset(&hints, 0, sizeof(hints));
-		hints.ai_family   = PF_UNSPEC;
-		hints.ai_socktype = SOCK_STREAM;
-		hints.ai_protocol = IPPROTO_TCP;
-		
-		int gai_error = getaddrinfo([host UTF8String], [portStr UTF8String], &hints, &res0);
-		
-		if (gai_error)
-		{
-			error = [self gaiError:gai_error];
-		}
-		else
-		{
-			NSUInteger capacity = 0;
-			for (res = res0; res; res = res->ai_next)
-			{
-				if (res->ai_family == AF_INET || res->ai_family == AF_INET6) {
-					capacity++;
-				}
-			}
-			
-			addresses = [NSMutableArray arrayWithCapacity:capacity];
-			
-			for (res = res0; res; res = res->ai_next)
-			{
-				if (res->ai_family == AF_INET)
-				{
-					// Found IPv4 address.
-					// Wrap the native address structure, and add to results.
-					
-					NSData *address4 = [NSData dataWithBytes:res->ai_addr length:res->ai_addrlen];
-					[addresses addObject:address4];
-				}
-				else if (res->ai_family == AF_INET6)
-				{
-					// Found IPv6 address.
-					// Wrap the native address structure, and add to results.
-					
-					NSData *address6 = [NSData dataWithBytes:res->ai_addr length:res->ai_addrlen];
-					[addresses addObject:address6];
-				}
-			}
-			freeaddrinfo(res0);
-			
-			if ([addresses count] == 0)
-			{
-				error = [self gaiError:EAI_FAIL];
-			}
-		}
-	}
-	
-	if (errPtr) *errPtr = error;
-	return addresses;
+    LogTrace();
+    
+    NSMutableArray *addresses = nil;
+    NSError *error = nil;
+    
+    if ([host isEqualToString:@"localhost"] || [host isEqualToString:@"loopback"])
+    {
+        // Use LOOPBACK address
+        struct sockaddr_in nativeAddr4;
+        nativeAddr4.sin_len         = sizeof(struct sockaddr_in);
+        nativeAddr4.sin_family      = AF_INET;
+        nativeAddr4.sin_port        = htons(port);
+        nativeAddr4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        memset(&(nativeAddr4.sin_zero), 0, sizeof(nativeAddr4.sin_zero));
+        
+        struct sockaddr_in6 nativeAddr6;
+        nativeAddr6.sin6_len        = sizeof(struct sockaddr_in6);
+        nativeAddr6.sin6_family     = AF_INET6;
+        nativeAddr6.sin6_port       = htons(port);
+        nativeAddr6.sin6_flowinfo   = 0;
+        nativeAddr6.sin6_addr       = in6addr_loopback;
+        nativeAddr6.sin6_scope_id   = 0;
+        
+        // Wrap the native address structures
+        
+        NSData *address4 = [NSData dataWithBytes:&nativeAddr4 length:sizeof(nativeAddr4)];
+        NSData *address6 = [NSData dataWithBytes:&nativeAddr6 length:sizeof(nativeAddr6)];
+        
+        addresses = [NSMutableArray arrayWithCapacity:2];
+        [addresses addObject:address4];
+        [addresses addObject:address6];
+    }
+    else
+    {
+        NSString *portStr = [NSString stringWithFormat:@"%hu", port];
+        
+        struct addrinfo hints, *res, *res0;
+        
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_family   = PF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_protocol = IPPROTO_TCP;
+        
+        int gai_error = getaddrinfo([host UTF8String], [portStr UTF8String], &hints, &res0);
+        
+        if (gai_error)
+        {
+            error = [self gaiError:gai_error];
+        }
+        else
+        {
+            NSUInteger capacity = 0;
+            for (res = res0; res; res = res->ai_next)
+            {
+                if (res->ai_family == AF_INET || res->ai_family == AF_INET6) {
+                    capacity++;
+                }
+            }
+            
+            addresses = [NSMutableArray arrayWithCapacity:capacity];
+            
+            for (res = res0; res; res = res->ai_next)
+            {
+                if (res->ai_family == AF_INET)
+                {
+                    // Found IPv4 address.
+                    // Wrap the native address structure, and add to results.
+                    
+                    NSData *address4 = [NSData dataWithBytes:res->ai_addr length:res->ai_addrlen];
+                    [addresses addObject:address4];
+                }
+                else if (res->ai_family == AF_INET6)
+                {
+                    // Found IPv6 address.
+                    // Wrap the native address structure, and add to results.
+                    
+                    NSData *address6 = [NSData dataWithBytes:res->ai_addr length:res->ai_addrlen];
+                    [addresses addObject:address6];
+                }
+            }
+            freeaddrinfo(res0);
+            
+            if ([addresses count] == 0)
+            {
+                error = [self gaiError:EAI_FAIL];
+            }
+        }
+    }
+    
+    if (errPtr) *errPtr = error;
+    return addresses;
 }
 
 + (NSString *)hostFromSockaddr4:(const struct sockaddr_in *)pSockaddr4
 {
-	char addrBuf[INET_ADDRSTRLEN];
-	
-	if (inet_ntop(AF_INET, &pSockaddr4->sin_addr, addrBuf, (socklen_t)sizeof(addrBuf)) == NULL)
-	{
-		addrBuf[0] = '\0';
-	}
-	
-	return [NSString stringWithCString:addrBuf encoding:NSASCIIStringEncoding];
+    char addrBuf[INET_ADDRSTRLEN];
+    
+    if (inet_ntop(AF_INET, &pSockaddr4->sin_addr, addrBuf, (socklen_t)sizeof(addrBuf)) == NULL)
+    {
+        addrBuf[0] = '\0';
+    }
+    
+    return [NSString stringWithCString:addrBuf encoding:NSASCIIStringEncoding];
 }
 
 + (NSString *)hostFromSockaddr6:(const struct sockaddr_in6 *)pSockaddr6
 {
-	char addrBuf[INET6_ADDRSTRLEN];
-	
-	if (inet_ntop(AF_INET6, &pSockaddr6->sin6_addr, addrBuf, (socklen_t)sizeof(addrBuf)) == NULL)
-	{
-		addrBuf[0] = '\0';
-	}
-	
-	return [NSString stringWithCString:addrBuf encoding:NSASCIIStringEncoding];
+    char addrBuf[INET6_ADDRSTRLEN];
+    
+    if (inet_ntop(AF_INET6, &pSockaddr6->sin6_addr, addrBuf, (socklen_t)sizeof(addrBuf)) == NULL)
+    {
+        addrBuf[0] = '\0';
+    }
+    
+    return [NSString stringWithCString:addrBuf encoding:NSASCIIStringEncoding];
 }
 
 + (uint16_t)portFromSockaddr4:(const struct sockaddr_in *)pSockaddr4
 {
-	return ntohs(pSockaddr4->sin_port);
+    return ntohs(pSockaddr4->sin_port);
 }
 
 + (uint16_t)portFromSockaddr6:(const struct sockaddr_in6 *)pSockaddr6
 {
-	return ntohs(pSockaddr6->sin6_port);
+    return ntohs(pSockaddr6->sin6_port);
 }
 
 + (NSString *)hostFromAddress:(NSData *)address
 {
-	NSString *host;
-	
-	if ([self getHost:&host port:NULL fromAddress:address])
-		return host;
-	else
-		return nil;
+    NSString *host;
+    
+    if ([self getHost:&host port:NULL fromAddress:address])
+        return host;
+    else
+        return nil;
 }
 
 + (uint16_t)portFromAddress:(NSData *)address
 {
-	uint16_t port;
-	
-	if ([self getHost:NULL port:&port fromAddress:address])
-		return port;
-	else
-		return 0;
+    uint16_t port;
+    
+    if ([self getHost:NULL port:&port fromAddress:address])
+        return port;
+    else
+        return 0;
 }
 
 + (BOOL)isIPv4Address:(NSData *)address
 {
-	if ([address length] >= sizeof(struct sockaddr))
-	{
-		const struct sockaddr *sockaddrX = [address bytes];
-		
-		if (sockaddrX->sa_family == AF_INET) {
-			return YES;
-		}
-	}
-	
-	return NO;
+    if ([address length] >= sizeof(struct sockaddr))
+    {
+        const struct sockaddr *sockaddrX = [address bytes];
+        
+        if (sockaddrX->sa_family == AF_INET) {
+            return YES;
+        }
+    }
+    
+    return NO;
 }
 
 + (BOOL)isIPv6Address:(NSData *)address
 {
-	if ([address length] >= sizeof(struct sockaddr))
-	{
-		const struct sockaddr *sockaddrX = [address bytes];
-		
-		if (sockaddrX->sa_family == AF_INET6) {
-			return YES;
-		}
-	}
-	
-	return NO;
+    if ([address length] >= sizeof(struct sockaddr))
+    {
+        const struct sockaddr *sockaddrX = [address bytes];
+        
+        if (sockaddrX->sa_family == AF_INET6) {
+            return YES;
+        }
+    }
+    
+    return NO;
 }
 
 + (BOOL)getHost:(NSString **)hostPtr port:(uint16_t *)portPtr fromAddress:(NSData *)address
 {
-	return [self getHost:hostPtr port:portPtr family:NULL fromAddress:address];
+    return [self getHost:hostPtr port:portPtr family:NULL fromAddress:address];
 }
 
 + (BOOL)getHost:(NSString **)hostPtr port:(uint16_t *)portPtr family:(sa_family_t *)afPtr fromAddress:(NSData *)address
 {
-	if ([address length] >= sizeof(struct sockaddr))
-	{
-		const struct sockaddr *sockaddrX = [address bytes];
-		
-		if (sockaddrX->sa_family == AF_INET)
-		{
-			if ([address length] >= sizeof(struct sockaddr_in))
-			{
-				struct sockaddr_in sockaddr4;
-				memcpy(&sockaddr4, sockaddrX, sizeof(sockaddr4));
-				
-				if (hostPtr) *hostPtr = [self hostFromSockaddr4:&sockaddr4];
-				if (portPtr) *portPtr = [self portFromSockaddr4:&sockaddr4];
-				if (afPtr)   *afPtr   = AF_INET;
-				
-				return YES;
-			}
-		}
-		else if (sockaddrX->sa_family == AF_INET6)
-		{
-			if ([address length] >= sizeof(struct sockaddr_in6))
-			{
-				struct sockaddr_in6 sockaddr6;
-				memcpy(&sockaddr6, sockaddrX, sizeof(sockaddr6));
-				
-				if (hostPtr) *hostPtr = [self hostFromSockaddr6:&sockaddr6];
-				if (portPtr) *portPtr = [self portFromSockaddr6:&sockaddr6];
-				if (afPtr)   *afPtr   = AF_INET6;
-				
-				return YES;
-			}
-		}
-	}
-	
-	return NO;
+    if ([address length] >= sizeof(struct sockaddr))
+    {
+        const struct sockaddr *sockaddrX = [address bytes];
+        
+        if (sockaddrX->sa_family == AF_INET)
+        {
+            if ([address length] >= sizeof(struct sockaddr_in))
+            {
+                struct sockaddr_in sockaddr4;
+                memcpy(&sockaddr4, sockaddrX, sizeof(sockaddr4));
+                
+                if (hostPtr) *hostPtr = [self hostFromSockaddr4:&sockaddr4];
+                if (portPtr) *portPtr = [self portFromSockaddr4:&sockaddr4];
+                if (afPtr)   *afPtr   = AF_INET;
+                
+                return YES;
+            }
+        }
+        else if (sockaddrX->sa_family == AF_INET6)
+        {
+            if ([address length] >= sizeof(struct sockaddr_in6))
+            {
+                struct sockaddr_in6 sockaddr6;
+                memcpy(&sockaddr6, sockaddrX, sizeof(sockaddr6));
+                
+                if (hostPtr) *hostPtr = [self hostFromSockaddr6:&sockaddr6];
+                if (portPtr) *portPtr = [self portFromSockaddr6:&sockaddr6];
+                if (afPtr)   *afPtr   = AF_INET6;
+                
+                return YES;
+            }
+        }
+    }
+    
+    return NO;
 }
 
 + (NSData *)CRLFData
 {
-	return [NSData dataWithBytes:"\x0D\x0A" length:2];
+    return [NSData dataWithBytes:"\x0D\x0A" length:2];
 }
 
 + (NSData *)CRData
 {
-	return [NSData dataWithBytes:"\x0D" length:1];
+    return [NSData dataWithBytes:"\x0D" length:1];
 }
 
 + (NSData *)LFData
 {
-	return [NSData dataWithBytes:"\x0A" length:1];
+    return [NSData dataWithBytes:"\x0A" length:1];
 }
 
 + (NSData *)ZeroData
 {
-	return [NSData dataWithBytes:"" length:1];
+    return [NSData dataWithBytes:"" length:1];
 }
 
-@end	
+@end


### PR DESCRIPTION
This commit fixes a number of issues including type changes, ambiguous operators
and some deprecations. Now compiles in XCode 6.4 / Swift 1.2
Also updates to newer versions of the GCDAsyncSocket code to accommodate newer
OS X versions which deprecate some SSL calls

Tested briefly with mosquitto-1.4.2 on the broker side but not guaranteed to be
widely tested or interoperable with other MQTT implementations.

Resolves #2 (but perhaps not very elegantly... :smile:)