### PR TITLE
test: cover MQTT5 QoS0 receive no-ack branch

### DIFF
--- a/CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift
+++ b/CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift
@@ -147,6 +147,26 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
         XCTAssertEqual(frameType(from: socket.writes[0]), FrameType.pubrec.rawValue)
     }
 
+    func testDidReceiveQoS0PublishDoesNotSendAck() {
+        CocoaMQTTStorage()?.setMQTTVersion("5.0")
+        defer { CocoaMQTTStorage()?.setMQTTVersion("3.1.1") }
+
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "mq5-recv-qos0-\(UUID().uuidString)", socket: socket)
+        let reader = CocoaMQTTReader(socket: socket, delegate: nil)
+
+        var outboundPublish = FramePublish(topic: "t/qos0", payload: [0x30], qos: .qos0)
+        outboundPublish.publishProperties = MqttPublishProperties(contentType: "text/plain")
+        guard let publish = decodePublishFromOutboundFrame(outboundPublish) else {
+            XCTFail("Failed to decode MQTT5 QoS0 publish frame")
+            return
+        }
+
+        mqtt5.didReceive(reader, publish: publish)
+
+        XCTAssertTrue(socket.writes.isEmpty)
+    }
+
     func testDidReceiveMessageWithContentTypeAndUnspecifiedPayloadFormatKeepsWillPropertiesUnset() {
         CocoaMQTTStorage()?.setMQTTVersion("5.0")
         defer { CocoaMQTTStorage()?.setMQTTVersion("3.1.1") }


### PR DESCRIPTION
## What changed
- added `testDidReceiveQoS0PublishDoesNotSendAck` in `CocoaMQTT5ReceiveMessageContentTypeTests`
- exercised the `CocoaMQTT5.didReceive(_:publish:)` QoS0 path where no ACK frame should be written
- reused the existing socket spy to assert outbound writes stay empty for QoS0 receives

## Why this improves coverage
Recent master changes added explicit ACK behavior tests for QoS1/QoS2 publish receive flows, but the adjacent QoS0 branch remained untested. This test closes that gap and protects against regressions that would incorrectly send PUBACK/PUBREC for QoS0 traffic.

## Verification
- `swift test --filter CocoaMQTT5ReceiveMessageContentTypeTests`

## Notes for reviewers
- Scope is intentionally small and limited to the changed MQTT5 receive-path area.
