### PR TITLE
Improve the implement of frames and testcases

### DIFF
--- a/CocoaMQTT.xcodeproj/project.pbxproj
+++ b/CocoaMQTT.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		8225B556227C334700E4DB51 /* CocoaMQTTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0409971E1C1B0B96006B5A6D /* CocoaMQTTTests.swift */; };
 		8225B557227C334700E4DB51 /* CocoaMQTTFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8270C4AA21DA6F6700C5D485 /* CocoaMQTTFrameTests.swift */; };
 		8225B571227C3B0200E4DB51 /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8225B543227C308900E4DB51 /* CocoaAsyncSocket.framework */; };
+		82519C0722ACC6E100FA0815 /* CocoaMQTTTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82519C0622ACC6E100FA0815 /* CocoaMQTTTypes.swift */; };
 		82CF1FB022943B2100DF539A /* CocoaMQTTReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CF1FAF22943B2100DF539A /* CocoaMQTTReader.swift */; };
 /* End PBXBuildFile section */
 
@@ -44,6 +45,7 @@
 		8225B532227C2E8700E4DB51 /* CocoaMQTT.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CocoaMQTT.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8225B543227C308900E4DB51 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/Mac/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
 		8225B54C227C32C500E4DB51 /* CocoaMQTT-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CocoaMQTT-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		82519C0622ACC6E100FA0815 /* CocoaMQTTTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaMQTTTypes.swift; sourceTree = "<group>"; };
 		8270C4AA21DA6F6700C5D485 /* CocoaMQTTFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaMQTTFrameTests.swift; sourceTree = "<group>"; };
 		82CF1FAF22943B2100DF539A /* CocoaMQTTReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaMQTTReader.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -106,6 +108,7 @@
 				8225B4C8227B182200E4DB51 /* CocoaMQTTTimer.swift */,
 				8225B4CC227B196F00E4DB51 /* CocoaMQTTLogger.swift */,
 				82CF1FAF22943B2100DF539A /* CocoaMQTTReader.swift */,
+				82519C0622ACC6E100FA0815 /* CocoaMQTTTypes.swift */,
 				040997791C1B14F0006B5A6D /* Supporting Files */,
 			);
 			path = Source;
@@ -265,6 +268,7 @@
 				8225B53D227C2FC600E4DB51 /* CocoaMQTTDeliver.swift in Sources */,
 				8225B53E227C2FC600E4DB51 /* CocoaMQTTTimer.swift in Sources */,
 				8225B53F227C2FC600E4DB51 /* CocoaMQTTLogger.swift in Sources */,
+				82519C0722ACC6E100FA0815 /* CocoaMQTTTypes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CocoaMQTTTests/CocoaMQTTFrameTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTFrameTests.swift
@@ -28,17 +28,17 @@ class CocoaMQTTFrameTests: XCTestCase {
         
         var f0 = CocoaMQTTFrameConnect(client: client)
         
-        XCTAssertEqual(f0.header, 0x10)
-        XCTAssertEqual(f0.type, CocoaMQTTFrameType.connect.rawValue)
+        XCTAssertEqual(f0.fixedHeader, 0x10)
+        XCTAssertEqual(f0.type, CocoaMQTTFrameType.connect)
         XCTAssertEqual(f0.dup, false)
-        XCTAssertEqual(f0.qos, 0)
+        XCTAssertEqual(f0.qos, .qos0)
         XCTAssertEqual(f0.retained, false)
         
-        XCTAssertEqual(f0.flags, 0x00)
+        XCTAssertEqual(f0.connFlags, 0x00)
         XCTAssertEqual(f0.flagUsername, false)
         XCTAssertEqual(f0.flagPassword, false)
         XCTAssertEqual(f0.flagWillRetain, false)
-        XCTAssertEqual(f0.flagWillQOS, 0)
+        XCTAssertEqual(f0.flagWillQoS, 0)
         XCTAssertEqual(f0.flagWill, false)
         XCTAssertEqual(f0.flagCleanSession, false)
         
@@ -54,11 +54,11 @@ class CocoaMQTTFrameTests: XCTestCase {
         XCTAssertEqual(f0.flagWillRetain, true)
         f0.flagWillRetain = false
         
-        f0.flagWillQOS = 1
-        XCTAssertEqual(f0.flagWillQOS, 1)
-        f0.flagWillQOS = 2
-        XCTAssertEqual(f0.flagWillQOS, 2)
-        f0.flagWillQOS = 0
+        f0.flagWillQoS = 1
+        XCTAssertEqual(f0.flagWillQoS, 1)
+        f0.flagWillQoS = 2
+        XCTAssertEqual(f0.flagWillQoS, 2)
+        f0.flagWillQoS = 0
         
         f0.flagWill = true
         XCTAssertEqual(f0.flagWill, true)
@@ -68,11 +68,11 @@ class CocoaMQTTFrameTests: XCTestCase {
         XCTAssertEqual(f0.flagCleanSession, true)
         f0.flagCleanSession = false
         
-        XCTAssertEqual(f0.flags, 0x00)
+        XCTAssertEqual(f0.connFlags, 0x00)
         XCTAssertEqual(f0.flagUsername, false)
         XCTAssertEqual(f0.flagPassword, false)
         XCTAssertEqual(f0.flagWillRetain, false)
-        XCTAssertEqual(f0.flagWillQOS, 0)
+        XCTAssertEqual(f0.flagWillQoS, 0)
         XCTAssertEqual(f0.flagWill, false)
         XCTAssertEqual(f0.flagCleanSession, false)
     }
@@ -80,15 +80,24 @@ class CocoaMQTTFrameTests: XCTestCase {
     func testFramePublish() {
         
         // PUBLISH - QOS2 - DUP - RETAINED
-        var f0 = CocoaMQTTFramePublish(header: 0x3D, data: [])
-        XCTAssertEqual(f0.header, 0x3D)
-        XCTAssertEqual(f0.type, CocoaMQTTFrameType.publish.rawValue)
+        guard var f0 = CocoaMQTTFramePublish(fixedHeader: 0x3D, bytes: [0x00, 0x03, 0x74, 0x2f, 0x61, // topic = t/a
+                                                                        0x00, 0x10,                   // msgid = 16
+                                                                        0x61, 0x61, 0x61]) else {     // payload = aaa
+            XCTAssertTrue(false)
+            return
+        }
+        XCTAssertEqual(f0.fixedHeader, 0x3D)
+        XCTAssertEqual(f0.type, CocoaMQTTFrameType.publish)
         XCTAssertEqual(f0.dup, true)
-        XCTAssertEqual(f0.qos, 2)
+        XCTAssertEqual(f0.qos, .qos2)
         XCTAssertEqual(f0.retained, true)
         
+        XCTAssertEqual(f0.topic, "t/a")
+        XCTAssertEqual(f0.msgid, 16)
+        XCTAssertEqual(f0.payload, [0x61, 0x61, 0x61])
+        
         f0.dup = false
-        f0.qos = CocoaMQTTQOS.qos0.rawValue
+        f0.qos = CocoaMQTTQoS.qos0
         f0.retained = false
     
         f0.dup = true
@@ -96,41 +105,44 @@ class CocoaMQTTFrameTests: XCTestCase {
         f0.dup = false
         XCTAssertEqual(f0.dup, false)
         
-        XCTAssertEqual(f0.qos, 0)
+        XCTAssertEqual(f0.qos, .qos0)
         // FIXME: should use Qos Type???
-        f0.qos = CocoaMQTTQOS.qos1.rawValue
-        XCTAssertEqual(f0.qos, 1)
-        f0.qos = CocoaMQTTQOS.qos2.rawValue
-        XCTAssertEqual(f0.qos, 2)
-        f0.qos = CocoaMQTTQOS.qos0.rawValue
-        XCTAssertEqual(f0.qos, 0)
+        f0.qos = CocoaMQTTQoS.qos1
+        XCTAssertEqual(f0.qos, .qos1)
+        f0.qos = CocoaMQTTQoS.qos2
+        XCTAssertEqual(f0.qos, .qos2)
+        f0.qos = CocoaMQTTQoS.qos0
+        XCTAssertEqual(f0.qos, .qos0)
 
         XCTAssertEqual(f0.retained, false)
         f0.retained = true
         XCTAssertEqual(f0.retained, true)
         f0.retained = false
         XCTAssertEqual(f0.retained, false)
+        
+        XCTAssertNil(CocoaMQTTFramePublish(fixedHeader: 0x3D, bytes: []))
+        XCTAssertNil(CocoaMQTTFramePublish(fixedHeader: 0x3D, bytes: [0x00, 0x01, 0x02, 0x03]))
     }
     
     func testFramePubAck() {
         // INITIAL
         var puback = CocoaMQTTFramePubAck(type: .puback, msgid: 0x1010)
-        XCTAssertEqual(puback.header, 0x40)
+        XCTAssertEqual(puback.fixedHeader, 0x40)
         XCTAssertEqual(puback.msgid, 0x1010)
         XCTAssertEqual(puback.data(), [0x40, 0x02, 0x10, 0x10])
         
         var pubrec = CocoaMQTTFramePubAck(type: .pubrec, msgid: 0x1011)
-        XCTAssertEqual(pubrec.header, 0x50)
+        XCTAssertEqual(pubrec.fixedHeader, 0x50)
         XCTAssertEqual(pubrec.msgid, 0x1011)
         XCTAssertEqual(pubrec.data(), [0x50, 0x02, 0x10, 0x11])
         
         var pubrel = CocoaMQTTFramePubAck(type: .pubrel, msgid: 0x1012)
-        XCTAssertEqual(pubrel.header, 0x62)
+        XCTAssertEqual(pubrel.fixedHeader, 0x62)
         XCTAssertEqual(pubrel.msgid, 0x1012)
         XCTAssertEqual(pubrel.data(), [0x62, 0x02, 0x10, 0x12])
         
         var pubcom = CocoaMQTTFramePubAck(type: .pubcomp, msgid: 0x1013)
-        XCTAssertEqual(pubcom.header, 0x70)
+        XCTAssertEqual(pubcom.fixedHeader, 0x70)
         XCTAssertEqual(pubcom.msgid, 0x1013)
         XCTAssertEqual(pubcom.data(), [0x70, 0x02, 0x10, 0x13])
     }
@@ -138,7 +150,7 @@ class CocoaMQTTFrameTests: XCTestCase {
     func testFrameSubscribe() {
         // INITIAL
         var subs = CocoaMQTTFrameSubscribe(msgid: 0x1010, topic: "topic", reqos: .qos1)
-        XCTAssertEqual(subs.header, 0x82)
+        XCTAssertEqual(subs.fixedHeader, 0x82)
         XCTAssertEqual(subs.msgid, 0x1010)
         XCTAssertEqual(subs.topics.count, 1)
         for (t, qos) in subs.topics {
@@ -152,18 +164,33 @@ class CocoaMQTTFrameTests: XCTestCase {
     }
     
     func testFrameSubAck() {
-        // TODO:
+        // INITIAL
+        guard var suback = CocoaMQTTFrameSubAck(fixedHeader: 0x90, bytes: [0x00, 0x11, 0x00, 0x80, 0x02]) else {
+            XCTAssertTrue(false)
+            return
+        }
+        XCTAssertEqual(suback.type, .suback)
+        XCTAssertEqual(suback.qos, .qos0)
+        XCTAssertEqual(suback.dup, false)
+        XCTAssertEqual(suback.retained, false)
+        
+        XCTAssertEqual(suback.msgid, 17)
+        XCTAssertEqual(suback.grantedQos, [.qos0, .FAILTURE, .qos2])
+        
+        XCTAssertNil(CocoaMQTTFrameSubAck(fixedHeader: 0x90, bytes: []))
+        XCTAssertNil(CocoaMQTTFrameSubAck(fixedHeader: 0x90, bytes: [0x00, 0x01, 0x22]))
     }
     
     func testFrameUnsubscribe() {
         // INITIAL
-        var unsub = CocoaMQTTFrameUnsubscribe(msgid: 0x1010, topic: "topic")
-        XCTAssertEqual(unsub.header, 0xA2)
+        var unsub = CocoaMQTTFrameUnsubscribe(msgid: 0x1010, topics: ["topic", "t2"])
+        XCTAssertEqual(unsub.fixedHeader, 0xA2)
         XCTAssertEqual(unsub.msgid, 0x1010)
-        XCTAssertEqual(unsub.topic, "topic")
-        XCTAssertEqual(unsub.data(), [0xA2, 0x09,
+        XCTAssertEqual(unsub.topics, ["topic", "t2"])
+        XCTAssertEqual(unsub.data(), [0xA2, 0x0d,
                                       0x10, 0x10,
-                                      0x00, 0x05, 0x74, 0x6F, 0x70, 0x69, 0x63])
+                                      0x00, 0x05, 0x74, 0x6F, 0x70, 0x69, 0x63,
+                                      0x00, 0x02, 0x74, 0x32])
     }
     
     func testFrameUnsubAck() {
@@ -173,18 +200,18 @@ class CocoaMQTTFrameTests: XCTestCase {
     func testFrameDisconnect() {
         // INITIAL
         var disconn = CocoaMQTTFrameDisconnect()
-        XCTAssertEqual(disconn.header, 0xE0)
+        XCTAssertEqual(disconn.fixedHeader, 0xE0)
         XCTAssertEqual(disconn.data(), [0xE0, 0x00])
     }
     
     func testFramePing() {
         // INITIAL
         var ping = CocoaMQTTFramePing()
-        XCTAssertEqual(ping.header, 0xC0)
+        XCTAssertEqual(ping.fixedHeader, 0xC0)
         XCTAssertEqual(ping.data(), [0xC0, 0x00])
     }
     
-    func testFramePoing() {
+    func testFramePong() {
         // TODO:
     }
 }

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -124,6 +124,7 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: CocoaMQTTDelegate {
+    
     // Optional ssl CocoaMQTTDelegate
     func mqtt(_ mqtt: CocoaMQTT, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void) {
         TRACE("trust: \(trust)")
@@ -143,7 +144,7 @@ extension ViewController: CocoaMQTTDelegate {
         TRACE("ack: \(ack)")
 
         if ack == .accept {
-            mqtt.subscribe("chat/room/animals/client/+", qos: CocoaMQTTQOS.qos1)
+            mqtt.subscribe("chat/room/animals/client/+", qos: CocoaMQTTQoS.qos1)
             
             let chatViewController = storyboard?.instantiateViewController(withIdentifier: "ChatViewController") as? ChatViewController
             chatViewController?.mqtt = mqtt
@@ -170,12 +171,12 @@ extension ViewController: CocoaMQTTDelegate {
         NotificationCenter.default.post(name: name, object: self, userInfo: ["message": message.string!, "topic": message.topic])
     }
     
-    func mqtt(_ mqtt: CocoaMQTT, didSubscribeTopic topics: [String]) {
+    func mqtt(_ mqtt: CocoaMQTT, didSubscribeTopics topics: [String]) {
         TRACE("topics: \(topics)")
     }
     
-    func mqtt(_ mqtt: CocoaMQTT, didUnsubscribeTopic topic: String) {
-        TRACE("topic: \(topic)")
+    func mqtt(_ mqtt: CocoaMQTT, didUnsubscribeTopics topics: [String]) {
+        TRACE("topic: \(topics)")
     }
     
     func mqttDidPing(_ mqtt: CocoaMQTT) {

--- a/Source/CocoaMQTTDeliver.swift
+++ b/Source/CocoaMQTTDeliver.swift
@@ -69,11 +69,13 @@ class CocoaMQTTDeliver: NSObject {
         }
         
         // Insert to In-flight window for Qos1/Qos2 message
-        if frame.qos != 0 && frame.msgid != nil {
+        if frame.qos != .qos0 {
             let _ = CocoaMQTTTimer.after(timeout) { [weak self] in
                 guard let weakSelf = self else { return }
-                printDebug("re-delvery frame \(frame)")
-                weakSelf.send(frame)
+                var dupFrame = frame
+                dupFrame.dup = true
+                printDebug("re-delvery frame \(dupFrame)")
+                weakSelf.send(dupFrame)
             }
             inflight.append(frame)
         }

--- a/Source/CocoaMQTTMessage.swift
+++ b/Source/CocoaMQTTMessage.swift
@@ -9,38 +9,33 @@
 import Foundation
 
 
-/**
- * MQTT Message
- */
+/// MQTT Message
 public class CocoaMQTTMessage: NSObject {
-    public var qos = CocoaMQTTQOS.qos1
-    public var dup = false
-
+    public var qos = CocoaMQTTQoS.qos1
+    
     public var topic: String
     public var payload: [UInt8]
     public var retained = false
     
-    // utf8 bytes array to string
+    /// Return the payload as a utf8 string if possiable
     public var string: String? {
         get {
             return NSString(bytes: payload, length: payload.count, encoding: String.Encoding.utf8.rawValue) as String?
         }
     }
     
-    public init(topic: String, string: String, qos: CocoaMQTTQOS = .qos1, retained: Bool = false, dup: Bool = false) {
+    public init(topic: String, string: String, qos: CocoaMQTTQoS = .qos1, retained: Bool = false) {
         self.topic = topic
         self.payload = [UInt8](string.utf8)
         self.qos = qos
         self.retained = retained
-        self.dup = dup
     }
 
-    public init(topic: String, payload: [UInt8], qos: CocoaMQTTQOS = .qos1, retained: Bool = false, dup: Bool = false) {
+    public init(topic: String, payload: [UInt8], qos: CocoaMQTTQoS = .qos1, retained: Bool = false) {
         self.topic = topic
         self.payload = payload
         self.qos = qos
         self.retained = retained
-        self.dup = dup
     }
 }
 

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -1,0 +1,63 @@
+//
+//  CocoaMQTTTypes.swift
+//  CocoaMQTT
+//
+//  Created by HJianBo on 2019/6/9.
+//  Copyright © 2019 emqtt.io. All rights reserved.
+//
+
+import Foundation
+
+
+/// Encode and Decode big-endian UInt16
+extension UInt16 {
+    
+    /// Most Significant Byte (MSB)
+    private var highByte: UInt8 {
+        return UInt8( (self & 0xFF00) >> 8)
+    }
+    
+    /// Least Significant Byte (LSB)
+    private var lowByte: UInt8 {
+        return UInt8(self & 0x00FF)
+    }
+    
+    var hlBytes: [UInt8] {
+        return [highByte, lowByte]
+    }
+}
+
+
+extension String {
+    
+    /// String with two bytes length
+    var bytesWithLength: [UInt8] {
+        return UInt16(utf8.count).hlBytes + utf8
+    }
+}
+
+
+extension Bool {
+    
+    /// Bool to bit of UInt8
+    var bit: UInt8 {
+        return self ? 1 : 0
+    }
+    
+    /// Initial a bool with a bit
+    init(bit: UInt8) {
+        self = (bit == 0) ? false : true
+    }
+}
+
+extension UInt8 {
+    
+    /// Read a bit value
+    func bitAt(_ offset: UInt8) -> UInt8 {
+        return (self >> offset) & 0x01
+    }
+}
+
+public enum CocoaMQTTError: Error {
+    case invalidFrameStructrue
+}


### PR DESCRIPTION
Hi, guys. I have improved the implement of frames and test cases:

-  Refactor all of the CocoaMQTTFrame structs
- The 'unsubscribe' function can unsubscribe a topic list at once
- Modify the function signature for 'CocoaMQTTDelegate'
- Remove the 'dup' argument  from 'publish' function
- Rename 'CocoaMQTTQOS' to 'CocoaMQTTQoS' and Add an enum member 'FAILURE' to 'CocoaMQTTQoS'
- Pretty comments for code