### PR TITLE
Make MQTTMessage constructors public.

### DIFF
--- a/Source/CocoaMQTTMessage.swift
+++ b/Source/CocoaMQTTMessage.swift
@@ -30,7 +30,7 @@ public class CocoaMQTTMessage {
 
     var dup: Bool = false
 
-    init(topic: String, string: String, qos: CocoaMQTTQOS = .QOS1, retain: Bool = false, dup: Bool = false) {
+    public init(topic: String, string: String, qos: CocoaMQTTQOS = .QOS1, retain: Bool = false, dup: Bool = false) {
         self.topic = topic
         self.payload = [UInt8](string.utf8)
         self.qos = qos
@@ -38,7 +38,7 @@ public class CocoaMQTTMessage {
         self.dup = dup
     }
 
-    init(topic: String, payload: [UInt8], qos: CocoaMQTTQOS = .QOS1, retain: Bool = false, dup: Bool = false) {
+    public init(topic: String, payload: [UInt8], qos: CocoaMQTTQOS = .QOS1, retain: Bool = false, dup: Bool = false) {
         self.topic = topic
         self.payload = payload
         self.qos = qos


### PR DESCRIPTION
I wanted to send a message that wasn't a string - so needed to create my own message and couldn't.

Expect this was just an oversight - since the `.publish` method that takes a message isn't that useful without!