### PR TITLE
chore: prepare 2.2.1 release

### DIFF
--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "CocoaMQTT"
-  s.version     = "2.2.0"
+  s.version     = "2.2.1"
   s.summary     = "MQTT v3.1.1 client library for iOS and OS X written with Swift 5"
   s.homepage    = "https://github.com/emqx/CocoaMQTT"
   s.license     = { :type => "MIT" }
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "12.0"
   s.tvos.deployment_target = "10.0"
   # s.watchos.deployment_target = "2.0"
-  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.2.0"}
+  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.2.1"}
   s.default_subspec = 'Core'
   
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
## What changed
- bump CocoaMQTT podspec version from 2.2.0 to 2.2.1
- bump podspec source tag from 2.2.0 to 2.2.1

## Why
Prepare the next patch release after merging the WebSockets subspec platform fix.

## Verification
- pod ipc spec CocoaMQTT.podspec
