### PR TITLE
Add clousures beside to delegates

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ mqtt.connect()
 
 ```
 
+Now you can use clousures instead of `CocoaMQTTDelegate`:
+
+```swift 
+mqtt.didReceiveMessage = { mqtt, message, id in
+	print("Message received in topic \(message.topic) with payload \(message.string!)")           
+}
+```
+
 ## SSL Secure
 
 1. One-way certification


### PR DESCRIPTION
Based on issues [#123](https://github.com/emqtt/CocoaMQTT/issues/123)

Now we can use closures instead of delegate. 

Example:

```swift
mqtt.didReceiveMessage = { mqtt, message, id in
    print("Message received in topic \(message.topic) with payload \(message.string!)")           
}
```

Thanks.