### PR TITLE
Fix graceful MQTT disconnect

### DIFF
--- a/CocoaMQTTTests/GracefulDisconnectTests.swift
+++ b/CocoaMQTTTests/GracefulDisconnectTests.swift
@@ -1,0 +1,331 @@
+import Foundation
+import XCTest
+@testable import CocoaMQTT
+#if os(macOS)
+import Network
+#endif
+#if IS_SWIFT_PACKAGE
+@testable import CocoaMQTTWebSocket
+#endif
+
+final class GracefulDisconnectTests: XCTestCase {
+    private final class DeferredDisconnectSocket: CocoaMQTTDisconnectAfterWritingSocket {
+        var enableSSL = false
+        private(set) var disconnectCount = 0
+        private(set) var writeAndDisconnectCount = 0
+        private(set) var finalWrites = [Data]()
+
+        func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
+        func connect(toHost host: String, onPort port: UInt16) throws {}
+        func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
+        func disconnect() {
+            disconnectCount += 1
+        }
+        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
+        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {}
+        func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
+            writeAndDisconnectCount += 1
+            finalWrites.append(data)
+        }
+
+        func completeFinalWrite() {
+            disconnect()
+        }
+    }
+
+    func testMQTT311WaitsForDisconnectWriteAndCoalescesRepeatedRequests() {
+        let socket = DeferredDisconnectSocket()
+        let mqtt = CocoaMQTT(clientID: "graceful-disconnect-311", socket: socket)
+
+        mqtt.disconnect()
+        mqtt.disconnect()
+
+        XCTAssertEqual(socket.writeAndDisconnectCount, 1)
+        XCTAssertEqual(socket.finalWrites, [Data([FrameType.disconnect.rawValue, 0])])
+        XCTAssertEqual(socket.disconnectCount, 0)
+
+        socket.completeFinalWrite()
+        XCTAssertEqual(socket.disconnectCount, 1)
+    }
+
+    func testMQTT5WaitsForDisconnectWriteAndPreservesReasonProperties() throws {
+        let socket = DeferredDisconnectSocket()
+        let mqtt = CocoaMQTT5(clientID: "graceful-disconnect-5", socket: socket)
+
+        mqtt.disconnect(
+            reasonCode: .disconnectWithWillMessage,
+            userProperties: ["reason": "manual"]
+        )
+        mqtt.disconnect()
+
+        XCTAssertEqual(socket.writeAndDisconnectCount, 1)
+        XCTAssertEqual(socket.disconnectCount, 0)
+
+        let bytes = try XCTUnwrap(socket.finalWrites.first).map { $0 }
+        XCTAssertEqual(bytes.first, FrameType.disconnect.rawValue)
+        XCTAssertEqual(Int(bytes[1]), bytes.count - 2)
+        let frame = try XCTUnwrap(FrameDisconnect(
+            packetFixedHeaderType: bytes[0],
+            bytes: Array(bytes.dropFirst(2)),
+            protocolVersion: .v5
+        ))
+        XCTAssertEqual(frame.receiveReasonCode, .disconnectWithWillMessage)
+        XCTAssertEqual(frame.userProperties, ["reason": "manual"])
+
+        socket.completeFinalWrite()
+        XCTAssertEqual(socket.disconnectCount, 1)
+    }
+
+    #if IS_SWIFT_PACKAGE
+    private final class WebSocketConnection: NSObject, CocoaMQTTWebSocketConnection {
+        weak var delegate: CocoaMQTTWebSocketConnectionDelegate?
+        var queue = DispatchQueue(label: "tests.graceful-disconnect.websocket")
+        var onWrite: (() -> Void)?
+        var onDisconnect: (() -> Void)?
+        private var completions = [(Error?) -> Void]()
+        private var events = [String]()
+
+        func connect() {}
+
+        func disconnect() {
+            events.append("disconnect")
+            onDisconnect?()
+        }
+
+        func write(data: Data, handler: @escaping (Error?) -> Void) {
+            events.append("write:\(data.first ?? 0)")
+            completions.append(handler)
+            onWrite?()
+        }
+
+        func completeWrite(at index: Int, with error: Error? = nil) {
+            queue.async {
+                let completion = self.completions.remove(at: index)
+                self.events.append("complete")
+                completion(error)
+            }
+        }
+
+        func snapshot() -> [String] {
+            queue.sync { events }
+        }
+    }
+
+    private final class WebSocketBuilder: CocoaMQTTWebSocketConnectionBuilder {
+        let connection: WebSocketConnection
+
+        init(connection: WebSocketConnection) {
+            self.connection = connection
+        }
+
+        func buildConnection(forURL url: URL, withHeaders headers: [String: String]) throws -> CocoaMQTTWebSocketConnection {
+            connection
+        }
+    }
+
+    private final class SocketDelegate: CocoaMQTTSocketDelegate {
+        var onConnect: (() -> Void)?
+        var onWrite: ((Int) -> Void)?
+        var onDisconnect: ((Error?) -> Void)?
+
+        func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+            onConnect?()
+        }
+        func socket(_ socket: CocoaMQTTSocketProtocol,
+                    didReceive trust: SecTrust,
+                    completionHandler: @escaping (Bool) -> Void) {
+            completionHandler(true)
+        }
+        func socketUrlSession(_ socket: CocoaMQTTSocketProtocol,
+                              didReceiveTrust trust: SecTrust,
+                              didReceiveChallenge challenge: URLAuthenticationChallenge,
+                              completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+            completionHandler(.performDefaultHandling, nil)
+        }
+        func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {
+            onWrite?(tag)
+        }
+        func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {}
+        func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
+            onDisconnect?(err)
+        }
+    }
+
+    func testWebSocketClosesOnlyAfterAllPendingWritesComplete() throws {
+        let connection = WebSocketConnection()
+        let websocket = CocoaMQTTWebSocket(
+            uri: "/mqtt",
+            builder: WebSocketBuilder(connection: connection)
+        )
+        let delegate = SocketDelegate()
+        let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.callbacks")
+        let writesQueued = expectation(description: "writes queued")
+        writesQueued.expectedFulfillmentCount = 2
+        let disconnected = expectation(description: "disconnected")
+        connection.onWrite = { writesQueued.fulfill() }
+        delegate.onDisconnect = { error in
+            XCTAssertNil(error)
+            disconnected.fulfill()
+        }
+        websocket.setDelegate(delegate, delegateQueue: callbackQueue)
+        try websocket.connect(toHost: "localhost", onPort: 8083)
+
+        websocket.write(Data([1]), withTimeout: 1, tag: 1)
+        websocket.writeAndDisconnect(Data([2]), withTimeout: 1, tag: 2)
+        wait(for: [writesQueued], timeout: 1)
+
+        connection.completeWrite(at: 1)
+        connection.queue.sync {}
+        XCTAssertFalse(connection.snapshot().contains("disconnect"))
+
+        connection.completeWrite(at: 0)
+        wait(for: [disconnected], timeout: 1)
+        XCTAssertEqual(connection.snapshot(), ["write:1", "write:2", "complete", "complete", "disconnect"])
+
+        websocket.write(Data([3]), withTimeout: 0.01, tag: 3)
+        connection.queue.sync {}
+        XCTAssertEqual(connection.snapshot(), ["write:1", "write:2", "complete", "complete", "disconnect"])
+
+        let reconnectWrite = expectation(description: "write after reconnect")
+        connection.onWrite = { reconnectWrite.fulfill() }
+        try websocket.connect(toHost: "localhost", onPort: 8083)
+        websocket.write(Data([3]), withTimeout: 1, tag: 3)
+        wait(for: [reconnectWrite], timeout: 1)
+        XCTAssertEqual(connection.snapshot().last, "write:3")
+        connection.completeWrite(at: 0)
+        connection.queue.sync {}
+    }
+
+    func testWebSocketRejectsWritesAfterGracefulCloseStarts() throws {
+        let connection = WebSocketConnection()
+        let websocket = CocoaMQTTWebSocket(
+            uri: "/mqtt",
+            builder: WebSocketBuilder(connection: connection)
+        )
+        let writeQueued = expectation(description: "final write queued")
+        connection.onWrite = { writeQueued.fulfill() }
+        try websocket.connect(toHost: "localhost", onPort: 8083)
+
+        websocket.writeAndDisconnect(Data([2]), withTimeout: 1, tag: 2)
+        websocket.write(Data([3]), withTimeout: 1, tag: 3)
+        wait(for: [writeQueued], timeout: 1)
+        connection.queue.sync {}
+
+        XCTAssertEqual(connection.snapshot(), ["write:2"])
+        connection.completeWrite(at: 0)
+    }
+
+    func testWebSocketWriteFailureClosesWithError() throws {
+        let connection = WebSocketConnection()
+        let websocket = CocoaMQTTWebSocket(
+            uri: "/mqtt",
+            builder: WebSocketBuilder(connection: connection)
+        )
+        let delegate = SocketDelegate()
+        let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.failure-callbacks")
+        let writeQueued = expectation(description: "final write queued")
+        let disconnected = expectation(description: "failed disconnect")
+        connection.onWrite = { writeQueued.fulfill() }
+        delegate.onDisconnect = { error in
+            XCTAssertNotNil(error)
+            disconnected.fulfill()
+        }
+        websocket.setDelegate(delegate, delegateQueue: callbackQueue)
+        try websocket.connect(toHost: "localhost", onPort: 8083)
+
+        websocket.writeAndDisconnect(Data([2]), withTimeout: 1, tag: 2)
+        wait(for: [writeQueued], timeout: 1)
+        connection.completeWrite(
+            at: 0,
+            with: NSError(domain: "GracefulDisconnectTests", code: 1)
+        )
+
+        wait(for: [disconnected], timeout: 1)
+        XCTAssertEqual(connection.snapshot().last, "disconnect")
+    }
+
+    func testWebSocketWriteTimeoutClosesConnection() throws {
+        let connection = WebSocketConnection()
+        let websocket = CocoaMQTTWebSocket(
+            uri: "/mqtt",
+            builder: WebSocketBuilder(connection: connection)
+        )
+        let delegate = SocketDelegate()
+        let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.timeout-callbacks")
+        let writeQueued = expectation(description: "final write queued")
+        let disconnected = expectation(description: "timed out disconnect")
+        connection.onWrite = { writeQueued.fulfill() }
+        delegate.onDisconnect = { error in
+            XCTAssertNotNil(error)
+            disconnected.fulfill()
+        }
+        websocket.setDelegate(delegate, delegateQueue: callbackQueue)
+        try websocket.connect(toHost: "localhost", onPort: 8083)
+
+        websocket.writeAndDisconnect(Data([2]), withTimeout: 0.01, tag: 2)
+
+        wait(for: [writeQueued, disconnected], timeout: 1)
+        XCTAssertEqual(connection.snapshot().last, "disconnect")
+    }
+
+    #if os(macOS)
+    func testTCPSendsFinalBytesBeforeClosing() throws {
+        let listenerQueue = DispatchQueue(label: "tests.graceful-disconnect.tcp-listener")
+        let listener = try NWListener(using: .tcp, on: .any)
+        let listenerReady = expectation(description: "listener ready")
+        let receivedEOF = expectation(description: "received final bytes before EOF")
+        let socketDisconnected = expectation(description: "socket disconnected")
+        let expectedData = Data([FrameType.disconnect.rawValue, 0])
+        let receivedLock = NSLock()
+        var receivedData = Data()
+
+        func receiveUntilEOF(_ connection: NWConnection) {
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 1024) { data, _, isComplete, error in
+                if let data {
+                    receivedLock.lock()
+                    receivedData.append(data)
+                    receivedLock.unlock()
+                }
+                if isComplete || error != nil {
+                    receivedEOF.fulfill()
+                } else {
+                    receiveUntilEOF(connection)
+                }
+            }
+        }
+
+        listener.stateUpdateHandler = { state in
+            if case .ready = state {
+                listenerReady.fulfill()
+            }
+        }
+        listener.newConnectionHandler = { connection in
+            connection.start(queue: listenerQueue)
+            receiveUntilEOF(connection)
+        }
+        listener.start(queue: listenerQueue)
+        wait(for: [listenerReady], timeout: 2)
+        let port = try XCTUnwrap(listener.port?.rawValue)
+
+        let socket = CocoaMQTTSocket()
+        let delegate = SocketDelegate()
+        delegate.onConnect = {
+            socket.writeAndDisconnect(expectedData, withTimeout: 1, tag: 1)
+        }
+        delegate.onDisconnect = { error in
+            XCTAssertNil(error)
+            socketDisconnected.fulfill()
+        }
+        socket.setDelegate(delegate, delegateQueue: DispatchQueue(label: "tests.graceful-disconnect.tcp-callbacks"))
+        try socket.connect(toHost: "127.0.0.1", onPort: port, withTimeout: 1)
+
+        wait(for: [receivedEOF, socketDisconnected], timeout: 2)
+        listener.cancel()
+        receivedLock.lock()
+        let finalData = receivedData
+        receivedLock.unlock()
+        XCTAssertEqual(finalData, expectedData)
+    }
+    #endif
+    #endif
+}

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -257,6 +257,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     private var pendingSocketDisconnectReconnectAttemptCount: UInt?
     private var shouldResumeAutoReconnectAfterPendingDisconnect = false
     private var is_internal_disconnected = false
+    private var isExpectedDisconnectPending = false
 
     /// Console log level
     public var logLevel: CocoaMQTTLoggerLevel {
@@ -350,10 +351,15 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         socket.disconnect()
     }
 
-    fileprivate func send(_ frame: Frame, tag: Int = 0) {
+    fileprivate func send(_ frame: Frame, tag: Int = 0, disconnectAfterWriting: Bool = false) {
         printDebug("SEND: \(frame)")
         let data = frame.bytes(version: version)
-        socket.write(Data(bytes: data, count: data.count), withTimeout: 5, tag: tag)
+        let packet = Data(bytes: data, count: data.count)
+        if disconnectAfterWriting {
+            socket.writeAndDisconnect(packet, withTimeout: 5, tag: tag)
+        } else {
+            socket.write(packet, withTimeout: 5, tag: tag)
+        }
     }
 
     fileprivate func sendConnectFrame() {
@@ -589,9 +595,15 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     }
 
     private func expected_disconnect() {
+        clientStateLock.lock()
+        guard !isExpectedDisconnectPending else {
+            clientStateLock.unlock()
+            return
+        }
+        isExpectedDisconnectPending = true
         is_internal_disconnected = true
-        send(FrameDisconnect(), tag: -0xE0)
-        socket.disconnect()
+        clientStateLock.unlock()
+        send(FrameDisconnect(), tag: -0xE0, disconnectAfterWriting: true)
     }
 
     /// Send a PING request to broker
@@ -852,6 +864,9 @@ extension CocoaMQTT {
 extension CocoaMQTT: CocoaMQTTSocketDelegate {
 
     public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+        clientStateLock.lock()
+        isExpectedDisconnectPending = false
+        clientStateLock.unlock()
         sendConnectFrame()
     }
 
@@ -898,6 +913,7 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
         clientStateLock.lock()
+        isExpectedDisconnectPending = false
         // Publish uses the same lock, so queue admission cannot race with the
         // transition from the disconnected session to the next connection.
         deliver.beginConnection()

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -273,6 +273,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     private var pendingSocketDisconnectReconnectAttemptCount: UInt?
     private var shouldResumeAutoReconnectAfterPendingDisconnect = false
     private var is_internal_disconnected = false
+    private var isExpectedDisconnectPending = false
     private let disconnectReasonLock = NSLock()
     private var pendingLocalDisconnectReasonCode: CocoaMQTTDISCONNECTReasonCode?
     private var _lastDisconnectReason: CocoaMQTT5DisconnectReason?
@@ -397,7 +398,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
 
     @discardableResult
-    fileprivate func send(_ frame: Frame, tag: Int = 0) -> Bool {
+    fileprivate func send(_ frame: Frame, tag: Int = 0, disconnectAfterWriting: Bool = false) -> Bool {
         printDebug("SEND: \(frame)")
         let data = frame.bytes(version: version)
 
@@ -409,7 +410,12 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
             return false
         }
 
-        socket.write(Data(bytes: data, count: data.count), withTimeout: 5, tag: tag)
+        let packet = Data(bytes: data, count: data.count)
+        if disconnectAfterWriting {
+            socket.writeAndDisconnect(packet, withTimeout: 5, tag: tag)
+        } else {
+            socket.write(packet, withTimeout: 5, tag: tag)
+        }
         return true
     }
 
@@ -640,8 +646,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// - Note: Only can be called from outside.
     ///         This closes the connection expectedly, so auto-reconnect will not run.
     public func disconnect() {
-        markPendingLocalDisconnect(reasonCode: .normalDisconnection)
-        expected_disconnect(reasonCode: .normalDisconnection)
+        expected_disconnect(reasonCode: .normalDisconnection, recordsLocalReason: true)
     }
 
     public func disconnect(reasonCode: CocoaMQTTDISCONNECTReasonCode, userProperties: [String: String] ) {
@@ -649,8 +654,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
             printError("Invalid MQTT 5 DISCONNECT User Properties.")
             return
         }
-        markPendingLocalDisconnect(reasonCode: reasonCode)
-        expected_disconnect(reasonCode: reasonCode, userProperties: userProperties)
+        expected_disconnect(reasonCode: reasonCode, userProperties: userProperties, recordsLocalReason: true)
     }
 
     /// Disconnect unexpectedly.
@@ -728,12 +732,26 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         expected_disconnect(reasonCode: reasonCode, userProperties: userProperties)
     }
 
-    private func expected_disconnect(reasonCode: CocoaMQTTDISCONNECTReasonCode, userProperties: [String: String]? = nil) {
+    private func expected_disconnect(reasonCode: CocoaMQTTDISCONNECTReasonCode,
+                                     userProperties: [String: String]? = nil,
+                                     recordsLocalReason: Bool = false) {
+        clientStateLock.lock()
+        guard !isExpectedDisconnectPending else {
+            clientStateLock.unlock()
+            return
+        }
+        isExpectedDisconnectPending = true
         is_internal_disconnected = true
+        clientStateLock.unlock()
+        if recordsLocalReason {
+            markPendingLocalDisconnect(reasonCode: reasonCode)
+        }
         var frameDisconnect = FrameDisconnect(disconnectReasonCode: reasonCode)
         frameDisconnect.userProperties = userProperties ?? [:]
-        send(frameDisconnect, tag: -0xE0)
-        socket.disconnect()
+        guard send(frameDisconnect, tag: -0xE0, disconnectAfterWriting: true) else {
+            socket.disconnect()
+            return
+        }
     }
     /// Send a PING request to broker
     public func ping() {
@@ -1161,6 +1179,9 @@ extension CocoaMQTT5 {
 extension CocoaMQTT5: CocoaMQTTSocketDelegate {
 
     public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+        clientStateLock.lock()
+        isExpectedDisconnectPending = false
+        clientStateLock.unlock()
         sendConnectFrame()
     }
 
@@ -1207,6 +1228,7 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
         clientStateLock.lock()
+        isExpectedDisconnectPending = false
         // Publish uses the same lock, so no frame can enter the new connection
         // queue while it still observes aliases or limits from the old one.
         deliver.beginConnection()

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -31,6 +31,26 @@ public protocol CocoaMQTTSocketProtocol {
     func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int)
 }
 
+/// A socket transport that can close only after its final write has drained.
+public protocol CocoaMQTTDisconnectAfterWritingSocket: CocoaMQTTSocketProtocol {
+    func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int)
+}
+
+public extension CocoaMQTTSocketProtocol {
+    /// Writes the final bytes for a connection and closes it afterwards.
+    ///
+    /// Custom transports can adopt `CocoaMQTTDisconnectAfterWritingSocket` to
+    /// provide drain semantics. Other transports retain the legacy immediate close.
+    func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
+        if let gracefulSocket = self as? CocoaMQTTDisconnectAfterWritingSocket {
+            gracefulSocket.writeAndDisconnect(data, withTimeout: timeout, tag: tag)
+            return
+        }
+        write(data, withTimeout: timeout, tag: tag)
+        disconnect()
+    }
+}
+
 // MARK: - CocoaMQTTSocket
 
 public class CocoaMQTTSocket: NSObject {
@@ -53,7 +73,7 @@ public class CocoaMQTTSocket: NSObject {
     public override init() { super.init() }
 }
 
-extension CocoaMQTTSocket: CocoaMQTTSocketProtocol {
+extension CocoaMQTTSocket: CocoaMQTTDisconnectAfterWritingSocket {
     public func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
         delegate = theDelegate
         reference.setDelegate((delegate != nil ? self : nil), delegateQueue: delegateQueue)
@@ -77,6 +97,11 @@ extension CocoaMQTTSocket: CocoaMQTTSocketProtocol {
 
     public func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
         reference.write(data, withTimeout: timeout, tag: tag)
+    }
+
+    public func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
+        reference.write(data, withTimeout: timeout, tag: tag)
+        reference.disconnectAfterWriting()
     }
 }
 

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -49,7 +49,7 @@ public protocol CocoaMQTTWebSocketConnectionBuilder {
 
 // MARK: - CocoaMQTTWebSocket
 
-public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
+public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
 
     public var enableSSL = false
 
@@ -105,8 +105,8 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
 
         guard let url = URL(string: urlStr) else { throw CocoaMQTTError.invalidURL }
         try internalQueue.sync {
-            connection?.disconnect()
-            connection?.delegate = nil
+            reset()
+            disconnectAfterWrites = false
             let newConnection = try builder.buildConnection(forURL: url, withHeaders: self.headers)
             connection = newConnection
             newConnection.delegate = self
@@ -118,6 +118,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
     public func disconnect() {
         internalQueue.async {
             // self.reset()
+            self.disconnectAfterWrites = true
             self.closeConnection(withError: nil)
         }
     }
@@ -132,18 +133,16 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
 
     public func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
         internalQueue.async {
-            let newWrite = WriteItem(tag: tag, timeout: (timeout > 0.0) ? .now() + timeout : .distantFuture)
-            self.scheduledWrites.insert(newWrite)
-            self.checkScheduledWrites()
-            self.connection?.write(data: data) { possibleError in
-                if let error = possibleError {
-                    self.closeConnection(withError: error)
-                } else {
-                    guard self.scheduledWrites.remove(newWrite) != nil else { return }
-                    guard let delegate = self.delegate else { return }
-                    delegate.socket(self, didWriteDataWithTag: tag)
-                }
-            }
+            guard !self.disconnectAfterWrites else { return }
+            self.enqueueWrite(data, withTimeout: timeout, tag: tag)
+        }
+    }
+
+    public func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
+        internalQueue.async {
+            guard !self.disconnectAfterWrites else { return }
+            self.disconnectAfterWrites = true
+            self.enqueueWrite(data, withTimeout: timeout, tag: tag)
         }
     }
 
@@ -168,6 +167,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
     }
 
     private func closeConnection(withError error: Error?) {
+        disconnectAfterWrites = true
         reset()
         __delegate_queue {
             self.delegate?.socketDidDisconnect(self, withError: error)
@@ -243,7 +243,29 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
         }
     }
     private var scheduledWrites = Set<WriteItem>()
+    private var disconnectAfterWrites = false
     private lazy var writeTimeoutTimer = ReusableTimer(queue: internalQueue)
+
+    private func enqueueWrite(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
+        let newWrite = WriteItem(tag: tag, timeout: (timeout > 0.0) ? .now() + timeout : .distantFuture)
+        scheduledWrites.insert(newWrite)
+        checkScheduledWrites()
+        connection?.write(data: data) { possibleError in
+            guard self.scheduledWrites.remove(newWrite) != nil else { return }
+            if let error = possibleError {
+                self.closeConnection(withError: error)
+                return
+            }
+
+            self.delegate?.socket(self, didWriteDataWithTag: tag)
+            if self.disconnectAfterWrites && self.scheduledWrites.isEmpty {
+                self.closeConnection(withError: nil)
+            } else {
+                self.checkScheduledWrites()
+            }
+        }
+    }
+
     private func checkScheduledWrites() {
         writeTimeoutTimer.reset()
         guard let closestTimeout = scheduledWrites.sorted(by: { a, b in a.timeout < b.timeout }).first?.timeout else { return }


### PR DESCRIPTION
## Summary

- add an opt-in transport capability for writing the final MQTT packet before closing without breaking existing socket conformers
- drain TCP writes with `disconnectAfterWriting()` and drain WebSocket writes with bounded success, failure, and timeout handling
- preserve MQTT 3.1.1 and MQTT 5 expected-disconnect, reason-code, user-property, and auto-reconnect behavior
- reject writes after WebSocket graceful close starts until the next connection

## Verification

- `swift test --parallel --skip CocoaMQTTTests.CocoaMQTTTests` — 164 tests passed
- `swift test --filter GracefulDisconnectTests` — 7 tests passed
- `swift package plugin --allow-writing-to-package-directory swiftlint --config .swiftlint.yml --strict --reporter xcode` — 0 violations
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6` — passed with existing Sendable warnings
- `xcodebuild -quiet -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath . build` — passed
- `git diff --check` — passed

Fixes #697