### PR TITLE
chore: prepare 2.2.4 release

### DIFF
--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "CocoaMQTT"
-  s.version     = "2.2.3"
+  s.version     = "2.2.4"
   s.summary     = "MQTT v3.1.1 client library for iOS and OS X written with Swift 5"
   s.homepage    = "https://github.com/emqx/CocoaMQTT"
   s.license     = { :type => "MIT" }
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "12.0"
   s.tvos.deployment_target = "10.0"
   # s.watchos.deployment_target = "2.0"
-  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.2.3"}
+  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.2.4"}
   s.default_subspec = 'Core'
   
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
## Summary
- bump CocoaMQTT.podspec version to 2.2.4
- update CocoaMQTT.podspec source tag to 2.2.4

## Release notes
- Fix MQTT 5 SUBACK parsing for rejected subscription reason codes.
- Handle MQTT 5 SUBACK properties before reason codes, including multi-byte property length.
- Fix MQTT 5 SUBACK User Property decoding crash.

## Verification
- swift build
- swift package dump-package
- swift package plugin --allow-writing-to-package-directory swiftlint --config .swiftlint.yml --strict --reporter github-actions-logging
- swift test --filter FrameTests --filter CocoaMQTTReaderProtocolErrorTests
- pod lib lint CocoaMQTT.podspec --subspec=Core --platforms=macos --allow-warnings --skip-tests --fail-fast --verbose
- pod lib lint CocoaMQTT.podspec --subspec=WebSockets --platforms=macos --allow-warnings --skip-tests --fail-fast --verbose

Note: full local CocoaPods lint reached iOS simulator selection and failed because this machine has no matching iOS 26.4 simulator destination; macOS subspec lint passed locally and PR CI will run the full release lint on GitHub runners.