### PR TITLE
Fix WebSockets subspec platform declarations

### DIFF
--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -27,8 +27,6 @@ Pod::Spec.new do |s|
     # values from the parent spec, so all supported platforms are redeclared.
     ss.ios.deployment_target = "12.0"
     ss.osx.deployment_target = "10.13"
-    # Support Starscream 4.x and 5.x API
-    # Starscream 4.0.8+ requires tvOS 12.0 in CocoaPods, so tvOS is raised here.
     ss.tvos.deployment_target = "12.0"
     ss.dependency "Starscream", ">= 4.0.8", "< 6.0"
     ss.source_files = "Source/CocoaMQTTWebSocket.swift"


### PR DESCRIPTION
## Summary
- redeclare iOS/macOS deployment targets in `WebSockets` subspec
- keep tvOS at 12.0 for Starscream 4.0.8+ compatibility
- add a short comment explaining CocoaPods subspec platform override behavior

## Why
`CocoaMQTT/WebSockets` resolved to tvOS-only platforms in podspec metadata, causing iOS integration to fail.

Fixes #653

## Verification
- `pod ipc spec CocoaMQTT.podspec` -> WebSockets platforms include iOS/macOS/tvOS
- `pod spec lint CocoaMQTT.podspec --quick --allow-warnings`