### PR TITLE
Added more functions to CocoaMQTT  to supply mqtt message id

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -219,6 +219,12 @@ open class CocoaMQTT: NSObject, CocoaMQTTClient {
         let message = CocoaMQTTMessage(topic: topic, string: string, qos: qos, retained: retained, dup: dup)
         return publish(message)
     }
+    
+    @discardableResult
+    open func publish(_ topic: String, msgid:UInt16, withString string: String, qos: CocoaMQTTQOS = .qos1, retained: Bool = false, dup: Bool = false) -> UInt16 {
+        let message = CocoaMQTTMessage(topic: topic, string: string, qos: qos, retained: retained, dup: dup)
+        return publish(message,msgid:msgid)
+    }
 
     @discardableResult
     open func publish(_ message: CocoaMQTTMessage) -> UInt16 {
@@ -237,6 +243,24 @@ open class CocoaMQTT: NSObject, CocoaMQTTClient {
 
         return msgid
     }
+    
+    @discardableResult
+    open func publish(_ message: CocoaMQTTMessage, msgid:UInt16) -> UInt16 {
+        gmid = msgid
+        let frame = CocoaMQTTFramePublish(msgid: msgid, topic: message.topic, payload: message.payload)
+        frame.qos = message.qos.rawValue
+        frame.retained = message.retained
+        frame.dup = message.dup
+        send(frame, tag: Int(msgid))
+        
+        if message.qos != CocoaMQTTQOS.qos0 {
+            messages[msgid] = message //cache
+        }
+        
+        delegate?.mqtt(self, didPublishMessage: message, id: msgid)
+        
+        return msgid
+    }
 
     @discardableResult
     open func subscribe(_ topic: String, qos: CocoaMQTTQOS = .qos1) -> UInt16 {
@@ -246,10 +270,28 @@ open class CocoaMQTT: NSObject, CocoaMQTTClient {
         subscriptions[msgid] = topic
         return msgid
     }
+    
+    @discardableResult
+    open func subscribe(_ topic: String, msgid:UInt16, qos: CocoaMQTTQOS = .qos1) -> UInt16 {
+        gmid = msgid
+        let frame = CocoaMQTTFrameSubscribe(msgid: msgid, topic: topic, reqos: qos.rawValue)
+        send(frame, tag: Int(msgid))
+        subscriptions[msgid] = topic
+        return msgid
+    }
 
     @discardableResult
     open func unsubscribe(_ topic: String) -> UInt16 {
         let msgid = nextMessageID()
+        let frame = CocoaMQTTFrameUnsubscribe(msgid: msgid, topic: topic)
+        subscriptions[msgid] = topic
+        send(frame, tag: Int(msgid))
+        return msgid
+    }
+    
+    @discardableResult
+    open func unsubscribe(_ topic: String, msgid:UInt16) -> UInt16 {
+        gmid = msgid
         let frame = CocoaMQTTFrameUnsubscribe(msgid: msgid, topic: topic)
         subscriptions[msgid] = topic
         send(frame, tag: Int(msgid))


### PR DESCRIPTION
Added more functions to CocoaMQTT  to supply mqtt message id from the calling clients.

Currently their is no way to keep track of MQTT message ids used by the application. So added few methods to CocoaMQTT class which allows the client applications to pass their generated MQTT message id and keep track of these ids to resend or validate message PublishAck with stored MQTT message ids.