### PR TITLE
test: cover MQTT5 QoS0 receive path without properties

### DIFF
--- a/CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift
+++ b/CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift
@@ -147,6 +147,34 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
         XCTAssertEqual(frameType(from: socket.writes[0]), FrameType.pubrec.rawValue)
     }
 
+    func testDidReceiveQoS0PublishWithoutPropertiesDoesNotSendAck() {
+        CocoaMQTTStorage()?.setMQTTVersion("5.0")
+        defer { CocoaMQTTStorage()?.setMQTTVersion("3.1.1") }
+
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "mq5-recv-qos0-\(UUID().uuidString)", socket: socket)
+        let reader = CocoaMQTTReader(socket: socket, delegate: nil)
+
+        var callbackMessage: CocoaMQTT5Message?
+        var callbackPublishData: MqttDecodePublish?
+        mqtt5.didReceiveMessage = { _, message, _, publishData in
+            callbackMessage = message
+            callbackPublishData = publishData
+        }
+
+        let outboundPublish = FramePublish(topic: "t/qos0", payload: [0x30], qos: .qos0)
+        guard let publish = decodePublishFromOutboundFrame(outboundPublish) else {
+            XCTFail("Failed to decode MQTT5 QoS0 publish frame")
+            return
+        }
+
+        mqtt5.didReceive(reader, publish: publish)
+
+        XCTAssertTrue(socket.writes.isEmpty)
+        XCTAssertNil(callbackMessage?.contentType)
+        XCTAssertNil(callbackPublishData)
+    }
+
     func testDidReceiveMessageWithContentTypeAndUnspecifiedPayloadFormatKeepsWillPropertiesUnset() {
         CocoaMQTTStorage()?.setMQTTVersion("5.0")
         defer { CocoaMQTTStorage()?.setMQTTVersion("3.1.1") }

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -765,14 +765,15 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
     func didReceive(_ reader: CocoaMQTTReader, publish: FramePublish) {
         printDebug("RECV: \(publish)")
 
+        let publishData = (publish.publishRecProperties?.propertyLength ?? 0) > 0 ? publish.publishRecProperties : nil
         let message = CocoaMQTT5Message(topic: publish.mqtt5Topic, payload: publish.payload5(), qos: publish.qos, retained: publish.retained)
 
         message.duplicated = publish.dup
-        message.contentType = publish.publishRecProperties?.contentType
+        message.contentType = publishData?.contentType
 
         printInfo("Received message: \(message)")
-        delegate?.mqtt5(self, didReceiveMessage: message, id: publish.msgid, publishData: publish.publishRecProperties ?? nil)
-        didReceiveMessage(self, message, publish.msgid, publish.publishRecProperties ?? nil)
+        delegate?.mqtt5(self, didReceiveMessage: message, id: publish.msgid, publishData: publishData)
+        didReceiveMessage(self, message, publish.msgid, publishData)
 
         if message.qos == .qos1 {
             puback(FrameType.puback, msgid: publish.msgid)


### PR DESCRIPTION
## What changed
- Added a focused regression test for MQTT5 QoS0 receive frames without publish properties.
- Updated `CocoaMQTT5.didReceive(_:publish:)` to treat decoded publish properties as absent when `propertyLength == 0`.
- Kept content type mapping aligned with the effective `publishData` passed to callbacks.

## Why this improves coverage
Recent `master` receive-path fixes covered MQTT5 publish-property mapping and QoS1/QoS2 ACK behavior, but the QoS0 + no-properties branch in the same method remained untested. This path is important because QoS0 must not send ACK frames, and callback metadata should represent that no MQTT5 publish properties were present.

## Before vs after
- Before this patch, the new test failed: callbacks received a non-`nil` empty `MqttDecodePublish` object for a no-properties QoS0 publish.
- After this patch, callbacks receive `publishData == nil`, `message.contentType == nil`, and no outbound ACK frame is written.

## Verification
- `swift test --filter CocoaMQTT5ReceiveMessageContentTypeTests`