### PR TITLE
Set state back to initial on expected disconnect

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -445,7 +445,9 @@ extension CocoaMQTT: GCDAsyncSocketDelegate {
 
         dispatchQueue.async {
             self.autoReconnTimer?.invalidate()
-            if !self.disconnectExpectedly && self.autoReconnect && self.autoReconnectTimeInterval > 0 {
+            if self.disconnectExpectedly {
+                self.connState = .initial
+            } else if self.autoReconnect && self.autoReconnectTimeInterval > 0 {
                 self.autoReconnTimer = Timer.every(Double(self.autoReconnectTimeInterval), { [weak self] (timer: Timer) in
                     printDebug("try reconnect")
                     self?.connect()


### PR DESCRIPTION
When the host app disconnects MQTT connection I think it is good to set the state back to initial.

Please, feel free to comment on this. This implementation helps me in my app.