### PR TITLE
test: cover MQTT5 publish receive ack paths

### DIFF
--- a/CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift
+++ b/CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift
@@ -6,13 +6,30 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
 
     private final class SocketSpy: CocoaMQTTSocketProtocol {
         var enableSSL: Bool = false
+        var writes: [Data] = []
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
         func connect(toHost host: String, onPort port: UInt16) throws {}
         func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
         func disconnect() {}
         func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
-        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {}
+        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
+            writes.append(data)
+        }
+    }
+
+    private func decodePublishFromOutboundFrame(_ publish: FramePublish) -> FramePublish? {
+        let packet = publish.bytes(version: "5.0")
+        let remainingLength = decodeVariableByteInteger(data: packet, offset: 1)
+        let body = [UInt8](packet[remainingLength.newOffset..<packet.count])
+        return FramePublish(packetFixedHeaderType: packet[0], bytes: body)
+    }
+
+    private func frameType(from data: Data) -> UInt8? {
+        guard let firstByte = data.first else {
+            return nil
+        }
+        return firstByte & 0xF0
     }
 
     func testDidReceiveMessageMapsContentType() {
@@ -33,10 +50,7 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
         let publishProperties = MqttPublishProperties(contentType: "application/json")
         var outboundPublish = FramePublish(topic: "t/content-type", payload: [0x7B, 0x7D], qos: .qos0)
         outboundPublish.publishProperties = publishProperties
-        let packet = outboundPublish.bytes(version: "5.0")
-        let remainingLength = decodeVariableByteInteger(data: packet, offset: 1)
-        let body = [UInt8](packet[remainingLength.newOffset..<packet.count])
-        guard let publish = FramePublish(packetFixedHeaderType: packet[0], bytes: body) else {
+        guard let publish = decodePublishFromOutboundFrame(outboundPublish) else {
             XCTFail("Failed to decode MQTT5 publish frame")
             return
         }
@@ -70,10 +84,7 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
         )
         var outboundPublish = FramePublish(topic: "t/properties", payload: [0x7B, 0x7D], qos: .qos0)
         outboundPublish.publishProperties = publishProperties
-        let packet = outboundPublish.bytes(version: "5.0")
-        let remainingLength = decodeVariableByteInteger(data: packet, offset: 1)
-        let body = [UInt8](packet[remainingLength.newOffset..<packet.count])
-        guard let publish = FramePublish(packetFixedHeaderType: packet[0], bytes: body) else {
+        guard let publish = decodePublishFromOutboundFrame(outboundPublish) else {
             XCTFail("Failed to decode MQTT5 publish frame")
             return
         }
@@ -91,5 +102,48 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
         XCTAssertNil(callbackMessage?.willResponseTopic)
         XCTAssertNil(callbackMessage?.willCorrelationData)
         XCTAssertNil(callbackMessage?.willUserProperty)
+        XCTAssertNil(callbackMessage?.contentType)
+    }
+
+    func testDidReceiveQoS1PublishSendsPuback() {
+        CocoaMQTTStorage()?.setMQTTVersion("5.0")
+        defer { CocoaMQTTStorage()?.setMQTTVersion("3.1.1") }
+
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "mq5-recv-qos1-\(UUID().uuidString)", socket: socket)
+        let reader = CocoaMQTTReader(socket: socket, delegate: nil)
+
+        var outboundPublish = FramePublish(topic: "t/qos1", payload: [0x31], qos: .qos1, msgid: 42)
+        outboundPublish.publishProperties = MqttPublishProperties(contentType: "text/plain")
+        guard let publish = decodePublishFromOutboundFrame(outboundPublish) else {
+            XCTFail("Failed to decode MQTT5 QoS1 publish frame")
+            return
+        }
+
+        mqtt5.didReceive(reader, publish: publish)
+
+        XCTAssertEqual(socket.writes.count, 1)
+        XCTAssertEqual(frameType(from: socket.writes[0]), FrameType.puback.rawValue)
+    }
+
+    func testDidReceiveQoS2PublishSendsPubrec() {
+        CocoaMQTTStorage()?.setMQTTVersion("5.0")
+        defer { CocoaMQTTStorage()?.setMQTTVersion("3.1.1") }
+
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "mq5-recv-qos2-\(UUID().uuidString)", socket: socket)
+        let reader = CocoaMQTTReader(socket: socket, delegate: nil)
+
+        var outboundPublish = FramePublish(topic: "t/qos2", payload: [0x32], qos: .qos2, msgid: 77)
+        outboundPublish.publishProperties = MqttPublishProperties(contentType: "text/plain")
+        guard let publish = decodePublishFromOutboundFrame(outboundPublish) else {
+            XCTFail("Failed to decode MQTT5 QoS2 publish frame")
+            return
+        }
+
+        mqtt5.didReceive(reader, publish: publish)
+
+        XCTAssertEqual(socket.writes.count, 1)
+        XCTAssertEqual(frameType(from: socket.writes[0]), FrameType.pubrec.rawValue)
     }
 }


### PR DESCRIPTION
## Why
Recent master changes in `CocoaMQTT5.didReceive(_:publish:)` focused on MQTT5 publish-property mapping, but tests only exercised QoS0 receive flows. The QoS1/QoS2 ACK branches in the same method were still untested.

## What changed
- extended `CocoaMQTT5ReceiveMessageContentTypeTests` with a write-capturing socket spy
- added helpers to decode outbound MQTT5 publish frames and inspect emitted frame types
- added focused tests for receive ACK behavior:
  - `testDidReceiveQoS1PublishSendsPuback`
  - `testDidReceiveQoS2PublishSendsPubrec`
- tightened an existing assertion to verify `message.contentType` stays nil when publish properties omit content type

## Review guide
- start with `CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift`
- confirm each new test feeds a decoded MQTT5 PUBLISH frame into `didReceive(_:publish:)` and asserts the ACK frame type written to socket

## Verification
- `swift test --filter CocoaMQTT5ReceiveMessageContentTypeTests`
