### PR TITLE
Add autoReconnect pause and resume controls

### DIFF
--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "CocoaMQTT"
-  s.version     = "2.2.6"
+  s.version     = "2.3.0"
   s.summary     = "MQTT v3.1.1 client library for iOS and OS X written with Swift 5"
   s.homepage    = "https://github.com/emqx/CocoaMQTT"
   s.license     = { :type => "MIT" }
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "12.0"
   s.tvos.deployment_target = "10.0"
   # s.watchos.deployment_target = "2.0"
-  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.2.6"}
+  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.3.0"}
   s.default_subspec = 'Core'
   
   s.subspec 'Core' do |ss|

--- a/CocoaMQTTTests/AutoReconnectStateTests.swift
+++ b/CocoaMQTTTests/AutoReconnectStateTests.swift
@@ -98,6 +98,35 @@ final class AutoReconnectStateTests: XCTestCase {
         return condition()
     }
 
+    private func makeDelegateQueue() -> DispatchQueue {
+        DispatchQueue(label: "tests.auto-reconnect.\(UUID().uuidString)")
+    }
+
+    private func waitForReconnectSchedules(
+        on queue: DispatchQueue,
+        expected: [ReconnectSchedule],
+        delegateSchedules: @escaping () -> [ReconnectSchedule],
+        closureSchedules: @escaping () -> [ReconnectSchedule]
+    ) -> Bool {
+        waitUntil {
+            queue.sync {
+                delegateSchedules() == expected && closureSchedules() == expected
+            }
+        }
+    }
+
+    private func assertNoReconnectSchedules(
+        on queue: DispatchQueue,
+        delegateSchedules: @escaping () -> [ReconnectSchedule],
+        closureSchedules: @escaping () -> [ReconnectSchedule],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        queue.sync {}
+        XCTAssertTrue(delegateSchedules().isEmpty, file: file, line: line)
+        XCTAssertTrue(closureSchedules().isEmpty, file: file, line: line)
+    }
+
     private func containsDisconnectFrame(_ writes: [Data]) -> Bool {
         writes.contains { data in
             data.first == FrameType.disconnect.rawValue
@@ -118,6 +147,8 @@ final class AutoReconnectStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = MQTTDelegateSpy()
         let mqtt = CocoaMQTT(clientID: "reconnect-state-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
         mqtt.delegate = delegate
         mqtt.autoReconnect = true
         mqtt.autoReconnectTimeInterval = 1
@@ -132,8 +163,12 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
-        XCTAssertEqual(delegate.reconnectSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
-        XCTAssertEqual(closureSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [ReconnectSchedule(attemptCount: 1, interval: 1)],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
 
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
         XCTAssertEqual(mqtt.reconnectTimeInterval, 2)
@@ -142,11 +177,15 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt.reconnectTimeInterval, 2)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 2)
-        XCTAssertEqual(delegate.reconnectSchedules, [
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [
             ReconnectSchedule(attemptCount: 1, interval: 1),
             ReconnectSchedule(attemptCount: 2, interval: 2)
-        ])
-        XCTAssertEqual(closureSchedules, delegate.reconnectSchedules)
+            ],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
 
         XCTAssertTrue(waitUntil(timeout: 3) { socket.connectCount == 2 })
         XCTAssertEqual(mqtt.reconnectTimeInterval, 3)
@@ -161,6 +200,8 @@ final class AutoReconnectStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = MQTTDelegateSpy()
         let mqtt = CocoaMQTT(clientID: "reconnect-disable-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
         mqtt.delegate = delegate
         mqtt.autoReconnect = true
         mqtt.autoReconnectTimeInterval = 1
@@ -177,15 +218,276 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
-        XCTAssertTrue(delegate.reconnectSchedules.isEmpty)
-        XCTAssertTrue(closureSchedules.isEmpty)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
         XCTAssertEqual(socket.connectCount, 0)
+    }
+
+    func testCocoaMQTTResumeAfterExpectedDisconnectDoesNotReconnect() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "resume-after-expected-disconnect-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt.disconnect()
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        mqtt.pauseAutoReconnect()
+        mqtt.resumeAutoReconnect()
+
+        XCTAssertFalse(mqtt.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+        XCTAssertEqual(socket.connectCount, 0)
+    }
+
+    func testCocoaMQTTResumeWithAutoReconnectDisabledDoesNotReconnect() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "resume-autoreconnect-disabled-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = false
+        mqtt.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt.pauseAutoReconnect()
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        mqtt.resumeAutoReconnect()
+
+        XCTAssertFalse(mqtt.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+        XCTAssertEqual(socket.connectCount, 0)
+    }
+
+    func testCocoaMQTTPausedAutoReconnectDoesNotScheduleUntilResume() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "reconnect-paused-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt.pauseAutoReconnect()
+        mqtt.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertTrue(mqtt.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+        XCTAssertEqual(socket.connectCount, 0)
+
+        mqtt.resumeAutoReconnect()
+
+        XCTAssertFalse(mqtt.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [ReconnectSchedule(attemptCount: 1, interval: 0)],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 2)
+    }
+
+    func testCocoaMQTTPauseCancelsScheduledReconnectAndResumeRunsImmediately() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "reconnect-cancel-paused-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [ReconnectSchedule(attemptCount: 1, interval: 1)],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
+
+        mqtt.pauseAutoReconnect()
+
+        XCTAssertTrue(mqtt.isAutoReconnectPaused)
+        XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 0 })
+
+        mqtt.resumeAutoReconnect()
+
+        XCTAssertFalse(mqtt.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [
+            ReconnectSchedule(attemptCount: 1, interval: 1),
+            ReconnectSchedule(attemptCount: 1, interval: 0)
+            ],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 2)
+    }
+
+    func testCocoaMQTTResumeFromBackgroundQueueSchedulesReconnectOnDelegateQueue() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "reconnect-background-resume-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        let delegateQueueKey = DispatchSpecificKey<String>()
+        delegateQueue.setSpecific(key: delegateQueueKey, value: "delegate")
+        mqtt.delegateQueue = delegateQueue
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 1
+
+        var callbackQueue: String?
+        mqtt.didScheduleReconnect = { _, _, _ in
+            callbackQueue = DispatchQueue.getSpecific(key: delegateQueueKey)
+        }
+
+        mqtt.pauseAutoReconnect()
+        mqtt.socketDidDisconnect(socket, withError: nil)
+
+        DispatchQueue.global().async {
+            mqtt.resumeAutoReconnect()
+        }
+
+        XCTAssertTrue(waitUntil {
+            delegateQueue.sync {
+                callbackQueue == "delegate"
+            }
+        })
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+    }
+
+    func testCocoaMQTTResumeInDisconnectCallbackSchedulesReconnectOnce() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "reconnect-resume-in-disconnect-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didDisconnect = { mqtt, _ in
+            mqtt.resumeAutoReconnect()
+        }
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt.pauseAutoReconnect()
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        delegateQueue.sync {}
+
+        let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
+        XCTAssertFalse(mqtt.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
+        XCTAssertEqual(delegate.reconnectSchedules, expectedSchedules)
+        XCTAssertEqual(closureSchedules, expectedSchedules)
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
+    }
+
+    func testCocoaMQTTResumeInConnackFailureCallbackSchedulesReconnectAfterDisconnectOnce() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "connack-resume-after-disconnect-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didConnectAck = { mqtt, ack in
+            XCTAssertEqual(ack, .serverUnavailable)
+            mqtt.resumeAutoReconnect()
+        }
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt.pauseAutoReconnect()
+        mqtt.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(returnCode: .serverUnavailable))
+
+        XCTAssertEqual(delegate.connectAcks, [.serverUnavailable])
+        XCTAssertEqual(socket.disconnectCount, 1)
+        XCTAssertEqual(socket.connectCount, 0)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        delegateQueue.sync {}
+
+        let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
+        XCTAssertFalse(mqtt.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
+        XCTAssertEqual(delegate.reconnectSchedules, expectedSchedules)
+        XCTAssertEqual(closureSchedules, expectedSchedules)
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
     }
 
     func testCocoaMQTTConnackFailureKeepsAutoReconnectEnabled() {
         let socket = SocketSpy()
         let delegate = MQTTDelegateSpy()
         let mqtt = CocoaMQTT(clientID: "connack-failure-reconnect-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
         mqtt.delegate = delegate
         mqtt.autoReconnect = true
         mqtt.autoReconnectTimeInterval = 1
@@ -210,8 +512,12 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
-        XCTAssertEqual(delegate.reconnectSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
-        XCTAssertEqual(closureSchedules, delegate.reconnectSchedules)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [ReconnectSchedule(attemptCount: 1, interval: 1)],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
     }
 
@@ -260,6 +566,8 @@ final class AutoReconnectStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = MQTT5DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "reconnect-state-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
         mqtt5.delegate = delegate
         mqtt5.autoReconnect = true
         mqtt5.autoReconnectTimeInterval = 1
@@ -274,8 +582,12 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
-        XCTAssertEqual(delegate.reconnectSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
-        XCTAssertEqual(closureSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [ReconnectSchedule(attemptCount: 1, interval: 1)],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
 
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 2)
@@ -284,11 +596,15 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 2)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 2)
-        XCTAssertEqual(delegate.reconnectSchedules, [
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [
             ReconnectSchedule(attemptCount: 1, interval: 1),
             ReconnectSchedule(attemptCount: 2, interval: 2)
-        ])
-        XCTAssertEqual(closureSchedules, delegate.reconnectSchedules)
+            ],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
 
         XCTAssertTrue(waitUntil(timeout: 3) { socket.connectCount == 2 })
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 3)
@@ -303,6 +619,8 @@ final class AutoReconnectStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = MQTT5DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "reconnect-disable-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
         mqtt5.delegate = delegate
         mqtt5.autoReconnect = true
         mqtt5.autoReconnectTimeInterval = 1
@@ -319,15 +637,276 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
-        XCTAssertTrue(delegate.reconnectSchedules.isEmpty)
-        XCTAssertTrue(closureSchedules.isEmpty)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
         XCTAssertEqual(socket.connectCount, 0)
+    }
+
+    func testCocoaMQTT5ResumeAfterExpectedDisconnectDoesNotReconnect() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "resume-after-expected-disconnect-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt5.disconnect()
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+        mqtt5.pauseAutoReconnect()
+        mqtt5.resumeAutoReconnect()
+
+        XCTAssertFalse(mqtt5.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+        XCTAssertEqual(socket.connectCount, 0)
+    }
+
+    func testCocoaMQTT5ResumeWithAutoReconnectDisabledDoesNotReconnect() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "resume-autoreconnect-disabled-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = false
+        mqtt5.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt5.pauseAutoReconnect()
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+        mqtt5.resumeAutoReconnect()
+
+        XCTAssertFalse(mqtt5.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+        XCTAssertEqual(socket.connectCount, 0)
+    }
+
+    func testCocoaMQTT5PausedAutoReconnectDoesNotScheduleUntilResume() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-paused-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt5.pauseAutoReconnect()
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertTrue(mqtt5.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+        XCTAssertEqual(socket.connectCount, 0)
+
+        mqtt5.resumeAutoReconnect()
+
+        XCTAssertFalse(mqtt5.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [ReconnectSchedule(attemptCount: 1, interval: 0)],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 2)
+    }
+
+    func testCocoaMQTT5PauseCancelsScheduledReconnectAndResumeRunsImmediately() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-cancel-paused-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [ReconnectSchedule(attemptCount: 1, interval: 1)],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
+
+        mqtt5.pauseAutoReconnect()
+
+        XCTAssertTrue(mqtt5.isAutoReconnectPaused)
+        XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 0 })
+
+        mqtt5.resumeAutoReconnect()
+
+        XCTAssertFalse(mqtt5.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [
+            ReconnectSchedule(attemptCount: 1, interval: 1),
+            ReconnectSchedule(attemptCount: 1, interval: 0)
+            ],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 2)
+    }
+
+    func testCocoaMQTT5ResumeFromBackgroundQueueSchedulesReconnectOnDelegateQueue() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-background-resume-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        let delegateQueueKey = DispatchSpecificKey<String>()
+        delegateQueue.setSpecific(key: delegateQueueKey, value: "delegate")
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 1
+
+        var callbackQueue: String?
+        mqtt5.didScheduleReconnect = { _, _, _ in
+            callbackQueue = DispatchQueue.getSpecific(key: delegateQueueKey)
+        }
+
+        mqtt5.pauseAutoReconnect()
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        DispatchQueue.global().async {
+            mqtt5.resumeAutoReconnect()
+        }
+
+        XCTAssertTrue(waitUntil {
+            delegateQueue.sync {
+                callbackQueue == "delegate"
+            }
+        })
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+    }
+
+    func testCocoaMQTT5ResumeInDisconnectCallbackSchedulesReconnectOnce() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-resume-in-disconnect-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didDisconnect = { mqtt5, _ in
+            mqtt5.resumeAutoReconnect()
+        }
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt5.pauseAutoReconnect()
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+        delegateQueue.sync {}
+
+        let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
+        XCTAssertFalse(mqtt5.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
+        XCTAssertEqual(delegate.reconnectSchedules, expectedSchedules)
+        XCTAssertEqual(closureSchedules, expectedSchedules)
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
+    }
+
+    func testCocoaMQTT5ResumeInConnackFailureCallbackSchedulesReconnectAfterDisconnectOnce() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "connack-resume-after-disconnect-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 1
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didConnectAck = { mqtt5, ack, _ in
+            XCTAssertEqual(ack, .serverBusy)
+            mqtt5.resumeAutoReconnect()
+        }
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        mqtt5.pauseAutoReconnect()
+        mqtt5.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(code: .serverBusy))
+
+        XCTAssertEqual(delegate.connectAcks, [.serverBusy])
+        XCTAssertEqual(socket.disconnectCount, 1)
+        XCTAssertEqual(socket.connectCount, 0)
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+        delegateQueue.sync {}
+
+        let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
+        XCTAssertFalse(mqtt5.isAutoReconnectPaused)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
+        XCTAssertEqual(delegate.reconnectSchedules, expectedSchedules)
+        XCTAssertEqual(closureSchedules, expectedSchedules)
+        XCTAssertTrue(waitUntil { socket.connectCount == 1 })
+        XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
     }
 
     func testCocoaMQTT5ConnackFailureKeepsAutoReconnectEnabled() {
         let socket = SocketSpy()
         let delegate = MQTT5DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "connack-failure-reconnect-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
         mqtt5.delegate = delegate
         mqtt5.autoReconnect = true
         mqtt5.autoReconnectTimeInterval = 1
@@ -352,8 +931,12 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
-        XCTAssertEqual(delegate.reconnectSchedules, [ReconnectSchedule(attemptCount: 1, interval: 1)])
-        XCTAssertEqual(closureSchedules, delegate.reconnectSchedules)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: [ReconnectSchedule(attemptCount: 1, interval: 1)],
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
     }
 

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -240,7 +240,22 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// The value resets to `0` after a successful connection or expected disconnect.
     public private(set) var reconnectAttemptCount: UInt = 0
 
+    /// Whether auto-reconnect is currently paused by the application.
+    public var isAutoReconnectPaused: Bool {
+        autoReconnectLock.lock()
+        defer { autoReconnectLock.unlock() }
+        return _isAutoReconnectPaused
+    }
+
+    private let autoReconnectLock = NSLock()
+    private var _isAutoReconnectPaused = false
     private var autoReconnTimer: CocoaMQTTTimer?
+    private var isAutoReconnectAttemptScheduled = false
+    private var hasPausedAutoReconnectAttempt = false
+    private var hasPendingAutoReconnectAttempt = false
+    // Tracks the window after requesting an unexpected socket close and before socketDidDisconnect cleans it up.
+    private var pendingSocketDisconnectReconnectAttemptCount: UInt?
+    private var shouldResumeAutoReconnectAfterPendingDisconnect = false
     private var is_internal_disconnected = false
 
     /// Console log level
@@ -423,8 +438,72 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Disconnect unexpectedly.
     /// This keeps auto-reconnect behavior enabled.
     func internal_disconnect() {
+        autoReconnectLock.lock()
+        pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCount
+        autoReconnectLock.unlock()
+
         is_internal_disconnected = false
         socket.disconnect()
+    }
+
+    /// Pause auto-reconnect attempts without disabling `autoReconnect`.
+    ///
+    /// Use this when the application knows reconnect attempts should not run yet,
+    /// for example while waiting for network reachability to recover.
+    public func pauseAutoReconnect() {
+        autoReconnectLock.lock()
+        _isAutoReconnectPaused = true
+        if isAutoReconnectAttemptScheduled {
+            hasPausedAutoReconnectAttempt = true
+            isAutoReconnectAttemptScheduled = false
+        }
+        shouldResumeAutoReconnectAfterPendingDisconnect = false
+        autoReconnTimer = nil
+        autoReconnectLock.unlock()
+    }
+
+    /// Resume auto-reconnect attempts after `pauseAutoReconnect()`.
+    ///
+    /// If an auto-reconnect attempt is pending, this schedules the next reconnect
+    /// attempt immediately.
+    public func resumeAutoReconnect() {
+        autoReconnectLock.lock()
+        guard _isAutoReconnectPaused else {
+            autoReconnectLock.unlock()
+            return
+        }
+
+        _isAutoReconnectPaused = false
+
+        guard autoReconnect, connState == .disconnected else {
+            hasPausedAutoReconnectAttempt = false
+            hasPendingAutoReconnectAttempt = false
+            shouldResumeAutoReconnectAfterPendingDisconnect = false
+            autoReconnectLock.unlock()
+            return
+        }
+
+        if pendingSocketDisconnectReconnectAttemptCount != nil {
+            // Avoid reconnecting before socketDidDisconnect clears the old socket delegate.
+            shouldResumeAutoReconnectAfterPendingDisconnect = true
+            autoReconnectLock.unlock()
+            return
+        }
+
+        guard hasPausedAutoReconnectAttempt || hasPendingAutoReconnectAttempt else {
+            autoReconnectLock.unlock()
+            return
+        }
+
+        if !hasPausedAutoReconnectAttempt {
+            prepareAutoReconnectAttempt()
+        }
+        hasPausedAutoReconnectAttempt = false
+        hasPendingAutoReconnectAttempt = false
+        let schedule = scheduleAutoReconnectAttemptLocked(after: 0)
+        autoReconnectLock.unlock()
+
+        notifyAutoReconnectScheduled(schedule)
     }
 
     private func expected_disconnect() {
@@ -589,14 +668,51 @@ extension CocoaMQTT {
     }
 
     private func resetAutoReconnectState() {
+        autoReconnectLock.lock()
         reconnectTimeInterval = 0
         reconnectAttemptCount = 0
+        _isAutoReconnectPaused = false
         autoReconnTimer = nil
+        isAutoReconnectAttemptScheduled = false
+        hasPausedAutoReconnectAttempt = false
+        hasPendingAutoReconnectAttempt = false
+        pendingSocketDisconnectReconnectAttemptCount = nil
+        shouldResumeAutoReconnectAfterPendingDisconnect = false
+        autoReconnectLock.unlock()
     }
 
-    private func notifyAutoReconnectScheduled() {
-        delegate?.mqtt?(self, didScheduleReconnect: reconnectAttemptCount, after: reconnectTimeInterval)
-        didScheduleReconnect(self, reconnectAttemptCount, reconnectTimeInterval)
+    private func notifyAutoReconnectScheduled(_ schedule: (attemptCount: UInt, interval: UInt16)) {
+        __delegate_queue {
+            self.delegate?.mqtt?(self, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
+            self.didScheduleReconnect(self, schedule.attemptCount, schedule.interval)
+        }
+    }
+
+    private func scheduleAutoReconnectAttemptLocked(after interval: UInt16? = nil) -> (attemptCount: UInt, interval: UInt16) {
+        let delay = interval ?? reconnectTimeInterval
+
+        printInfo("Try reconnect to server after \(delay)s")
+        isAutoReconnectAttemptScheduled = true
+        autoReconnTimer = CocoaMQTTTimer.after(Double(delay), name: "autoReconnTimer", { [weak self] in
+            guard let self = self, self.prepareScheduledAutoReconnectFire() else { return }
+            _ = self.connect()
+        })
+
+        return (reconnectAttemptCount, delay)
+    }
+
+    private func prepareScheduledAutoReconnectFire() -> Bool {
+        autoReconnectLock.lock()
+        defer { autoReconnectLock.unlock() }
+
+        guard !_isAutoReconnectPaused else {
+            isAutoReconnectAttemptScheduled = false
+            return false
+        }
+
+        isAutoReconnectAttemptScheduled = false
+        updateAutoReconnectIntervalForNextAttempt()
+        return true
     }
 }
 
@@ -656,6 +772,12 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         }
 
         connState = .disconnected
+        autoReconnectLock.lock()
+        let reconnectAttemptCountBeforeCallbacks = pendingSocketDisconnectReconnectAttemptCount ?? reconnectAttemptCount
+        if !is_internal_disconnected && autoReconnect {
+            pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCountBeforeCallbacks
+        }
+        autoReconnectLock.unlock()
         delegate?.mqttDidDisconnect(self, withError: err)
         didDisconnect(self, err)
 
@@ -669,16 +791,32 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
             return
         }
 
-        prepareAutoReconnectAttempt()
+        autoReconnectLock.lock()
+        pendingSocketDisconnectReconnectAttemptCount = nil
+        guard !_isAutoReconnectPaused,
+              !isAutoReconnectAttemptScheduled,
+              reconnectAttemptCount == reconnectAttemptCountBeforeCallbacks else {
+            if _isAutoReconnectPaused,
+               !isAutoReconnectAttemptScheduled,
+               reconnectAttemptCount == reconnectAttemptCountBeforeCallbacks {
+                hasPendingAutoReconnectAttempt = true
+            }
+            shouldResumeAutoReconnectAfterPendingDisconnect = false
+            autoReconnectLock.unlock()
+            return
+        }
 
-        // Start reconnector once socket error occurred
-        printInfo("Try reconnect to server after \(reconnectTimeInterval)s")
-        notifyAutoReconnectScheduled()
-        autoReconnTimer = CocoaMQTTTimer.after(Double(reconnectTimeInterval), name: "autoReconnTimer", { [weak self] in
-            guard let self = self else { return }
-            self.updateAutoReconnectIntervalForNextAttempt()
-            _ = self.connect()
-        })
+        let shouldResumeAfterPendingDisconnect = shouldResumeAutoReconnectAfterPendingDisconnect
+        shouldResumeAutoReconnectAfterPendingDisconnect = false
+        if !hasPausedAutoReconnectAttempt {
+            prepareAutoReconnectAttempt()
+        }
+        hasPausedAutoReconnectAttempt = false
+        hasPendingAutoReconnectAttempt = false
+        let schedule = scheduleAutoReconnectAttemptLocked(after: shouldResumeAfterPendingDisconnect ? 0 : nil)
+        autoReconnectLock.unlock()
+
+        notifyAutoReconnectScheduled(schedule)
     }
 }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -256,7 +256,22 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// The value resets to `0` after a successful connection or expected disconnect.
     public private(set) var reconnectAttemptCount: UInt = 0
 
+    /// Whether auto-reconnect is currently paused by the application.
+    public var isAutoReconnectPaused: Bool {
+        autoReconnectLock.lock()
+        defer { autoReconnectLock.unlock() }
+        return _isAutoReconnectPaused
+    }
+
+    private let autoReconnectLock = NSLock()
+    private var _isAutoReconnectPaused = false
     private var autoReconnTimer: CocoaMQTTTimer?
+    private var isAutoReconnectAttemptScheduled = false
+    private var hasPausedAutoReconnectAttempt = false
+    private var hasPendingAutoReconnectAttempt = false
+    // Tracks the window after requesting an unexpected socket close and before socketDidDisconnect cleans it up.
+    private var pendingSocketDisconnectReconnectAttemptCount: UInt?
+    private var shouldResumeAutoReconnectAfterPendingDisconnect = false
     private var is_internal_disconnected = false
     private let disconnectReasonLock = NSLock()
     private var pendingLocalDisconnectReasonCode: CocoaMQTTDISCONNECTReasonCode?
@@ -459,8 +474,72 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Disconnect unexpectedly.
     /// This keeps auto-reconnect behavior enabled.
     func internal_disconnect() {
+        autoReconnectLock.lock()
+        pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCount
+        autoReconnectLock.unlock()
+
         is_internal_disconnected = false
         socket.disconnect()
+    }
+
+    /// Pause auto-reconnect attempts without disabling `autoReconnect`.
+    ///
+    /// Use this when the application knows reconnect attempts should not run yet,
+    /// for example while waiting for network reachability to recover.
+    public func pauseAutoReconnect() {
+        autoReconnectLock.lock()
+        _isAutoReconnectPaused = true
+        if isAutoReconnectAttemptScheduled {
+            hasPausedAutoReconnectAttempt = true
+            isAutoReconnectAttemptScheduled = false
+        }
+        shouldResumeAutoReconnectAfterPendingDisconnect = false
+        autoReconnTimer = nil
+        autoReconnectLock.unlock()
+    }
+
+    /// Resume auto-reconnect attempts after `pauseAutoReconnect()`.
+    ///
+    /// If an auto-reconnect attempt is pending, this schedules the next reconnect
+    /// attempt immediately.
+    public func resumeAutoReconnect() {
+        autoReconnectLock.lock()
+        guard _isAutoReconnectPaused else {
+            autoReconnectLock.unlock()
+            return
+        }
+
+        _isAutoReconnectPaused = false
+
+        guard autoReconnect, connState == .disconnected else {
+            hasPausedAutoReconnectAttempt = false
+            hasPendingAutoReconnectAttempt = false
+            shouldResumeAutoReconnectAfterPendingDisconnect = false
+            autoReconnectLock.unlock()
+            return
+        }
+
+        if pendingSocketDisconnectReconnectAttemptCount != nil {
+            // Avoid reconnecting before socketDidDisconnect clears the old socket delegate.
+            shouldResumeAutoReconnectAfterPendingDisconnect = true
+            autoReconnectLock.unlock()
+            return
+        }
+
+        guard hasPausedAutoReconnectAttempt || hasPendingAutoReconnectAttempt else {
+            autoReconnectLock.unlock()
+            return
+        }
+
+        if !hasPausedAutoReconnectAttempt {
+            prepareAutoReconnectAttempt()
+        }
+        hasPausedAutoReconnectAttempt = false
+        hasPendingAutoReconnectAttempt = false
+        let schedule = scheduleAutoReconnectAttemptLocked(after: 0)
+        autoReconnectLock.unlock()
+
+        notifyAutoReconnectScheduled(schedule)
     }
 
     func internal_disconnect_withProperties(reasonCode: CocoaMQTTDISCONNECTReasonCode, userProperties: [String: String] ) {
@@ -671,14 +750,51 @@ extension CocoaMQTT5 {
     }
 
     private func resetAutoReconnectState() {
+        autoReconnectLock.lock()
         reconnectTimeInterval = 0
         reconnectAttemptCount = 0
+        _isAutoReconnectPaused = false
         autoReconnTimer = nil
+        isAutoReconnectAttemptScheduled = false
+        hasPausedAutoReconnectAttempt = false
+        hasPendingAutoReconnectAttempt = false
+        pendingSocketDisconnectReconnectAttemptCount = nil
+        shouldResumeAutoReconnectAfterPendingDisconnect = false
+        autoReconnectLock.unlock()
     }
 
-    private func notifyAutoReconnectScheduled() {
-        delegate?.mqtt5?(self, didScheduleReconnect: reconnectAttemptCount, after: reconnectTimeInterval)
-        didScheduleReconnect(self, reconnectAttemptCount, reconnectTimeInterval)
+    private func notifyAutoReconnectScheduled(_ schedule: (attemptCount: UInt, interval: UInt16)) {
+        __delegate_queue {
+            self.delegate?.mqtt5?(self, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
+            self.didScheduleReconnect(self, schedule.attemptCount, schedule.interval)
+        }
+    }
+
+    private func scheduleAutoReconnectAttemptLocked(after interval: UInt16? = nil) -> (attemptCount: UInt, interval: UInt16) {
+        let delay = interval ?? reconnectTimeInterval
+
+        printInfo("Try reconnect to server after \(delay)s")
+        isAutoReconnectAttemptScheduled = true
+        autoReconnTimer = CocoaMQTTTimer.after(Double(delay), name: "autoReconnTimer", { [weak self] in
+            guard let self = self, self.prepareScheduledAutoReconnectFire() else { return }
+            _ = self.connect()
+        })
+
+        return (reconnectAttemptCount, delay)
+    }
+
+    private func prepareScheduledAutoReconnectFire() -> Bool {
+        autoReconnectLock.lock()
+        defer { autoReconnectLock.unlock() }
+
+        guard !_isAutoReconnectPaused else {
+            isAutoReconnectAttemptScheduled = false
+            return false
+        }
+
+        isAutoReconnectAttemptScheduled = false
+        updateAutoReconnectIntervalForNextAttempt()
+        return true
     }
 
     private func resetDisconnectReasonState() {
@@ -776,6 +892,12 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         }
 
         connState = .disconnected
+        autoReconnectLock.lock()
+        let reconnectAttemptCountBeforeCallbacks = pendingSocketDisconnectReconnectAttemptCount ?? reconnectAttemptCount
+        if !is_internal_disconnected && autoReconnect {
+            pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCountBeforeCallbacks
+        }
+        autoReconnectLock.unlock()
 
         delegate?.mqtt5DidDisconnect(self, withError: err)
         didDisconnect(self, err)
@@ -790,16 +912,32 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
             return
         }
 
-        prepareAutoReconnectAttempt()
+        autoReconnectLock.lock()
+        pendingSocketDisconnectReconnectAttemptCount = nil
+        guard !_isAutoReconnectPaused,
+              !isAutoReconnectAttemptScheduled,
+              reconnectAttemptCount == reconnectAttemptCountBeforeCallbacks else {
+            if _isAutoReconnectPaused,
+               !isAutoReconnectAttemptScheduled,
+               reconnectAttemptCount == reconnectAttemptCountBeforeCallbacks {
+                hasPendingAutoReconnectAttempt = true
+            }
+            shouldResumeAutoReconnectAfterPendingDisconnect = false
+            autoReconnectLock.unlock()
+            return
+        }
 
-        // Start reconnector once socket error occurred
-        printInfo("Try reconnect to server after \(reconnectTimeInterval)s")
-        notifyAutoReconnectScheduled()
-        autoReconnTimer = CocoaMQTTTimer.after(Double(reconnectTimeInterval), name: "autoReconnTimer", { [weak self] in
-            guard let self = self else { return }
-            self.updateAutoReconnectIntervalForNextAttempt()
-            _ = self.connect()
-        })
+        let shouldResumeAfterPendingDisconnect = shouldResumeAutoReconnectAfterPendingDisconnect
+        shouldResumeAutoReconnectAfterPendingDisconnect = false
+        if !hasPausedAutoReconnectAttempt {
+            prepareAutoReconnectAttempt()
+        }
+        hasPausedAutoReconnectAttempt = false
+        hasPendingAutoReconnectAttempt = false
+        let schedule = scheduleAutoReconnectAttemptLocked(after: shouldResumeAfterPendingDisconnect ? 0 : nil)
+        autoReconnectLock.unlock()
+
+        notifyAutoReconnectScheduled(schedule)
     }
 }
 


### PR DESCRIPTION
Summary:
- Add app-controlled pauseAutoReconnect() and resumeAutoReconnect() APIs for CocoaMQTT and CocoaMQTT5.
- Keep autoReconnect enabled while paused, but avoid scheduling or firing reconnect attempts until the app resumes it.
- Resume immediately schedules the next reconnect attempt with 0s delay when the client is disconnected.
- Add regression coverage for MQTT 3.1.1 and MQTT 5 pause/resume behavior.

Rationale:
This addresses the network outage scenario from #691 without hard-coding internet reachability semantics into the MQTT client. Applications can decide when connectivity is actually usable, pause reconnect attempts while offline, and resume immediately when their own reachability policy allows it.

Verification:
- swift test --scratch-path /Users/admin/Workerspace/CocoaMQTT/.build --filter AutoReconnectStateTests

Refs #691