### PR TITLE
let objective-c see CocoaMQTTQOS enum

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -14,7 +14,7 @@ import MSWeakTimer
 /**
  * QOS
  */
-public enum CocoaMQTTQOS: UInt8 {
+@objc public enum CocoaMQTTQOS: UInt8 {
     case qos0 = 0
     case qos1
     case qos2


### PR DESCRIPTION
This addresses issue #126. 

The CocoaMQTTQOS enum was not visible in objective-c so when Xcode generated the header file to expose the swift methods it left out any methods with the CocoaMQTTQOS enum in it, including the ```subscribe``` method.

Note that there are a few other enums that are missing ```@objc```. Should those be included in the PR?