### PR TITLE
Fix a bug: mqtt.subcriptions may record more than one value of a topic.

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -428,6 +428,14 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         
         if let topicDict = subscriptionsWaitingAck.removeValue(forKey: msgid) {
             let topic = topicDict.first!.key
+            
+            // remove subscription with same topic
+            for (key, value) in subscriptions {
+                if value.first!.key == topic {
+                    subscriptions.removeValue(forKey: key)
+                }
+            }
+            
             subscriptions[msgid] = topicDict
             delegate?.mqtt(self, didSubscribeTopic: topic)
         } else {


### PR DESCRIPTION
Remove old subcription value which has the same topic with a new subscrption in mqtt.subscriptions.