### PR TITLE
[bug fix] Unable to Connect() to mqtt

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -161,7 +161,7 @@ open class CocoaMQTT: NSObject, CocoaMQTTClient, CocoaMQTTFrameBufferProtocol {
     open var secureMQTT = false
     open var cleanSession = true
     open var willMessage: CocoaMQTTWill?
-    open weak var delegate: CocoaMQTTDelegate?
+    open var delegate: CocoaMQTTDelegate?
     open var backgroundOnSocket = false
     open var dispatchQueue = DispatchQueue.main
     
@@ -568,7 +568,7 @@ class CocoaMQTTReader {
     private var length: UInt = 0
     private var data: [UInt8] = []
     private var multiply = 1
-    private weak var delegate: CocoaMQTTReaderDelegate?
+    private var delegate: CocoaMQTTReaderDelegate?
     private var timeout = 30000
 
     init(socket: GCDAsyncSocket, delegate: CocoaMQTTReaderDelegate?) {


### PR DESCRIPTION

based on issues https://github.com/emqtt/CocoaMQTT/issues/172
didConnectAct not trigered

Step to reproduce the issues on version 1.1.1:

change  connectToServer() method in ViewController.swift (Example) to:

    @IBAction func connectToServer() {
        let clientID = "CocoaMQTT-\(animal!)-" + String(ProcessInfo().processIdentifier)
        let mqtt = CocoaMQTT(clientID: clientID, host: defaultHost, port: 1883)
        mqtt.username = ""
        mqtt.password = ""
        mqtt.willMessage = CocoaMQTTWill(topic: "/will", message: "dieout")
        mqtt.keepAlive = 60
        mqtt.delegate = self
        mqtt.connect()
    }
    
The delegate didStateChangeTo will only be executed once , after that no delegate would be executed
Thanks
