### PR TITLE
Add kCFStreamSSLPeerName when starting TLS

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -286,9 +286,9 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, Cocoa
         
         if secureMQTT {
             #if DEBUG
-                sock.startTLS(["GCDAsyncSocketManuallyEvaluateTrust": true])
+                sock.startTLS(["GCDAsyncSocketManuallyEvaluateTrust": true, kCFStreamSSLPeerName: self.host])
             #else
-                sock.startTLS(nil)
+                sock.startTLS([kCFStreamSSLPeerName: self.host])
             #endif
         } else {
             let frame = CocoaMQTTFrameConnect(client: self)


### PR DESCRIPTION
This accomplishes two things:
1. We verify the hostname when connecting via TLS. This ensures that DNS spoofing will not work.
2. MQTT will now use SNI which allows proxies like HAProxy to forward based on the host name.