### PR TITLE
chore: harden GitHub Actions workflow security

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -14,6 +14,9 @@ on:
       - "*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -168,7 +171,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@19a43a6a2428d455dbd1b85344698725179c9d8c # v1
         with:
           ruby-version: "3.2"
 

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/swiftlint.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   swiftlint:
     name: SwiftLint (SPM plugin)


### PR DESCRIPTION
## Summary
- add explicit least-privilege `permissions: contents: read` to CI workflows flagged by code scanning
- pin `ruby/setup-ruby` to a full commit SHA in `distribution-check.yml`

## Why
GitHub code scanning reported open alerts for:
- `actions/missing-workflow-permissions`
- `actions/unpinned-tag`

This PR resolves those alerts by hardening workflow token permissions and pinning third-party action references.

## Verification
- reviewed workflow diffs for the three affected files
- `git diff --check`
