### PR TITLE
prevent crash when force unwrapping optional value frame.mgsid

### DIFF
--- a/Source/CocoaMQTTFrame.swift
+++ b/Source/CocoaMQTTFrame.swift
@@ -462,9 +462,10 @@ open class CocoaMQTTFrameBuffer: NSObject {
         send(frame)
         
         Timer.after(timeout.seconds) {
-            let msgid = frame.msgid!
-            if self.removeFrameFromSilos(withMsgid: msgid) {
-                printDebug("timeout of frame:\(msgid)")
+            if let msgid = frame.msgid {
+                if self.removeFrameFromSilos(withMsgid: msgid) {
+                    printDebug("timeout of frame:\(msgid)")
+                }
             }
         }
         


### PR DESCRIPTION
sometimes its crash when accessing frame.mgsid!, im adding "if let" to prevent force unwrapping optional value