### PR TITLE
Expose MQTT5 disconnect reason state

### DIFF
--- a/CocoaMQTTTests/CocoaMQTT5DisconnectReasonStateTests.swift
+++ b/CocoaMQTTTests/CocoaMQTT5DisconnectReasonStateTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import XCTest
+@testable import CocoaMQTT
+
+final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
+
+    private final class SocketSpy: CocoaMQTTSocketProtocol {
+        var enableSSL: Bool = false
+        private(set) var disconnectCount = 0
+        private(set) var writes: [Data] = []
+
+        func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
+        func connect(toHost host: String, onPort port: UInt16) throws {}
+        func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
+        func disconnect() {
+            disconnectCount += 1
+        }
+        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
+        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
+            writes.append(data)
+        }
+    }
+
+    private struct DisconnectSnapshot {
+        let source: CocoaMQTT5DisconnectReasonSource?
+        let reasonCode: CocoaMQTTDISCONNECTReasonCode?
+        let error: Error?
+    }
+
+    private final class DelegateSpy: NSObject, CocoaMQTT5Delegate {
+        private(set) var disconnectSnapshots: [DisconnectSnapshot] = []
+        private(set) var receivedDisconnectReasonCodes: [CocoaMQTTDISCONNECTReasonCode] = []
+
+        func mqtt5(_ mqtt5: CocoaMQTT5, didConnectAck ack: CocoaMQTTCONNACKReasonCode, connAckData: MqttDecodeConnAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishMessage message: CocoaMQTT5Message, id: UInt16) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishAck id: UInt16, pubAckData: MqttDecodePubAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishRec id: UInt16, pubRecData: MqttDecodePubRec?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveMessage message: CocoaMQTT5Message, id: UInt16, publishData: MqttDecodePublish?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didSubscribeTopics success: NSDictionary, failed: [String], subAckData: MqttDecodeSubAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didUnsubscribeTopics topics: [String], unsubAckData: MqttDecodeUnsubAck?) {}
+
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveDisconnectReasonCode reasonCode: CocoaMQTTDISCONNECTReasonCode) {
+            receivedDisconnectReasonCodes.append(reasonCode)
+        }
+
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveAuthReasonCode reasonCode: CocoaMQTTAUTHReasonCode) {}
+        func mqtt5DidPing(_ mqtt5: CocoaMQTT5) {}
+        func mqtt5DidReceivePong(_ mqtt5: CocoaMQTT5) {}
+
+        func mqtt5DidDisconnect(_ mqtt5: CocoaMQTT5, withError err: Error?) {
+            let reason = mqtt5.lastDisconnectReason
+            disconnectSnapshots.append(DisconnectSnapshot(
+                source: reason?.source,
+                reasonCode: reason?.reasonCode,
+                error: err
+            ))
+        }
+    }
+
+    func testManualDisconnectReasonIsReadableInDisconnectCallback() {
+        let socket = SocketSpy()
+        let delegate = DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "manual-disconnect-reason-\(UUID().uuidString)", socket: socket)
+        mqtt5.delegate = delegate
+
+        mqtt5.disconnect()
+
+        XCTAssertNil(mqtt5.lastDisconnectReason)
+        XCTAssertEqual(socket.disconnectCount, 1)
+        XCTAssertTrue(socket.writes.contains { $0.first == FrameType.disconnect.rawValue })
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
+        XCTAssertEqual(delegate.disconnectSnapshots[0].source, .local)
+        XCTAssertEqual(delegate.disconnectSnapshots[0].reasonCode, .normalDisconnection)
+        XCTAssertNil(delegate.disconnectSnapshots[0].error)
+        XCTAssertEqual(mqtt5.lastDisconnectReason?.source, .local)
+        XCTAssertEqual(mqtt5.lastDisconnectReason?.reasonCode, .normalDisconnection)
+    }
+
+    func testCustomManualDisconnectReasonIsReadableInDisconnectCallback() {
+        let socket = SocketSpy()
+        let delegate = DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "manual-custom-disconnect-reason-\(UUID().uuidString)", socket: socket)
+        mqtt5.delegate = delegate
+
+        mqtt5.disconnect(reasonCode: .disconnectWithWillMessage, userProperties: ["reason": "manual"])
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
+        XCTAssertEqual(delegate.disconnectSnapshots[0].source, .local)
+        XCTAssertEqual(delegate.disconnectSnapshots[0].reasonCode, .disconnectWithWillMessage)
+        XCTAssertNil(delegate.disconnectSnapshots[0].error)
+    }
+
+    func testManualDisconnectWithSocketErrorDoesNotReportLocalReason() {
+        let socket = SocketSpy()
+        let delegate = DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "manual-disconnect-error-\(UUID().uuidString)", socket: socket)
+        mqtt5.delegate = delegate
+
+        mqtt5.disconnect()
+        mqtt5.socketDidDisconnect(socket, withError: CocoaMQTTError.writeTimeout)
+
+        XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
+        XCTAssertNil(delegate.disconnectSnapshots[0].source)
+        XCTAssertNil(delegate.disconnectSnapshots[0].reasonCode)
+        XCTAssertNotNil(delegate.disconnectSnapshots[0].error)
+        XCTAssertNil(mqtt5.lastDisconnectReason)
+    }
+
+    func testRemoteDisconnectReasonIsReadableInDisconnectCallback() {
+        let socket = SocketSpy()
+        let delegate = DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "remote-disconnect-reason-\(UUID().uuidString)", socket: socket)
+        let reader = CocoaMQTTReader(socket: socket, delegate: nil)
+        let frame = FrameDisconnect(
+            packetFixedHeaderType: FrameType.disconnect.rawValue,
+            bytes: [CocoaMQTTDISCONNECTReasonCode.serverBusy.rawValue]
+        )
+        mqtt5.delegate = delegate
+
+        XCTAssertNotNil(frame)
+
+        mqtt5.didReceive(reader, disconnect: frame!)
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(delegate.receivedDisconnectReasonCodes, [.serverBusy])
+        XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
+        XCTAssertEqual(delegate.disconnectSnapshots[0].source, .remote)
+        XCTAssertEqual(delegate.disconnectSnapshots[0].reasonCode, .serverBusy)
+        XCTAssertNil(delegate.disconnectSnapshots[0].error)
+        XCTAssertEqual(mqtt5.lastDisconnectReason?.source, .remote)
+        XCTAssertEqual(mqtt5.lastDisconnectReason?.reasonCode, .serverBusy)
+    }
+
+    func testRemoteDisconnectWithSocketErrorDoesNotReportFinalReason() {
+        let socket = SocketSpy()
+        let delegate = DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "remote-disconnect-error-\(UUID().uuidString)", socket: socket)
+        let reader = CocoaMQTTReader(socket: socket, delegate: nil)
+        let frame = FrameDisconnect(
+            packetFixedHeaderType: FrameType.disconnect.rawValue,
+            bytes: [CocoaMQTTDISCONNECTReasonCode.serverBusy.rawValue]
+        )
+        mqtt5.delegate = delegate
+
+        XCTAssertNotNil(frame)
+
+        mqtt5.didReceive(reader, disconnect: frame!)
+        mqtt5.socketDidDisconnect(socket, withError: CocoaMQTTError.readTimeout)
+
+        XCTAssertEqual(delegate.receivedDisconnectReasonCodes, [.serverBusy])
+        XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
+        XCTAssertNil(delegate.disconnectSnapshots[0].source)
+        XCTAssertNil(delegate.disconnectSnapshots[0].reasonCode)
+        XCTAssertNotNil(delegate.disconnectSnapshots[0].error)
+        XCTAssertNil(mqtt5.lastDisconnectReason)
+    }
+
+    func testCleanSocketCloseWithoutMQTTReasonClearsDisconnectReason() {
+        let socket = SocketSpy()
+        let delegate = DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "clean-close-no-reason-\(UUID().uuidString)", socket: socket)
+        mqtt5.delegate = delegate
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
+        XCTAssertNil(delegate.disconnectSnapshots[0].source)
+        XCTAssertNil(delegate.disconnectSnapshots[0].reasonCode)
+        XCTAssertNil(delegate.disconnectSnapshots[0].error)
+        XCTAssertNil(mqtt5.lastDisconnectReason)
+    }
+}

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -26,6 +26,21 @@ import MqttCocoaAsyncSocket
     }
 }
 
+@objc public enum CocoaMQTT5DisconnectReasonSource: UInt8 {
+    case local = 1
+    case remote = 2
+}
+
+@objcMembers public final class CocoaMQTT5DisconnectReason: NSObject {
+    public let source: CocoaMQTT5DisconnectReasonSource
+    public let reasonCode: CocoaMQTTDISCONNECTReasonCode
+
+    public init(source: CocoaMQTT5DisconnectReasonSource, reasonCode: CocoaMQTTDISCONNECTReasonCode) {
+        self.source = source
+        self.reasonCode = reasonCode
+    }
+}
+
 /// CocoaMQTT5 Delegate
 @objc public protocol CocoaMQTT5Delegate {
 
@@ -243,6 +258,19 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     private var autoReconnTimer: CocoaMQTTTimer?
     private var is_internal_disconnected = false
+    private let disconnectReasonLock = NSLock()
+    private var pendingLocalDisconnectReasonCode: CocoaMQTTDISCONNECTReasonCode?
+    private var _lastDisconnectReason: CocoaMQTT5DisconnectReason?
+
+    /// The last MQTT 5 DISCONNECT reason observed for the current connection lifecycle.
+    ///
+    /// This is set before `mqtt5DidDisconnect(_:withError:)` / `didDisconnect` callbacks run.
+    /// It is `nil` for transport errors or clean socket closes without an MQTT DISCONNECT reason.
+    @objc public var lastDisconnectReason: CocoaMQTT5DisconnectReason? {
+        disconnectReasonLock.lock()
+        defer { disconnectReasonLock.unlock() }
+        return _lastDisconnectReason
+    }
 
     /// Console log level
     public var logLevel: CocoaMQTTLoggerLevel {
@@ -392,6 +420,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     ///   - Bool: It indicates whether successfully calling socket connect function.
     ///           Not yet established correct MQTT session
     public func connect(timeout: TimeInterval) -> Bool {
+        resetDisconnectReasonState()
         socket.setDelegate(self, delegateQueue: delegateQueue)
         reader = CocoaMQTTReader(socket: socket, delegate: self)
         do {
@@ -418,10 +447,12 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// - Note: Only can be called from outside.
     ///         This closes the connection expectedly, so auto-reconnect will not run.
     public func disconnect() {
+        markPendingLocalDisconnect(reasonCode: .normalDisconnection)
         expected_disconnect(reasonCode: .normalDisconnection)
     }
 
     public func disconnect(reasonCode: CocoaMQTTDISCONNECTReasonCode, userProperties: [String: String] ) {
+        markPendingLocalDisconnect(reasonCode: reasonCode)
         expected_disconnect(reasonCode: reasonCode, userProperties: userProperties)
     }
 
@@ -649,6 +680,43 @@ extension CocoaMQTT5 {
         delegate?.mqtt5?(self, didScheduleReconnect: reconnectAttemptCount, after: reconnectTimeInterval)
         didScheduleReconnect(self, reconnectAttemptCount, reconnectTimeInterval)
     }
+
+    private func resetDisconnectReasonState() {
+        disconnectReasonLock.lock()
+        pendingLocalDisconnectReasonCode = nil
+        _lastDisconnectReason = nil
+        disconnectReasonLock.unlock()
+    }
+
+    private func markPendingLocalDisconnect(reasonCode: CocoaMQTTDISCONNECTReasonCode) {
+        disconnectReasonLock.lock()
+        pendingLocalDisconnectReasonCode = reasonCode
+        _lastDisconnectReason = nil
+        disconnectReasonLock.unlock()
+    }
+
+    private func recordRemoteDisconnect(reasonCode: CocoaMQTTDISCONNECTReasonCode) {
+        disconnectReasonLock.lock()
+        pendingLocalDisconnectReasonCode = nil
+        _lastDisconnectReason = CocoaMQTT5DisconnectReason(source: .remote, reasonCode: reasonCode)
+        disconnectReasonLock.unlock()
+    }
+
+    private func updateDisconnectReasonAfterSocketDisconnect(error: Error?) {
+        disconnectReasonLock.lock()
+        defer {
+            pendingLocalDisconnectReasonCode = nil
+            disconnectReasonLock.unlock()
+        }
+
+        if error != nil {
+            _lastDisconnectReason = nil
+        } else if let reasonCode = pendingLocalDisconnectReasonCode {
+            _lastDisconnectReason = CocoaMQTT5DisconnectReason(source: .local, reasonCode: reasonCode)
+        } else if _lastDisconnectReason?.source != .remote {
+            _lastDisconnectReason = nil
+        }
+    }
 }
 
 // MARK: - CocoaMQTTSocketDelegate
@@ -702,6 +770,7 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
     public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
+        updateDisconnectReasonAfterSocketDisconnect(error: err)
         if is_internal_disconnected || !autoReconnect {
             resetAutoReconnectState()
         }
@@ -739,6 +808,7 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
     func didReceive(_ reader: CocoaMQTTReader, disconnect: FrameDisconnect) {
         let reasonCode = disconnect.receiveReasonCode ?? .normalDisconnection
+        recordRemoteDisconnect(reasonCode: reasonCode)
         delegate?.mqtt5(self, didReceiveDisconnectReasonCode: reasonCode)
         didDisconnectReasonCode(self, reasonCode)
     }


### PR DESCRIPTION
## Summary
- Add an Obj-C-compatible `CocoaMQTT5DisconnectReason` value object with a `source` (`local` or `remote`) and MQTT5 DISCONNECT `reasonCode`
- Expose `CocoaMQTT5.lastDisconnectReason` so callers can inspect the reason from inside `mqtt5DidDisconnect(_:withError:)`
- Track manual disconnect reason codes only for normal socket closes, and clear the state for transport errors or clean closes without an MQTT DISCONNECT reason

Fixes #686

## API design note
This uses an Obj-C-visible value object plus `CocoaMQTT5DisconnectReasonSource` instead of a Swift enum with associated values because associated-value enums are not importable from Objective-C.

The property is guarded with a lock and is updated before disconnect callbacks run, so reading it from `mqtt5DidDisconnect(_:withError:)` observes the current disconnect state.

## Tests
- `swift test --filter CocoaMQTT5DisconnectReasonStateTests`
- `swift test --filter CocoaMQTT5ReasonCodeFallbackTests`