### PR TITLE
Expose reconnect scheduling metrics

### DIFF
--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "CocoaMQTT"
-  s.version     = "2.2.4"
+  s.version     = "2.2.5"
   s.summary     = "MQTT v3.1.1 client library for iOS and OS X written with Swift 5"
   s.homepage    = "https://github.com/emqx/CocoaMQTT"
   s.license     = { :type => "MIT" }
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "12.0"
   s.tvos.deployment_target = "10.0"
   # s.watchos.deployment_target = "2.0"
-  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.2.4"}
+  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.2.5"}
   s.default_subspec = 'Core'
   
   s.subspec 'Core' do |ss|

--- a/CocoaMQTTTests/AutoReconnectStateTests.swift
+++ b/CocoaMQTTTests/AutoReconnectStateTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import XCTest
+@testable import CocoaMQTT
+
+final class AutoReconnectStateTests: XCTestCase {
+
+    private final class SocketSpy: CocoaMQTTSocketProtocol {
+        var enableSSL: Bool = false
+        private(set) weak var delegate: CocoaMQTTSocketDelegate?
+        private(set) var connectCount = 0
+        private(set) var disconnectCount = 0
+
+        func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
+            delegate = theDelegate
+        }
+
+        func connect(toHost host: String, onPort port: UInt16) throws {
+            connectCount += 1
+        }
+
+        func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {
+            connectCount += 1
+        }
+
+        func disconnect() {
+            disconnectCount += 1
+        }
+
+        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
+        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {}
+    }
+
+    private struct ReconnectSchedule: Equatable {
+        let attemptCount: UInt
+        let interval: UInt16
+    }
+
+    private final class MQTTDelegateSpy: NSObject, CocoaMQTTDelegate {
+        private(set) var reconnectSchedules: [ReconnectSchedule] = []
+
+        func mqtt(_ mqtt: CocoaMQTT, didConnectAck ack: CocoaMQTTConnAck) {}
+        func mqtt(_ mqtt: CocoaMQTT, didPublishMessage message: CocoaMQTTMessage, id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didPublishAck id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didReceiveMessage message: CocoaMQTTMessage, id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didSubscribeTopics success: NSDictionary, failed: [String]) {}
+        func mqtt(_ mqtt: CocoaMQTT, didUnsubscribeTopics topics: [String]) {}
+        func mqttDidPing(_ mqtt: CocoaMQTT) {}
+        func mqttDidReceivePong(_ mqtt: CocoaMQTT) {}
+        func mqttDidDisconnect(_ mqtt: CocoaMQTT, withError err: Error?) {}
+
+        func mqtt(_ mqtt: CocoaMQTT, didScheduleReconnect attemptCount: UInt, after interval: UInt16) {
+            reconnectSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+    }
+
+    private final class MQTT5DelegateSpy: NSObject, CocoaMQTT5Delegate {
+        private(set) var reconnectSchedules: [ReconnectSchedule] = []
+
+        func mqtt5(_ mqtt5: CocoaMQTT5, didConnectAck ack: CocoaMQTTCONNACKReasonCode, connAckData: MqttDecodeConnAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishMessage message: CocoaMQTT5Message, id: UInt16) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishAck id: UInt16, pubAckData: MqttDecodePubAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishRec id: UInt16, pubRecData: MqttDecodePubRec?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveMessage message: CocoaMQTT5Message, id: UInt16, publishData: MqttDecodePublish?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didSubscribeTopics success: NSDictionary, failed: [String], subAckData: MqttDecodeSubAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didUnsubscribeTopics topics: [String], unsubAckData: MqttDecodeUnsubAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveDisconnectReasonCode reasonCode: CocoaMQTTDISCONNECTReasonCode) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveAuthReasonCode reasonCode: CocoaMQTTAUTHReasonCode) {}
+        func mqtt5DidPing(_ mqtt5: CocoaMQTT5) {}
+        func mqtt5DidReceivePong(_ mqtt5: CocoaMQTT5) {}
+        func mqtt5DidDisconnect(_ mqtt5: CocoaMQTT5, withError err: Error?) {}
+
+        func mqtt5(_ mqtt5: CocoaMQTT5, didScheduleReconnect attemptCount: UInt, after interval: UInt16) {
+            reconnectSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+    }
+
+    private func waitUntil(timeout: TimeInterval = 2, condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return true
+            }
+            usleep(10_000)
+        }
+        return condition()
+    }
+
+    func testCocoaMQTTExposesReconnectIntervalAndAttemptCount() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "reconnect-state-\(UUID().uuidString)", socket: socket)
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 1
+        mqtt.maxAutoReconnectTimeInterval = 3
+
+        var observedInterval: UInt16?
+        var observedAttemptCount: UInt?
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didDisconnect = { mqtt, _ in
+            observedInterval = mqtt.reconnectTimeInterval
+            observedAttemptCount = mqtt.reconnectAttemptCount
+        }
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(observedInterval, 1)
+        XCTAssertEqual(observedAttemptCount, 1)
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 1)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
+        XCTAssertEqual(delegate.reconnectSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
+        XCTAssertEqual(closureSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
+
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 2)
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 2)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 2)
+        XCTAssertEqual(delegate.reconnectSchedules, [
+            ReconnectSchedule(attemptCount: 1, interval: 1),
+            ReconnectSchedule(attemptCount: 2, interval: 2)
+        ])
+        XCTAssertEqual(closureSchedules, delegate.reconnectSchedules)
+
+        XCTAssertTrue(waitUntil(timeout: 3) { socket.connectCount == 2 })
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 3)
+
+        mqtt.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(returnCode: .accept))
+
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
+    }
+
+    func testCocoaMQTT5ExposesReconnectIntervalAndAttemptCount() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-state-5-\(UUID().uuidString)", socket: socket)
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 1
+        mqtt5.maxAutoReconnectTimeInterval = 3
+
+        var observedInterval: UInt16?
+        var observedAttemptCount: UInt?
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didDisconnect = { mqtt5, _ in
+            observedInterval = mqtt5.reconnectTimeInterval
+            observedAttemptCount = mqtt5.reconnectAttemptCount
+        }
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(observedInterval, 1)
+        XCTAssertEqual(observedAttemptCount, 1)
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 1)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
+        XCTAssertEqual(delegate.reconnectSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
+        XCTAssertEqual(closureSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
+
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 2)
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 2)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 2)
+        XCTAssertEqual(delegate.reconnectSchedules, [
+            ReconnectSchedule(attemptCount: 1, interval: 1),
+            ReconnectSchedule(attemptCount: 2, interval: 2)
+        ])
+        XCTAssertEqual(closureSchedules, delegate.reconnectSchedules)
+
+        XCTAssertTrue(waitUntil(timeout: 3) { socket.connectCount == 2 })
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 3)
+
+        mqtt5.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(code: .success))
+
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+    }
+}

--- a/CocoaMQTTTests/AutoReconnectStateTests.swift
+++ b/CocoaMQTTTests/AutoReconnectStateTests.swift
@@ -94,21 +94,13 @@ final class AutoReconnectStateTests: XCTestCase {
         mqtt.autoReconnectTimeInterval = 1
         mqtt.maxAutoReconnectTimeInterval = 3
 
-        var observedInterval: UInt16?
-        var observedAttemptCount: UInt?
         var closureSchedules: [ReconnectSchedule] = []
-        mqtt.didDisconnect = { mqtt, _ in
-            observedInterval = mqtt.reconnectTimeInterval
-            observedAttemptCount = mqtt.reconnectAttemptCount
-        }
         mqtt.didScheduleReconnect = { _, attemptCount, interval in
             closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
         }
 
         mqtt.socketDidDisconnect(socket, withError: nil)
 
-        XCTAssertEqual(observedInterval, 1)
-        XCTAssertEqual(observedAttemptCount, 1)
         XCTAssertEqual(mqtt.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
         XCTAssertEqual(delegate.reconnectSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
@@ -136,6 +128,31 @@ final class AutoReconnectStateTests: XCTestCase {
         XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
     }
 
+    func testCocoaMQTTDoesNotScheduleReconnectWhenDisabledInDisconnectCallback() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "reconnect-disable-\(UUID().uuidString)", socket: socket)
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didDisconnect = { mqtt, _ in
+            mqtt.autoReconnect = false
+        }
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
+        XCTAssertTrue(delegate.reconnectSchedules.isEmpty)
+        XCTAssertTrue(closureSchedules.isEmpty)
+        XCTAssertEqual(socket.connectCount, 0)
+    }
+
     func testCocoaMQTT5ExposesReconnectIntervalAndAttemptCount() {
         let socket = SocketSpy()
         let delegate = MQTT5DelegateSpy()
@@ -145,21 +162,13 @@ final class AutoReconnectStateTests: XCTestCase {
         mqtt5.autoReconnectTimeInterval = 1
         mqtt5.maxAutoReconnectTimeInterval = 3
 
-        var observedInterval: UInt16?
-        var observedAttemptCount: UInt?
         var closureSchedules: [ReconnectSchedule] = []
-        mqtt5.didDisconnect = { mqtt5, _ in
-            observedInterval = mqtt5.reconnectTimeInterval
-            observedAttemptCount = mqtt5.reconnectAttemptCount
-        }
         mqtt5.didScheduleReconnect = { _, attemptCount, interval in
             closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
         }
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
 
-        XCTAssertEqual(observedInterval, 1)
-        XCTAssertEqual(observedAttemptCount, 1)
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
         XCTAssertEqual(delegate.reconnectSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
@@ -185,5 +194,30 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+    }
+
+    func testCocoaMQTT5DoesNotScheduleReconnectWhenDisabledInDisconnectCallback() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-disable-5-\(UUID().uuidString)", socket: socket)
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didDisconnect = { mqtt5, _ in
+            mqtt5.autoReconnect = false
+        }
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+        XCTAssertTrue(delegate.reconnectSchedules.isEmpty)
+        XCTAssertTrue(closureSchedules.isEmpty)
+        XCTAssertEqual(socket.connectCount, 0)
     }
 }

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -651,9 +651,7 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
     public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
-        if !is_internal_disconnected && autoReconnect {
-            prepareAutoReconnectAttempt()
-        } else {
+        if is_internal_disconnected || !autoReconnect {
             resetAutoReconnectState()
         }
 
@@ -667,8 +665,11 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         }
 
         guard autoReconnect else {
+            resetAutoReconnectState()
             return
         }
+
+        prepareAutoReconnectAttempt()
 
         // Start reconnector once socket error occurred
         printInfo("Try reconnect to server after \(reconnectTimeInterval)s")

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -229,9 +229,10 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// After that, it uses this value for subsequent requests.
     public var maxAutoReconnectTimeInterval: UInt16 = 128 // 128 seconds
 
-    /// Current auto-reconnect backoff interval in seconds.
+    /// Auto-reconnect backoff interval in seconds for the current reconnect cycle.
     ///
-    /// The value is `0` when no auto-reconnect attempt is scheduled.
+    /// This value is advanced for the next reconnect attempt while auto-reconnect is active,
+    /// and resets to `0` when auto-reconnect is inactive.
     public private(set) var reconnectTimeInterval: UInt16 = 0
 
     /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -85,6 +85,9 @@ import MqttCocoaAsyncSocket
 
     ///
     @objc optional func mqtt(_ mqtt: CocoaMQTT, didStateChangeTo state: CocoaMQTTConnState)
+
+    /// Called when auto-reconnect schedules a reconnect attempt after an unexpected disconnect.
+    @objc optional func mqtt(_ mqtt: CocoaMQTT, didScheduleReconnect attemptCount: UInt, after interval: UInt16)
 }
 
 /// set mqtt version to 3.1.1
@@ -226,7 +229,15 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// After that, it uses this value for subsequent requests.
     public var maxAutoReconnectTimeInterval: UInt16 = 128 // 128 seconds
 
-    private var reconnectTimeInterval: UInt16 = 0
+    /// Current auto-reconnect backoff interval in seconds.
+    ///
+    /// The value is `0` when no auto-reconnect attempt is scheduled.
+    public private(set) var reconnectTimeInterval: UInt16 = 0
+
+    /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.
+    ///
+    /// The value resets to `0` after a successful connection or expected disconnect.
+    public private(set) var reconnectAttemptCount: UInt = 0
 
     private var autoReconnTimer: CocoaMQTTTimer?
     private var is_internal_disconnected = false
@@ -294,6 +305,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     public var didReceiveTrust: (CocoaMQTT, SecTrust, @escaping (Bool) -> Swift.Void) -> Void = { _, _, _ in }
     public var didCompletePublish: (CocoaMQTT, UInt16) -> Void = { _, _ in }
     public var didChangeState: (CocoaMQTT, CocoaMQTTConnState) -> Void = { _, _ in }
+    public var didScheduleReconnect: (CocoaMQTT, UInt, UInt16) -> Void = { _, _, _ in }
 
     /// Initial client object
     ///
@@ -562,6 +574,29 @@ extension CocoaMQTT {
             fun()
         }
     }
+
+    private func prepareAutoReconnectAttempt() {
+        if reconnectTimeInterval == 0 {
+            reconnectTimeInterval = min(autoReconnectTimeInterval, maxAutoReconnectTimeInterval)
+        }
+        reconnectAttemptCount += 1
+    }
+
+    private func updateAutoReconnectIntervalForNextAttempt() {
+        let doubledInterval = UInt32(reconnectTimeInterval) * 2
+        reconnectTimeInterval = UInt16(min(doubledInterval, UInt32(maxAutoReconnectTimeInterval)))
+    }
+
+    private func resetAutoReconnectState() {
+        reconnectTimeInterval = 0
+        reconnectAttemptCount = 0
+        autoReconnTimer = nil
+    }
+
+    private func notifyAutoReconnectScheduled() {
+        delegate?.mqtt?(self, didScheduleReconnect: reconnectAttemptCount, after: reconnectTimeInterval)
+        didScheduleReconnect(self, reconnectAttemptCount, reconnectTimeInterval)
+    }
 }
 
 // MARK: - CocoaMQTTSocketDelegate
@@ -615,6 +650,12 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
     public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
+        if !is_internal_disconnected && autoReconnect {
+            prepareAutoReconnectAttempt()
+        } else {
+            resetAutoReconnectState()
+        }
+
         connState = .disconnected
         delegate?.mqttDidDisconnect(self, withError: err)
         didDisconnect(self, err)
@@ -628,19 +669,12 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
             return
         }
 
-        if reconnectTimeInterval == 0 {
-            reconnectTimeInterval = autoReconnectTimeInterval
-        }
-
         // Start reconnector once socket error occurred
         printInfo("Try reconnect to server after \(reconnectTimeInterval)s")
+        notifyAutoReconnectScheduled()
         autoReconnTimer = CocoaMQTTTimer.after(Double(reconnectTimeInterval), name: "autoReconnTimer", { [weak self] in
             guard let self = self else { return }
-            if self.reconnectTimeInterval < self.maxAutoReconnectTimeInterval {
-                self.reconnectTimeInterval *= 2
-            } else {
-                self.reconnectTimeInterval = self.maxAutoReconnectTimeInterval
-            }
+            self.updateAutoReconnectIntervalForNextAttempt()
             _ = self.connect()
         })
     }
@@ -656,8 +690,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
             // Disable auto-reconnect
 
-            reconnectTimeInterval = 0
-            autoReconnTimer = nil
+            resetAutoReconnectState()
             is_internal_disconnected = false
 
             // Start keepalive timer

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -230,9 +230,10 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// 3.15.2.2 AUTH Properties
     public var authProperties: MqttAuthProperties?
 
-    /// Current auto-reconnect backoff interval in seconds.
+    /// Auto-reconnect backoff interval in seconds for the current reconnect cycle.
     ///
-    /// The value is `0` when no auto-reconnect attempt is scheduled.
+    /// This value is advanced for the next reconnect attempt while auto-reconnect is active,
+    /// and resets to `0` when auto-reconnect is inactive.
     public private(set) var reconnectTimeInterval: UInt16 = 0
 
     /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -702,9 +702,7 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
     public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
-        if !is_internal_disconnected && autoReconnect {
-            prepareAutoReconnectAttempt()
-        } else {
+        if is_internal_disconnected || !autoReconnect {
             resetAutoReconnectState()
         }
 
@@ -719,8 +717,11 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         }
 
         guard autoReconnect else {
+            resetAutoReconnectState()
             return
         }
+
+        prepareAutoReconnectAttempt()
 
         // Start reconnector once socket error occurred
         printInfo("Try reconnect to server after \(reconnectTimeInterval)s")

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -77,6 +77,9 @@ import MqttCocoaAsyncSocket
 
     ///
     @objc optional func mqtt5(_ mqtt5: CocoaMQTT5, didStateChangeTo state: CocoaMQTTConnState)
+
+    /// Called when auto-reconnect schedules a reconnect attempt after an unexpected disconnect.
+    @objc optional func mqtt5(_ mqtt5: CocoaMQTT5, didScheduleReconnect attemptCount: UInt, after interval: UInt16)
 }
 
 /// set mqtt version to 5.0
@@ -227,7 +230,15 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// 3.15.2.2 AUTH Properties
     public var authProperties: MqttAuthProperties?
 
-    private var reconnectTimeInterval: UInt16 = 0
+    /// Current auto-reconnect backoff interval in seconds.
+    ///
+    /// The value is `0` when no auto-reconnect attempt is scheduled.
+    public private(set) var reconnectTimeInterval: UInt16 = 0
+
+    /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.
+    ///
+    /// The value resets to `0` after a successful connection or expected disconnect.
+    public private(set) var reconnectAttemptCount: UInt = 0
 
     private var autoReconnTimer: CocoaMQTTTimer?
     private var is_internal_disconnected = false
@@ -292,6 +303,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     public var didReceiveTrust: (CocoaMQTT5, SecTrust, @escaping (Bool) -> Swift.Void) -> Void = { _, _, _ in }
     public var didCompletePublish: (CocoaMQTT5, UInt16, MqttDecodePubComp?) -> Void = { _, _, _ in }
     public var didChangeState: (CocoaMQTT5, CocoaMQTTConnState) -> Void = { _, _ in }
+    public var didScheduleReconnect: (CocoaMQTT5, UInt, UInt16) -> Void = { _, _, _ in }
 
     /// Initial client object
     ///
@@ -613,6 +625,29 @@ extension CocoaMQTT5 {
             fun()
         }
     }
+
+    private func prepareAutoReconnectAttempt() {
+        if reconnectTimeInterval == 0 {
+            reconnectTimeInterval = min(autoReconnectTimeInterval, maxAutoReconnectTimeInterval)
+        }
+        reconnectAttemptCount += 1
+    }
+
+    private func updateAutoReconnectIntervalForNextAttempt() {
+        let doubledInterval = UInt32(reconnectTimeInterval) * 2
+        reconnectTimeInterval = UInt16(min(doubledInterval, UInt32(maxAutoReconnectTimeInterval)))
+    }
+
+    private func resetAutoReconnectState() {
+        reconnectTimeInterval = 0
+        reconnectAttemptCount = 0
+        autoReconnTimer = nil
+    }
+
+    private func notifyAutoReconnectScheduled() {
+        delegate?.mqtt5?(self, didScheduleReconnect: reconnectAttemptCount, after: reconnectTimeInterval)
+        didScheduleReconnect(self, reconnectAttemptCount, reconnectTimeInterval)
+    }
 }
 
 // MARK: - CocoaMQTTSocketDelegate
@@ -666,6 +701,12 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
     public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
+        if !is_internal_disconnected && autoReconnect {
+            prepareAutoReconnectAttempt()
+        } else {
+            resetAutoReconnectState()
+        }
+
         connState = .disconnected
 
         delegate?.mqtt5DidDisconnect(self, withError: err)
@@ -680,19 +721,12 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
             return
         }
 
-        if reconnectTimeInterval == 0 {
-            reconnectTimeInterval = autoReconnectTimeInterval
-        }
-
         // Start reconnector once socket error occurred
         printInfo("Try reconnect to server after \(reconnectTimeInterval)s")
+        notifyAutoReconnectScheduled()
         autoReconnTimer = CocoaMQTTTimer.after(Double(reconnectTimeInterval), name: "autoReconnTimer", { [weak self] in
             guard let self = self else { return }
-            if self.reconnectTimeInterval < self.maxAutoReconnectTimeInterval {
-                self.reconnectTimeInterval *= 2
-            } else {
-                self.reconnectTimeInterval = self.maxAutoReconnectTimeInterval
-            }
+            self.updateAutoReconnectIntervalForNextAttempt()
             _ = self.connect()
         })
     }
@@ -720,8 +754,7 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
             // Disable auto-reconnect
 
-            reconnectTimeInterval = 0
-            autoReconnTimer = nil
+            resetAutoReconnectState()
             is_internal_disconnected = false
 
             // Start keepalive timer


### PR DESCRIPTION
## Summary
- expose read-only reconnect interval and attempt count for MQTT 3.1.1 and MQTT 5 clients
- add optional didScheduleReconnect delegate callbacks and matching closure callbacks when auto-reconnect is scheduled
- clamp reconnect backoff updates to maxAutoReconnectTimeInterval

Fixes #684

## Verification
- swift test --filter AutoReconnectStateTests