### PR TITLE
Adding publish complete delegate func

### DIFF
--- a/CocoaMQTTTests/CocoaMQTTTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTTests.swift
@@ -28,7 +28,7 @@ class CocoaMQTTTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -68,6 +68,7 @@ fileprivate enum CocoaMQTTReadTag: Int {
     func mqttDidReceivePong(_ mqtt: CocoaMQTT)
     func mqttDidDisconnect(_ mqtt: CocoaMQTT, withError err: Error?)
     @objc optional func mqtt(_ mqtt: CocoaMQTT, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void)
+    @objc optional func mqtt(_ mqtt: CocoaMQTT, didPublishComplete id: UInt16)
 }
 
 /**
@@ -414,6 +415,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         #endif
 
         messages.removeValue(forKey: msgid)
+        delegate?.mqtt?(self, didPublishComplete: msgid)
     }
 
     func didReceiveSubAck(_ reader: CocoaMQTTReader, msgid: UInt16) {


### PR DESCRIPTION
This will allow SDK consumers to be able to know when message publish process is complete when using QoS 2.