### PR TITLE
mqttDidDisconnect(mqtt:withError:) should take an optional `NSError`

### DIFF
--- a/CocoaMQTT/CocoaMQTT.swift
+++ b/CocoaMQTT/CocoaMQTT.swift
@@ -32,7 +32,7 @@ protocol CocoaMQTTDelegate : class {
 
     func mqttDidReceivePong(mqtt: CocoaMQTT)
 
-    func mqttDidDisconnect(mqtt: CocoaMQTT, withError err: NSError)
+    func mqttDidDisconnect(mqtt: CocoaMQTT, withError err: NSError?)
 
 }
 


### PR DESCRIPTION
The `mqttDidDisconnect(mqtt:withError:)` protocol function should take an optional `NSError` instead of a non-optional one.

CocoaMQTT's invocation of `didDisconnect` happens in its own implementation of the `GCDAsyncSocket` delegate implementation of `socketDidDisconnect(sock:, withError:)`. Because of the state of the Swift language, ObjC bridging, and that GCDAsyncSocket hasn't been ObjC-annotated with the recent language/Xcode improvements to allow that... all the ObjC -> Swift bridge can do is declare the socket NSError as `NSError!`.

While that gets things to compile and bridge, it does obscure the fact that the parameter can actually be `nil`! This happens of course in the case where the socket disconnects normally and there is no error to report.

But then when CocoaMQTT attempts to force the nil `NSError` to unwrap, the app crashes.

While it'd be great for GCDAsyncSocket to have updated annotations, the real solution is for the `mqttDidDisconnect` function to accept an optional `NSError`.