### PR TITLE
Update required frameworks for Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install using [Carthage](https://github.com/Carthage/Carthage) by adding the fol
 
 ````
 github "robbiehanson/CocoaAsyncSocket" "master"
-github "CrazyWisdom/MSWeakTimer" "master"
+github "radex/SwiftyTimer" "master"
 github "emqtt/CocoaMQTT" "master"
 ````
 Then, run the following command:


### PR DESCRIPTION
Hi, thanks for this awesome lib :) I've followed the Carthage setup guide provided by you and I believe it is a little bit outdated. I've manage to setup the framework correctly by replacing old `MSWeakTimer` with `SwiftyTimer`. 

I've created a pull request for that change. Feel free to merge or close it if this is not a case. 