### PR TITLE
fix: preserve durable recovery and numeric ordering

### DIFF
--- a/Source/CocoaMQTTDeliver.swift
+++ b/Source/CocoaMQTTDeliver.swift
@@ -69,7 +69,7 @@ class CocoaMQTTDeliver: NSObject {
     var storage: CocoaMQTTStorage?
 
     func recoverSessionBy(_ storage: CocoaMQTTStorage) {
-        let frames = storage.takeAll()
+        let frames = storage.readAll()
         // Sync to push the frame to mqueue for avoiding overcommit
         deliverQueue.sync {
             self.storage = storage

--- a/Source/CocoaMQTTStorage.swift
+++ b/Source/CocoaMQTTStorage.swift
@@ -127,7 +127,19 @@ final class CocoaMQTTStorage: CocoaMQTTStorageProtocol {
     private func __read(needDelete: Bool) -> [Frame] {
         var frames = [Frame]()
         let allObjs = userDefault.dictionaryRepresentation().sorted { (k1, k2) in
-            return k1.key < k2.key
+            let left = UInt16(k1.key)
+            let right = UInt16(k2.key)
+
+            switch (left, right) {
+            case let (l?, r?):
+                return l < r
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            case (nil, nil):
+                return k1.key < k2.key
+            }
         }
         for (k, v) in allObjs {
             guard let bytes = v as? [UInt8] else { continue }


### PR DESCRIPTION
## What changed
- switch session recovery to non-destructive reads (`readAll`) so persisted QoS frames are not deleted before ACK
- sort persisted storage keys by numeric `msgid` value during recovery to keep send order (`1,2,10` instead of `1,10,2`)
- add regression tests for both behaviors:
  - `testRecoverSessionKeepStoredFramesUntilAck`
  - `testReadAllSortByNumericMsgid`

## Why
`takeAll()` removed persisted frames during reconnect. If the app crashed before PUBACK/PUBCOMP, the recovered QoS frame was lost permanently. Also, lexicographic sorting of string keys could reorder recovered messages.

## Verification
- started local EMQX broker (ports `1883`, `8083`, `8883`)
- `swift build`
- `swift test`
- `swift package plugin --allow-writing-to-package-directory swiftlint --config .swiftlint.yml --strict --reporter github-actions-logging`
- `swift build && swift test`

## Notes
- `xcodebuild -project CocoaMQTT.xcodeproj -scheme "Mac Framework"` cannot complete in this local environment because Carthage XCFrameworks are not present (`Carthage/Build/*.xcframework`).
