### PR TITLE
Fix for severity not working properly in Xcode 10

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -713,8 +713,8 @@ class CocoaMQTTReader {
 
 /// MARK - Logger
 
-public enum CocoaMQTTLoggerLevel {
-    case debug, warning, error, off
+public enum CocoaMQTTLoggerLevel: Int {
+    case debug = 0, warning, error, off
 }
 
 public class CocoaMQTTLogger: NSObject {
@@ -728,7 +728,7 @@ public class CocoaMQTTLogger: NSObject {
     
     // logs
     func log(level: CocoaMQTTLoggerLevel, message: String) {
-        guard level.hashValue >= minLevel.hashValue else { return }
+        guard level.rawValue >= minLevel.rawValue else { return }
         print("CocoaMQTT(\(level)): \(message)")
     }
     


### PR DESCRIPTION
In Xcode 10 raw value should be used instead of hash value for comparing enums