### PR TITLE
Fix MQTT packet read timeout

### DIFF
--- a/CocoaMQTTTests/CocoaMQTTReaderProtocolErrorTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTReaderProtocolErrorTests.swift
@@ -4,16 +4,108 @@ import XCTest
 
 final class CocoaMQTTReaderProtocolErrorTests: XCTestCase {
 
+    private struct ReadRequest: Equatable {
+        let length: UInt
+        let timeout: TimeInterval
+        let tag: Int
+    }
+
     private final class SocketSpy: CocoaMQTTSocketProtocol {
         var enableSSL: Bool = false
         private(set) var disconnectCount = 0
+        private(set) var readRequests = [ReadRequest]()
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
         func connect(toHost host: String, onPort port: UInt16) throws {}
         func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
         func disconnect() { disconnectCount += 1 }
-        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
+        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {
+            readRequests.append(ReadRequest(length: length, timeout: timeout, tag: tag))
+        }
         func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {}
+    }
+
+    func testReaderForwardsDefaultTimeoutToLengthAndPayloadReads() {
+        let socket = SocketSpy()
+        let reader = CocoaMQTTReader(socket: socket, delegate: ReaderDelegateSpy())
+
+        reader.start()
+        reader.headerReady(FrameType.publish.rawValue)
+        reader.lengthReady(3)
+
+        XCTAssertEqual(socket.readRequests, [
+            ReadRequest(length: 1, timeout: -1, tag: CocoaMQTTReadTag.header.rawValue),
+            ReadRequest(length: 1, timeout: 30, tag: CocoaMQTTReadTag.length.rawValue),
+            ReadRequest(length: 3, timeout: 30, tag: CocoaMQTTReadTag.payload.rawValue)
+        ])
+    }
+
+    func testReaderForwardsConfiguredTimeoutAndNormalizesDisabledTimeout() {
+        let configuredSocket = SocketSpy()
+        let configuredReader = CocoaMQTTReader(
+            socket: configuredSocket,
+            delegate: ReaderDelegateSpy(),
+            packetReadTimeout: 2.5
+        )
+        configuredReader.headerReady(FrameType.publish.rawValue)
+
+        let disabledSocket = SocketSpy()
+        let disabledReader = CocoaMQTTReader(
+            socket: disabledSocket,
+            delegate: ReaderDelegateSpy(),
+            packetReadTimeout: .infinity
+        )
+        disabledReader.headerReady(FrameType.publish.rawValue)
+
+        XCTAssertEqual(configuredSocket.readRequests.last?.timeout, 2.5)
+        XCTAssertEqual(disabledSocket.readRequests.last?.timeout, -1)
+    }
+
+    func testReaderAcceptsOneThroughFourByteRemainingLengths() {
+        let cases: [([UInt8], UInt)] = [
+            ([0x7f], 127),
+            ([0x80, 0x01], 128),
+            ([0x80, 0x80, 0x01], 16_384),
+            ([0xff, 0xff, 0xff, 0x7f], 268_435_455)
+        ]
+
+        for (encodedLength, expectedLength) in cases {
+            let socket = SocketSpy()
+            let reader = CocoaMQTTReader(socket: socket, delegate: ReaderDelegateSpy())
+            reader.headerReady(FrameType.publish.rawValue)
+            encodedLength.forEach(reader.lengthReady)
+
+            XCTAssertEqual(socket.disconnectCount, 0)
+            XCTAssertEqual(socket.readRequests.last?.length, expectedLength)
+            XCTAssertEqual(socket.readRequests.last?.tag, CocoaMQTTReadTag.payload.rawValue)
+        }
+    }
+
+    func testClientsPassPacketReadTimeoutToTheirReaders() {
+        let mqtt311Socket = SocketSpy()
+        let mqtt311 = CocoaMQTT(clientID: "reader-timeout-311", socket: mqtt311Socket)
+        mqtt311.packetReadTimeout = 4
+        XCTAssertTrue(mqtt311.connect())
+        mqtt311.socketConnected(mqtt311Socket)
+        mqtt311.socket(
+            mqtt311Socket,
+            didRead: Data([FrameType.publish.rawValue]),
+            withTag: CocoaMQTTReadTag.header.rawValue
+        )
+
+        let mqtt5Socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reader-timeout-5", socket: mqtt5Socket)
+        mqtt5.packetReadTimeout = 6
+        XCTAssertTrue(mqtt5.connect())
+        mqtt5.socketConnected(mqtt5Socket)
+        mqtt5.socket(
+            mqtt5Socket,
+            didRead: Data([FrameType.publish.rawValue]),
+            withTag: CocoaMQTTReadTag.header.rawValue
+        )
+
+        XCTAssertEqual(mqtt311Socket.readRequests.last?.timeout, 4)
+        XCTAssertEqual(mqtt5Socket.readRequests.last?.timeout, 6)
     }
 
     private final class ReaderDelegateSpy: CocoaMQTTReaderDelegate {

--- a/CocoaMQTTTests/GracefulDisconnectTests.swift
+++ b/CocoaMQTTTests/GracefulDisconnectTests.swift
@@ -106,6 +106,12 @@ final class GracefulDisconnectTests: XCTestCase {
             }
         }
 
+        func receive(_ data: Data) {
+            queue.async {
+                self.delegate?.connection(self, receivedData: data)
+            }
+        }
+
         func snapshot() -> [String] {
             queue.sync { events }
         }
@@ -126,6 +132,7 @@ final class GracefulDisconnectTests: XCTestCase {
     private final class SocketDelegate: CocoaMQTTSocketDelegate {
         var onConnect: (() -> Void)?
         var onWrite: ((Int) -> Void)?
+        var onRead: ((Data, Int) -> Void)?
         var onDisconnect: ((Error?) -> Void)?
 
         func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
@@ -145,7 +152,9 @@ final class GracefulDisconnectTests: XCTestCase {
         func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {
             onWrite?(tag)
         }
-        func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {}
+        func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {
+            onRead?(data, tag)
+        }
         func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
             onDisconnect?(err)
         }
@@ -278,6 +287,61 @@ final class GracefulDisconnectTests: XCTestCase {
         websocket.writeAndDisconnect(Data([2]), withTimeout: 0.01, tag: 2)
 
         wait(for: [writeQueued, disconnected], timeout: 1)
+        XCTAssertEqual(connection.snapshot().last, "disconnect")
+    }
+
+    func testWebSocketIncompletePayloadTriggersReadTimeout() throws {
+        let connection = WebSocketConnection()
+        let websocket = CocoaMQTTWebSocket(
+            uri: "/mqtt",
+            builder: WebSocketBuilder(connection: connection)
+        )
+        let delegate = SocketDelegate()
+        let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.read-timeout-callbacks")
+        let headerRead = expectation(description: "header read")
+        let lengthRead = expectation(description: "Remaining Length read")
+        let disconnected = expectation(description: "incomplete payload timed out")
+
+        delegate.onRead = { data, tag in
+            switch CocoaMQTTReadTag(rawValue: tag) {
+            case .header:
+                XCTAssertEqual(data, Data([FrameType.publish.rawValue]))
+                headerRead.fulfill()
+                websocket.readData(
+                    toLength: 1,
+                    withTimeout: 0.05,
+                    tag: CocoaMQTTReadTag.length.rawValue
+                )
+            case .length:
+                XCTAssertEqual(data, Data([2]))
+                lengthRead.fulfill()
+                websocket.readData(
+                    toLength: 2,
+                    withTimeout: 0.05,
+                    tag: CocoaMQTTReadTag.payload.rawValue
+                )
+            case .payload, .none:
+                XCTFail("Incomplete payload should not be delivered")
+            }
+        }
+        delegate.onDisconnect = { error in
+            guard let mqttError = error as? CocoaMQTTError,
+                  case .readTimeout = mqttError else {
+                return XCTFail("Expected readTimeout, got \(String(describing: error))")
+            }
+            disconnected.fulfill()
+        }
+        websocket.setDelegate(delegate, delegateQueue: callbackQueue)
+        try websocket.connect(toHost: "localhost", onPort: 8083)
+        websocket.readData(
+            toLength: 1,
+            withTimeout: -1,
+            tag: CocoaMQTTReadTag.header.rawValue
+        )
+
+        connection.receive(Data([FrameType.publish.rawValue, 2, 0x01]))
+
+        wait(for: [headerRead, lengthRead, disconnected], timeout: 1)
         XCTAssertEqual(connection.snapshot().last, "disconnect")
     }
 

--- a/CocoaMQTTTests/GracefulDisconnectTests.swift
+++ b/CocoaMQTTTests/GracefulDisconnectTests.swift
@@ -159,10 +159,18 @@ final class GracefulDisconnectTests: XCTestCase {
         )
         let delegate = SocketDelegate()
         let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.callbacks")
+        let callbackQueueKey = DispatchSpecificKey<Void>()
+        callbackQueue.setSpecific(key: callbackQueueKey, value: ())
         let writesQueued = expectation(description: "writes queued")
         writesQueued.expectedFulfillmentCount = 2
+        let writeCallbacks = expectation(description: "write callbacks")
+        writeCallbacks.expectedFulfillmentCount = 2
         let disconnected = expectation(description: "disconnected")
         connection.onWrite = { writesQueued.fulfill() }
+        delegate.onWrite = { _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: callbackQueueKey))
+            writeCallbacks.fulfill()
+        }
         delegate.onDisconnect = { error in
             XCTAssertNil(error)
             disconnected.fulfill()
@@ -179,7 +187,7 @@ final class GracefulDisconnectTests: XCTestCase {
         XCTAssertFalse(connection.snapshot().contains("disconnect"))
 
         connection.completeWrite(at: 0)
-        wait(for: [disconnected], timeout: 1)
+        wait(for: [writeCallbacks, disconnected], timeout: 1)
         XCTAssertEqual(connection.snapshot(), ["write:1", "write:2", "complete", "complete", "disconnect"])
 
         websocket.write(Data([3]), withTimeout: 0.01, tag: 3)
@@ -187,13 +195,18 @@ final class GracefulDisconnectTests: XCTestCase {
         XCTAssertEqual(connection.snapshot(), ["write:1", "write:2", "complete", "complete", "disconnect"])
 
         let reconnectWrite = expectation(description: "write after reconnect")
+        let reconnectCallback = expectation(description: "write callback after reconnect")
         connection.onWrite = { reconnectWrite.fulfill() }
+        delegate.onWrite = { _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: callbackQueueKey))
+            reconnectCallback.fulfill()
+        }
         try websocket.connect(toHost: "localhost", onPort: 8083)
         websocket.write(Data([3]), withTimeout: 1, tag: 3)
         wait(for: [reconnectWrite], timeout: 1)
         XCTAssertEqual(connection.snapshot().last, "write:3")
         connection.completeWrite(at: 0)
-        connection.queue.sync {}
+        wait(for: [reconnectCallback], timeout: 1)
     }
 
     func testWebSocketRejectsWritesAfterGracefulCloseStarts() throws {
@@ -269,6 +282,109 @@ final class GracefulDisconnectTests: XCTestCase {
     }
 
     #if os(macOS)
+    private static func extractMQTTPacket(from buffer: inout Data) -> (header: UInt8, body: [UInt8])? {
+        guard buffer.count >= 2 else { return nil }
+        var remainingLength = 0
+        var multiplier = 1
+        var index = 1
+        var lengthByteCount = 0
+
+        while index < buffer.count && lengthByteCount < 4 {
+            let byte = buffer[index]
+            remainingLength += Int(byte & 0x7f) * multiplier
+            multiplier *= 128
+            index += 1
+            lengthByteCount += 1
+            if byte & 0x80 == 0 {
+                guard buffer.count >= index + remainingLength else { return nil }
+                let header = buffer[0]
+                let body = Array(buffer[index..<(index + remainingLength)])
+                buffer = Data(buffer.dropFirst(index + remainingLength))
+                return (header, body)
+            }
+        }
+        return nil
+    }
+
+    func testMQTT5BrokerReceivesDisconnectReasonAndProperties() throws {
+        let listenerQueue = DispatchQueue(label: "tests.graceful-disconnect.mqtt5-broker")
+        let listener = try NWListener(using: .tcp, on: .any)
+        let listenerReady = expectation(description: "MQTT 5 broker ready")
+        let brokerReceivedDisconnect = expectation(description: "broker received MQTT 5 DISCONNECT")
+        let clientDisconnected = expectation(description: "MQTT 5 client disconnected")
+        let observedFrameLock = NSLock()
+        var observedFrame: FrameDisconnect?
+        var receiveBuffer = Data()
+
+        func receivePackets(from connection: NWConnection) {
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, isComplete, error in
+                if let data {
+                    receiveBuffer.append(data)
+                    while let packet = Self.extractMQTTPacket(from: &receiveBuffer) {
+                        switch packet.header & 0xf0 {
+                        case FrameType.connect.rawValue:
+                            connection.send(content: Data([FrameType.connack.rawValue, 3, 0, 0, 0]), completion: .contentProcessed { _ in })
+                        case FrameType.disconnect.rawValue:
+                            observedFrameLock.lock()
+                            observedFrame = FrameDisconnect(
+                                packetFixedHeaderType: packet.header,
+                                bytes: packet.body,
+                                protocolVersion: .v5
+                            )
+                            observedFrameLock.unlock()
+                            brokerReceivedDisconnect.fulfill()
+                        default:
+                            break
+                        }
+                    }
+                }
+                if !isComplete && error == nil {
+                    receivePackets(from: connection)
+                }
+            }
+        }
+
+        listener.stateUpdateHandler = { state in
+            if case .ready = state {
+                listenerReady.fulfill()
+            }
+        }
+        listener.newConnectionHandler = { connection in
+            connection.start(queue: listenerQueue)
+            receivePackets(from: connection)
+        }
+        listener.start(queue: listenerQueue)
+        wait(for: [listenerReady], timeout: 2)
+
+        let mqtt5 = CocoaMQTT5(
+            clientID: "graceful-disconnect-broker",
+            host: "127.0.0.1",
+            port: try XCTUnwrap(listener.port?.rawValue)
+        )
+        mqtt5.delegateQueue = DispatchQueue(label: "tests.graceful-disconnect.mqtt5-callbacks")
+        mqtt5.didConnectAck = { client, reasonCode, _ in
+            XCTAssertEqual(reasonCode, .success)
+            client.disconnect(
+                reasonCode: .disconnectWithWillMessage,
+                userProperties: ["reason": "integration"]
+            )
+        }
+        mqtt5.didDisconnect = { _, error in
+            XCTAssertNil(error)
+            clientDisconnected.fulfill()
+        }
+
+        XCTAssertTrue(mqtt5.connect(timeout: 1))
+        wait(for: [brokerReceivedDisconnect, clientDisconnected], timeout: 2)
+        listener.cancel()
+
+        observedFrameLock.lock()
+        let frame = observedFrame
+        observedFrameLock.unlock()
+        XCTAssertEqual(frame?.receiveReasonCode, .disconnectWithWillMessage)
+        XCTAssertEqual(frame?.userProperties, ["reason": "integration"])
+    }
+
     func testTCPSendsFinalBytesBeforeClosing() throws {
         let listenerQueue = DispatchQueue(label: "tests.graceful-disconnect.tcp-listener")
         let listener = try NWListener(using: .tcp, on: .any)

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -214,6 +214,11 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     public var keepAlive: UInt16 = 60
     private var aliveTimer: CocoaMQTTTimer?
 
+    /// Inactivity timeout in seconds for Remaining Length and payload reads after a packet header.
+    /// Header reads remain unlimited. Nonpositive or nonfinite values disable this timeout. Default is 30 seconds.
+    /// Changes take effect on the next connection.
+    public var packetReadTimeout: TimeInterval = CocoaMQTTReader.defaultPacketReadTimeout
+
     /// Enable auto-reconnect mechanism
     public var autoReconnect = false
 
@@ -495,7 +500,12 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         deliver.beginConnection()
         clientStateLock.unlock()
         socket.setDelegate(self, delegateQueue: delegateQueue)
-        reader = CocoaMQTTReader(socket: socket, delegate: self, protocolVersion: .v311)
+        reader = CocoaMQTTReader(
+            socket: socket,
+            delegate: self,
+            protocolVersion: .v311,
+            packetReadTimeout: packetReadTimeout
+        )
         do {
             if timeout > 0 {
                 try socket.connect(toHost: self.host, onPort: self.port, withTimeout: timeout)

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -214,8 +214,9 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     public var keepAlive: UInt16 = 60
     private var aliveTimer: CocoaMQTTTimer?
 
-    /// Inactivity timeout in seconds for Remaining Length and payload reads after a packet header.
-    /// Header reads remain unlimited. Nonpositive or nonfinite values disable this timeout. Default is 30 seconds.
+    /// Maximum duration in seconds for each Remaining Length byte and the complete payload read.
+    /// Each deadline starts with its read and is not reset by partial data. Header reads remain unlimited.
+    /// Nonpositive or nonfinite values disable these deadlines. Default is 30 seconds.
     /// Changes take effect on the next connection.
     public var packetReadTimeout: TimeInterval = CocoaMQTTReader.defaultPacketReadTimeout
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -224,6 +224,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     public var keepAlive: UInt16 = 60
     private var aliveTimer: CocoaMQTTTimer?
 
+    /// Inactivity timeout in seconds for Remaining Length and payload reads after a packet header.
+    /// Header reads remain unlimited. Nonpositive or nonfinite values disable this timeout. Default is 30 seconds.
+    /// Changes take effect on the next connection.
+    public var packetReadTimeout: TimeInterval = CocoaMQTTReader.defaultPacketReadTimeout
+
     /// Enable auto-reconnect mechanism
     public var autoReconnect = false
 
@@ -620,7 +625,8 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
             socket: socket,
             delegate: self,
             protocolVersion: .v5,
-            maximumPacketSize: connectProperties?.maximumPacketSize
+            maximumPacketSize: connectProperties?.maximumPacketSize,
+            packetReadTimeout: packetReadTimeout
         )
         do {
             if timeout > 0 {

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -224,8 +224,9 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     public var keepAlive: UInt16 = 60
     private var aliveTimer: CocoaMQTTTimer?
 
-    /// Inactivity timeout in seconds for Remaining Length and payload reads after a packet header.
-    /// Header reads remain unlimited. Nonpositive or nonfinite values disable this timeout. Default is 30 seconds.
+    /// Maximum duration in seconds for each Remaining Length byte and the complete payload read.
+    /// Each deadline starts with its read and is not reset by partial data. Header reads remain unlimited.
+    /// Nonpositive or nonfinite values disable these deadlines. Default is 30 seconds.
     /// Changes take effect on the next connection.
     public var packetReadTimeout: TimeInterval = CocoaMQTTReader.defaultPacketReadTimeout
 

--- a/Source/CocoaMQTTReader.swift
+++ b/Source/CocoaMQTTReader.swift
@@ -43,6 +43,8 @@ protocol CocoaMQTTReaderDelegate: AnyObject {
 
 class CocoaMQTTReader {
 
+    static let defaultPacketReadTimeout: TimeInterval = 30
+
     private var socket: CocoaMQTTSocketProtocol
 
     private weak var delegate: CocoaMQTTReaderDelegate?
@@ -51,7 +53,7 @@ class CocoaMQTTReader {
 
     private let maximumPacketSize: UInt32?
 
-    private let timeout: TimeInterval = 30_000
+    private let packetReadTimeout: TimeInterval
 
     /*  -- Reader states -- */
     private var header: UInt8 = 0
@@ -64,11 +66,15 @@ class CocoaMQTTReader {
     init(socket: CocoaMQTTSocketProtocol,
          delegate: CocoaMQTTReaderDelegate?,
          protocolVersion: CocoaMQTTProtocolVersion = .v311,
-         maximumPacketSize: UInt32? = nil) {
+         maximumPacketSize: UInt32? = nil,
+         packetReadTimeout: TimeInterval = CocoaMQTTReader.defaultPacketReadTimeout) {
         self.socket = socket
         self.delegate = delegate
         self.protocolVersion = protocolVersion
         self.maximumPacketSize = maximumPacketSize
+        self.packetReadTimeout = packetReadTimeout.isFinite && packetReadTimeout > 0
+            ? packetReadTimeout
+            : -1
     }
 
     func start() {
@@ -133,11 +139,11 @@ class CocoaMQTTReader {
     }
 
     private func readLength() {
-        socket.readData(toLength: 1, withTimeout: timeout, tag: CocoaMQTTReadTag.length.rawValue)
+        socket.readData(toLength: 1, withTimeout: packetReadTimeout, tag: CocoaMQTTReadTag.length.rawValue)
     }
 
     private func readPayload() {
-        socket.readData(toLength: length, withTimeout: timeout, tag: CocoaMQTTReadTag.payload.rawValue)
+        socket.readData(toLength: length, withTimeout: packetReadTimeout, tag: CocoaMQTTReadTag.payload.rawValue)
     }
 
     private func frameReady() {

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -257,7 +257,11 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
                 return
             }
 
-            self.delegate?.socket(self, didWriteDataWithTag: tag)
+            if let delegate = self.delegate {
+                self.__delegate_queue {
+                    delegate.socket(self, didWriteDataWithTag: tag)
+                }
+            }
             if self.disconnectAfterWrites && self.scheduledWrites.isEmpty {
                 self.closeConnection(withError: nil)
             } else {


### PR DESCRIPTION
## Summary

- replace the accidental 30,000-second partial-packet timeout with a documented, configurable 30-second `packetReadTimeout` for MQTT 3.1.1 and MQTT 5 clients
- keep idle header reads unlimited while applying fixed completion deadlines to each Remaining Length byte and payload read; nonpositive or nonfinite values disable them
- dispatch WebSocket write-completion callbacks through `delegateQueue`
- add valid Remaining Length, timeout wiring, incomplete WebSocket payload, callback-queue, and local MQTT 5 broker disconnect coverage

This also addresses the two outstanding review comments from #707.

## Verification

- `swift test --parallel --skip CocoaMQTTTests.CocoaMQTTTests` (170 tests passed)
- `swift test --sanitize=thread --filter GracefulDisconnectTests` (9 tests passed, no Thread Sanitizer reports)
- `.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/macos/swiftlint lint --strict --config .swiftlint.yml` (0 violations)
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `xcodebuild -quiet -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath . build`

Fixes #698