### PR TITLE
fix: clamp retry interval nanoseconds overflow

### DIFF
--- a/CocoaMQTTTests/CocoaMQTTDeliverTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTDeliverTests.swift
@@ -175,6 +175,19 @@ class CocoaMQTTDeliverTests: XCTestCase {
         XCTAssertEqual(deliver.t_retryIntervalNanoseconds(), 1)
     }
 
+    func testRetryIntervalNanosecondsHandlesInvalidAndHugeValues() {
+        let deliver = CocoaMQTTDeliver()
+
+        deliver.retryTimeInterval = .infinity
+        XCTAssertEqual(deliver.t_retryIntervalNanoseconds(), 1)
+
+        deliver.retryTimeInterval = .nan
+        XCTAssertEqual(deliver.t_retryIntervalNanoseconds(), 1)
+
+        deliver.retryTimeInterval = (Double(UInt64.max) / 1_000_000.0) + 1
+        XCTAssertEqual(deliver.t_retryIntervalNanoseconds(), UInt64.max)
+    }
+
     func testRedeliverWithZeroRetryIntervalDoesNotCrash() {
         let caller = Caller()
         let deliver = CocoaMQTTDeliver()

--- a/Source/CocoaMQTTDeliver.swift
+++ b/Source/CocoaMQTTDeliver.swift
@@ -216,6 +216,9 @@ extension CocoaMQTTDeliver {
         guard intervalNs.isFinite, intervalNs > 0 else {
             return 1
         }
+        if intervalNs >= Double(UInt64.max) {
+            return UInt64.max
+        }
         return UInt64(intervalNs.rounded())
     }
 


### PR DESCRIPTION
## What changed
- Clamp oversized finite retry intervals to `UInt64.max` before converting from `Double`
- Keep non-positive and invalid retry intervals clamped to `1`
- Add a focused regression test for `.infinity`, `.nan`, and oversized finite values

## Why
Converting very large finite retry intervals directly from `Double` to `UInt64` can overflow and crash. This change makes the conversion saturation-safe.

## Verification
- `SWIFTPM_ENABLE_PLUGINS=0 swift test --filter CocoaMQTTDeliverTests`