### PR TITLE
Fix concurrency utility semantics

### DIFF
--- a/CocoaMQTTTests/ConcurrentAtomicTests.swift
+++ b/CocoaMQTTTests/ConcurrentAtomicTests.swift
@@ -9,29 +9,28 @@ final class ConcurrentAtomicTests: XCTestCase {
         XCTAssertEqual($value.wrappedValue, 10, "Set value should be reflected")
     }
 
-    func testMutate() {
-        // Reset the value to a known state
-        $value.setSync(1)
-        XCTAssertEqual(self.value, 1, "Immediately after async mutate, value should still be 1")
-        // Asynchronously multiply the value
-        $value.mutate {
-            // 0.1 seconds delay
-            usleep(100_000)
-            $0 *= 20
-        }
-        XCTAssertEqual(self.value, 20, "Value should still be 20 immediately after async mutate is called")
+    func testAssignmentIsImmediatelyVisible() {
+        value = 10
+        XCTAssertEqual(value, 10)
     }
 
-    func testMultipleAsyncMutations() {
-        let expectation = XCTestExpectation(description: "All async mutations completed")
+    func testMutateReturnsAfterApplyingTransform() {
+        value = 1
+        let result = $value.mutate { value in
+            value *= 20
+            return value
+        }
 
-        // Reset to zero before starting concurrent increments
-        $value.setSync(0)
+        XCTAssertEqual(result, 20)
+        XCTAssertEqual(value, 20)
+    }
+
+    func testConcurrentMutationsAreAtomic() {
+        value = 0
 
         let group = DispatchGroup()
         let queue = DispatchQueue.global(qos: .userInitiated)
 
-        // Perform 100 asynchronous increments
         for _ in 0..<100 {
             group.enter()
             queue.async {
@@ -40,14 +39,16 @@ final class ConcurrentAtomicTests: XCTestCase {
             }
         }
 
-        // Wait for all tasks to finish, then check the result
-        group.notify(queue: .main) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                XCTAssertEqual(self.value, 100, "All async mutate operations should complete successfully")
-                expectation.fulfill()
-            }
-        }
+        XCTAssertEqual(group.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(value, 100)
+    }
 
-        wait(for: [expectation], timeout: 1.0)
+    func testCompareAndSet() {
+        value = 10
+
+        XCTAssertFalse($value.compareAndSet(expected: 9, newValue: 11))
+        XCTAssertEqual(value, 10)
+        XCTAssertTrue($value.compareAndSet(expected: 10, newValue: 12))
+        XCTAssertEqual(value, 12)
     }
 }

--- a/CocoaMQTTTests/ConcurrentAtomicTests.swift
+++ b/CocoaMQTTTests/ConcurrentAtomicTests.swift
@@ -51,4 +51,17 @@ final class ConcurrentAtomicTests: XCTestCase {
         XCTAssertTrue($value.compareAndSet(expected: 10, newValue: 12))
         XCTAssertEqual(value, 12)
     }
+
+    func testMutationObserverReceivesAssignmentsAndTransforms() {
+        var observedValues = [Int]()
+        $value.setMutationObserver { observedValues.append($0) }
+
+        value = 2
+        $value.mutate { $0 += 3 }
+        $value.setSync(8)
+        XCTAssertFalse($value.compareAndSet(expected: 7, newValue: 9))
+        XCTAssertTrue($value.compareAndSet(expected: 8, newValue: 9))
+
+        XCTAssertEqual(observedValues, [2, 5, 8, 9])
+    }
 }

--- a/CocoaMQTTTests/PublicLoggerAPITests.swift
+++ b/CocoaMQTTTests/PublicLoggerAPITests.swift
@@ -51,4 +51,13 @@ final class PublicLoggerAPITests: XCTestCase {
 
         XCTAssertEqual(readGroup.wait(timeout: .now() + 10), .success)
     }
+
+    func testMQTT5ConnStateProjectionRemainsPublic() {
+        let mqtt5 = CocoaMQTT5(clientID: "public-connstate-projection-\(UUID().uuidString)")
+        let projection: ConcurrentAtomic<CocoaMQTTConnState> = mqtt5.$connState
+
+        projection.wrappedValue = .connecting
+
+        XCTAssertEqual(mqtt5.connState, .connecting)
+    }
 }

--- a/CocoaMQTTTests/PublicLoggerAPITests.swift
+++ b/CocoaMQTTTests/PublicLoggerAPITests.swift
@@ -59,5 +59,7 @@ final class PublicLoggerAPITests: XCTestCase {
         projection.wrappedValue = .connecting
 
         XCTAssertEqual(mqtt5.connState, .connecting)
+        XCTAssertTrue(projection.compareAndSet(expected: .connecting, newValue: .connected))
+        XCTAssertEqual(mqtt5.connState, .connected)
     }
 }

--- a/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
+++ b/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
@@ -221,7 +221,7 @@ final class ThreadSafetyRegressionTests: XCTestCase {
         XCTAssertEqual(receivedStates, [.connecting, .connected])
     }
 
-    func testCocoaMQTT5ConnStateCallbacksAreSerializedOnConcurrentDelegateQueue() {
+    func testCocoaMQTT5ConnStateCallbacksFollowConcurrentDelegateQueueSemantics() {
         let mqtt5 = CocoaMQTT5(clientID: "connstate-concurrent-callbacks-\(UUID().uuidString)")
         mqtt5.delegateQueue = DispatchQueue(
             label: "tests.threadsafe.connstate-concurrent-callbacks",
@@ -230,26 +230,26 @@ final class ThreadSafetyRegressionTests: XCTestCase {
         let firstCallbackStarted = DispatchSemaphore(value: 0)
         let releaseFirstCallback = DispatchSemaphore(value: 0)
         let secondCallbackStarted = DispatchSemaphore(value: 0)
-        var receivedStates = [CocoaMQTTConnState]()
+        let callbacksFinished = expectation(description: "Concurrent state callbacks finished")
+        callbacksFinished.expectedFulfillmentCount = 2
 
         mqtt5.didChangeState = { _, state in
-            receivedStates.append(state)
             if state == .connecting {
                 firstCallbackStarted.signal()
                 releaseFirstCallback.wait()
             } else if state == .connected {
                 secondCallbackStarted.signal()
             }
+            callbacksFinished.fulfill()
         }
 
         mqtt5.connState = .connecting
         mqtt5.connState = .connected
 
         XCTAssertEqual(firstCallbackStarted.wait(timeout: .now() + 1), .success)
-        XCTAssertEqual(secondCallbackStarted.wait(timeout: .now() + 0.05), .timedOut)
-        releaseFirstCallback.signal()
         XCTAssertEqual(secondCallbackStarted.wait(timeout: .now() + 1), .success)
-        XCTAssertEqual(receivedStates, [.connecting, .connected])
+        releaseFirstCallback.signal()
+        wait(for: [callbacksFinished], timeout: 1)
     }
 
     func testConcurrentPublishesAllocateUniquePacketIdentifiers() {

--- a/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
+++ b/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
@@ -221,6 +221,37 @@ final class ThreadSafetyRegressionTests: XCTestCase {
         XCTAssertEqual(receivedStates, [.connecting, .connected])
     }
 
+    func testCocoaMQTT5ConnStateCallbacksAreSerializedOnConcurrentDelegateQueue() {
+        let mqtt5 = CocoaMQTT5(clientID: "connstate-concurrent-callbacks-\(UUID().uuidString)")
+        mqtt5.delegateQueue = DispatchQueue(
+            label: "tests.threadsafe.connstate-concurrent-callbacks",
+            attributes: .concurrent
+        )
+        let firstCallbackStarted = DispatchSemaphore(value: 0)
+        let releaseFirstCallback = DispatchSemaphore(value: 0)
+        let secondCallbackStarted = DispatchSemaphore(value: 0)
+        var receivedStates = [CocoaMQTTConnState]()
+
+        mqtt5.didChangeState = { _, state in
+            receivedStates.append(state)
+            if state == .connecting {
+                firstCallbackStarted.signal()
+                releaseFirstCallback.wait()
+            } else if state == .connected {
+                secondCallbackStarted.signal()
+            }
+        }
+
+        mqtt5.connState = .connecting
+        mqtt5.connState = .connected
+
+        XCTAssertEqual(firstCallbackStarted.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(secondCallbackStarted.wait(timeout: .now() + 0.05), .timedOut)
+        releaseFirstCallback.signal()
+        XCTAssertEqual(secondCallbackStarted.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(receivedStates, [.connecting, .connected])
+    }
+
     func testConcurrentPublishesAllocateUniquePacketIdentifiers() {
         let mqtt = CocoaMQTT(clientID: "thread-safe-publish-\(UUID().uuidString)", socket: SocketStub())
         mqtt.delegateQueue = DispatchQueue(label: "tests.threadsafe.publish.delegate")

--- a/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
+++ b/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
@@ -77,21 +77,43 @@ final class ThreadSafetyRegressionTests: XCTestCase {
         XCTAssertEqual(readGroup.wait(timeout: .now() + 10), .success)
     }
 
-    func testThreadSafeDictionaryRetainsCollectionCompatibilityWithSnapshotIteration() {
+    func testThreadSafeDictionarySequenceIterationUsesSnapshots() {
         let store = ThreadSafeDictionary<String, Int>(
             label: "tests.threadsafe.collection",
             dict: ["a": 1, "b": 2]
         )
-        let collection: any Collection = store
+        let sequence = AnySequence(store)
 
         XCTAssertEqual(store.count, 2)
         XCTAssertFalse(store.isEmpty)
         XCTAssertNotNil(store.first)
         XCTAssertEqual(
-            Dictionary(uniqueKeysWithValues: store.map { ($0.key, $0.value) }),
+            Dictionary(uniqueKeysWithValues: sequence.map { ($0.key, $0.value) }),
             ["a": 1, "b": 2]
         )
-        XCTAssertEqual(collection.count, 2)
+    }
+
+    func testThreadSafeDictionaryIteratesWhileMutating() {
+        let store = ThreadSafeDictionary<Int, Int>(label: "tests.threadsafe.snapshot-iteration")
+        let queue = DispatchQueue(label: "tests.threadsafe.snapshot-writes", attributes: .concurrent)
+        let group = DispatchGroup()
+
+        for worker in 0..<4 {
+            group.enter()
+            queue.async {
+                for value in stride(from: worker, to: 2_000, by: 4) {
+                    store[value] = value
+                }
+                group.leave()
+            }
+        }
+
+        for _ in 0..<100 {
+            XCTAssertTrue(store.allSatisfy { $0.key == $0.value })
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 2), .success)
+        XCTAssertEqual(store.count, 2_000)
     }
 
     func testWebSocketDelegateAndLoggerConcurrentAccess() {

--- a/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
+++ b/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
@@ -195,6 +195,32 @@ final class ThreadSafetyRegressionTests: XCTestCase {
         XCTAssertTrue([.connecting, .connected, .disconnected].contains(mqtt5.connState))
     }
 
+    func testCocoaMQTT5ConnStateCallbacksPreserveWrittenStates() {
+        let mqtt5 = CocoaMQTT5(clientID: "connstate-callbacks-\(UUID().uuidString)")
+        let callbackQueue = DispatchQueue(label: "tests.threadsafe.connstate-callbacks")
+        let callbackGate = DispatchSemaphore(value: 0)
+        let callbacksReceived = expectation(description: "State callbacks received")
+        callbacksReceived.expectedFulfillmentCount = 2
+        var receivedStates = [CocoaMQTTConnState]()
+
+        callbackQueue.async {
+            callbackGate.wait()
+        }
+        mqtt5.delegateQueue = callbackQueue
+        mqtt5.didChangeState = { _, state in
+            receivedStates.append(state)
+            callbacksReceived.fulfill()
+        }
+
+        mqtt5.connState = .connecting
+        mqtt5.connState = .connected
+        callbackGate.signal()
+
+        wait(for: [callbacksReceived], timeout: 1)
+        callbackQueue.sync {}
+        XCTAssertEqual(receivedStates, [.connecting, .connected])
+    }
+
     func testConcurrentPublishesAllocateUniquePacketIdentifiers() {
         let mqtt = CocoaMQTT(clientID: "thread-safe-publish-\(UUID().uuidString)", socket: SocketStub())
         mqtt.delegateQueue = DispatchQueue(label: "tests.threadsafe.publish.delegate")

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -188,23 +188,9 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     public var delegateQueue = DispatchQueue.main
 
     @ConcurrentAtomic(wrappedValue: CocoaMQTTConnState.disconnected, label: "CocoaMQTT5.connState")
-    private var connStateStorage
+    public var connState
 
-    public var connState: CocoaMQTTConnState {
-        get { connStateStorage }
-        set {
-            $connStateStorage.mutate { state in
-                state = newValue
-                // Enqueue while holding the atomic barrier so notifications retain
-                // the same order as concurrent state writes.
-                let notifiedState = newValue
-                __delegate_queue {
-                    self.delegate?.mqtt5?(self, didStateChangeTo: notifiedState)
-                    self.didChangeState(self, notifiedState)
-                }
-            }
-        }
-    }
+    private let stateNotificationQueue = DispatchQueue(label: "CocoaMQTT5.stateNotifications")
 
     // deliver
     private var deliver = CocoaMQTTDeliver()
@@ -399,6 +385,9 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         self.port = port
         self.socket = socket
         super.init()
+        $connState.setMutationObserver { [weak self] state in
+            self?.enqueueStateNotification(state)
+        }
         configureSessionExpiryController(for: clientID)
         deliver.protocolVersion = .v5
         deliver.delegate = self
@@ -1085,6 +1074,16 @@ extension CocoaMQTT5: CocoaMQTTDeliverProtocol {
 }
 
 extension CocoaMQTT5 {
+
+    private func enqueueStateNotification(_ state: CocoaMQTTConnState) {
+        let callbackQueue = delegateQueue
+        stateNotificationQueue.async {
+            callbackQueue.sync {
+                self.delegate?.mqtt5?(self, didStateChangeTo: state)
+                self.didChangeState(self, state)
+            }
+        }
+    }
 
     func __delegate_queue(_ fun: @escaping () -> Void) {
         delegateQueue.async { [weak self] in

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -190,8 +190,6 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     @ConcurrentAtomic(wrappedValue: CocoaMQTTConnState.disconnected, label: "CocoaMQTT5.connState")
     public var connState
 
-    private let stateNotificationQueue = DispatchQueue(label: "CocoaMQTT5.stateNotifications")
-
     // deliver
     private var deliver = CocoaMQTTDeliver()
 
@@ -386,7 +384,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         self.socket = socket
         super.init()
         $connState.setMutationObserver { [weak self] state in
-            self?.enqueueStateNotification(state)
+            guard let self = self else { return }
+            self.__delegate_queue {
+                self.delegate?.mqtt5?(self, didStateChangeTo: state)
+                self.didChangeState(self, state)
+            }
         }
         configureSessionExpiryController(for: clientID)
         deliver.protocolVersion = .v5
@@ -1074,16 +1076,6 @@ extension CocoaMQTT5: CocoaMQTTDeliverProtocol {
 }
 
 extension CocoaMQTT5 {
-
-    private func enqueueStateNotification(_ state: CocoaMQTTConnState) {
-        let callbackQueue = delegateQueue
-        stateNotificationQueue.async {
-            callbackQueue.sync {
-                self.delegate?.mqtt5?(self, didStateChangeTo: state)
-                self.didChangeState(self, state)
-            }
-        }
-    }
 
     func __delegate_queue(_ fun: @escaping () -> Void) {
         delegateQueue.async { [weak self] in

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -188,11 +188,20 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     public var delegateQueue = DispatchQueue.main
 
     @ConcurrentAtomic(wrappedValue: CocoaMQTTConnState.disconnected, label: "CocoaMQTT5.connState")
-    public var connState {
-        didSet {
-            __delegate_queue {
-                self.delegate?.mqtt5?(self, didStateChangeTo: self.connState)
-                self.didChangeState(self, self.connState)
+    private var connStateStorage
+
+    public var connState: CocoaMQTTConnState {
+        get { connStateStorage }
+        set {
+            $connStateStorage.mutate { state in
+                state = newValue
+                // Enqueue while holding the atomic barrier so notifications retain
+                // the same order as concurrent state writes.
+                let notifiedState = newValue
+                __delegate_queue {
+                    self.delegate?.mqtt5?(self, didStateChangeTo: notifiedState)
+                    self.didChangeState(self, notifiedState)
+                }
             }
         }
     }

--- a/Source/ThreadSafeDictionary.swift
+++ b/Source/ThreadSafeDictionary.swift
@@ -6,22 +6,14 @@ import Foundation
 
 /// A thread-safe dictionary.
 ///
-/// Iteration uses a stable snapshot. Explicit indices, like indices of any mutable
-/// Swift collection, are valid only until the dictionary is mutated.
-public final class ThreadSafeDictionary<K: Hashable, V>: Collection {
-    public typealias Index = Dictionary<K, V>.Index
+/// Iteration uses a stable snapshot so concurrent mutations cannot invalidate an
+/// iterator. Use `snapshot()` when an operation needs one consistent dictionary.
+public final class ThreadSafeDictionary<K: Hashable, V>: Sequence {
     public typealias Element = Dictionary<K, V>.Element
+    public typealias Iterator = Dictionary<K, V>.Iterator
 
     private var dictionary: [K: V]
     private let concurrentQueue: DispatchQueue
-
-    public var startIndex: Index {
-        concurrentQueue.sync { dictionary.startIndex }
-    }
-
-    public var endIndex: Index {
-        concurrentQueue.sync { dictionary.endIndex }
-    }
 
     public var count: Int {
         concurrentQueue.sync { dictionary.count }
@@ -40,16 +32,8 @@ public final class ThreadSafeDictionary<K: Hashable, V>: Collection {
         concurrentQueue = DispatchQueue(label: label, attributes: .concurrent)
     }
 
-    public func index(after i: Index) -> Index {
-        concurrentQueue.sync { dictionary.index(after: i) }
-    }
-
-    public subscript(index: Index) -> Element {
-        concurrentQueue.sync { dictionary[index] }
-    }
-
     /// `for-in`, `map`, and other sequence operations iterate over one snapshot.
-    public func makeIterator() -> Dictionary<K, V>.Iterator {
+    public func makeIterator() -> Iterator {
         snapshot().makeIterator()
     }
 

--- a/Source/utilities/ConcurrentAtomic.swift
+++ b/Source/utilities/ConcurrentAtomic.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// A thread-safe property wrapper that uses a concurrent dispatch queue for atomic operations.
 ///
-/// This wrapper provides both synchronous and asynchronous access to a wrapped value in a
-/// thread-safe manner using `DispatchQueue` with `.concurrent` attributes and `.barrier` writes.
+/// Reads run concurrently, while writes and compound mutations use synchronous barriers.
 ///
 /// - Important: Although this wrapper provides atomicity for access, it does not make the wrapped
 ///   value itself thread-safe if the type is not thread-safe. Avoid wrapping types that manage
-///   internal shared state without their own synchronization.
+///   internal shared state without their own synchronization. A read followed by a write is not
+///   one atomic operation; use `mutate` for compound changes.
 ///
 /// - Example:
 /// ```swift
 /// @ConcurrentAtomic var counter: Int = 0
-/// counter += 1
+/// $counter.mutate { $0 += 1 }
 /// print(counter)
 /// ```
 @propertyWrapper
@@ -23,14 +23,13 @@ public class ConcurrentAtomic<T> {
     /// Provides synchronous thread-safe access to the wrapped value.
     ///
     /// - Note: Reads use `queue.sync` and can happen concurrently.
-    /// - Warning: Writes are done asynchronously with `.barrier`, so a following read may
-    ///   not reflect the new value immediately.
+    /// - Note: Writes use a synchronous barrier and are visible when assignment returns.
     public var wrappedValue: T {
         get {
             queue.sync { _value }
         }
         set {
-            queue.async(flags: .barrier) {
+            queue.sync(flags: .barrier) {
                 self._value = newValue
             }
         }
@@ -60,14 +59,30 @@ public class ConcurrentAtomic<T> {
         }
     }
 
-    /// Asynchronously mutates the wrapped value using a transform closure.
+    /// Atomically mutates the wrapped value using a synchronous transform closure.
     ///
-    /// The mutation is performed with `.barrier`, ensuring it does not overlap with other reads or writes.
+    /// The barrier ensures the read-modify-write operation does not overlap with other access.
     ///
     /// - Parameter transform: A closure that receives `inout` access to the wrapped value.
-    public func mutate(_ transform: @escaping (inout T) -> Void) {
-        queue.async(flags: .barrier) {
-            transform(&self._value)
+    /// - Returns: The value returned by `transform`.
+    @discardableResult
+    public func mutate<Result>(_ transform: (inout T) throws -> Result) rethrows -> Result {
+        try queue.sync(flags: .barrier) {
+            try transform(&self._value)
+        }
+    }
+}
+
+public extension ConcurrentAtomic where T: Equatable {
+    /// Replaces the stored value only when it equals `expected`.
+    ///
+    /// - Returns: `true` when the value was replaced; otherwise `false`.
+    @discardableResult
+    func compareAndSet(expected: T, newValue: T) -> Bool {
+        mutate { value in
+            guard value == expected else { return false }
+            value = newValue
+            return true
         }
     }
 }

--- a/Source/utilities/ConcurrentAtomic.swift
+++ b/Source/utilities/ConcurrentAtomic.swift
@@ -63,6 +63,10 @@ public class ConcurrentAtomic<T> {
     ///
     /// The barrier ensures the read-modify-write operation does not overlap with other access.
     ///
+    /// - Important: Do not access this `ConcurrentAtomic` instance from `transform`. The
+    ///   transform executes while its synchronization barrier is held, so re-entering the
+    ///   same instance would deadlock.
+    ///
     /// - Parameter transform: A closure that receives `inout` access to the wrapped value.
     /// - Returns: The value returned by `transform`.
     @discardableResult

--- a/Source/utilities/ConcurrentAtomic.swift
+++ b/Source/utilities/ConcurrentAtomic.swift
@@ -18,6 +18,7 @@ import Foundation
 @propertyWrapper
 public class ConcurrentAtomic<T> {
     private var _value: T
+    private var mutationObserver: ((T) -> Void)?
     private let queue: DispatchQueue
 
     /// Provides synchronous thread-safe access to the wrapped value.
@@ -31,6 +32,7 @@ public class ConcurrentAtomic<T> {
         set {
             queue.sync(flags: .barrier) {
                 self._value = newValue
+                self.mutationObserver?(newValue)
             }
         }
     }
@@ -56,6 +58,7 @@ public class ConcurrentAtomic<T> {
     public func setSync(_ newValue: T) {
         queue.sync(flags: .barrier) {
             self._value = newValue
+            self.mutationObserver?(newValue)
         }
     }
 
@@ -72,7 +75,17 @@ public class ConcurrentAtomic<T> {
     @discardableResult
     public func mutate<Result>(_ transform: (inout T) throws -> Result) rethrows -> Result {
         try queue.sync(flags: .barrier) {
-            try transform(&self._value)
+            defer { self.mutationObserver?(self._value) }
+            return try transform(&self._value)
+        }
+    }
+
+    /// Installs an observer that runs inside the mutation barrier.
+    ///
+    /// The observer must not re-enter this `ConcurrentAtomic` instance.
+    func setMutationObserver(_ observer: ((T) -> Void)?) {
+        queue.sync(flags: .barrier) {
+            mutationObserver = observer
         }
     }
 }
@@ -83,9 +96,10 @@ public extension ConcurrentAtomic where T: Equatable {
     /// - Returns: `true` when the value was replaced; otherwise `false`.
     @discardableResult
     func compareAndSet(expected: T, newValue: T) -> Bool {
-        mutate { value in
-            guard value == expected else { return false }
-            value = newValue
+        queue.sync(flags: .barrier) {
+            guard _value == expected else { return false }
+            _value = newValue
+            mutationObserver?(newValue)
             return true
         }
     }


### PR DESCRIPTION
## Summary

- replace `ThreadSafeDictionary`’s unsafe `Collection` conformance with snapshot-backed `Sequence` iteration while preserving key subscripting, `count`, `first`, and snapshot APIs
- make `ConcurrentAtomic` assignment and `mutate` synchronous so writes are visible when calls return
- let atomic transforms return values and add `compareAndSet(expected:newValue:)` for conditional updates
- preserve the exact MQTT 5 state associated with each notification and submit notifications to `delegateQueue` in atomic write order
- preserve the public `$connState` projection and route projected mutations through the same notification path
- retain existing callback behavior: `.main` by default, serial execution on serial queues, and concurrent execution when callers select a concurrent queue
- document that `ConcurrentAtomic.mutate` transforms must not re-enter the same wrapper
- add deterministic concurrent mutation, compare-and-set, snapshot iteration, public API, and state callback coverage

## Compatibility

`ThreadSafeDictionary` no longer exposes `Collection` index APIs. Iteration (`for-in`, `map`, and other `Sequence` operations) remains source-compatible and now always uses an immutable snapshot. This intentionally removes index operations that could trap after a concurrent mutation.

`ConcurrentAtomic.mutate` now completes synchronously instead of enqueueing work asynchronously. No production call sites depended on the previous asynchronous completion behavior.

`CocoaMQTT5.connState` remains a public wrapped property, including its public `$connState` projection. Each mutation captures the state written by that operation and submits its callback directly using the existing asynchronous `delegateQueue` mechanism.

Serial queues, including the default main queue, retain ordered callback execution. Caller-supplied concurrent queues retain their existing concurrent callback semantics. This PR does not claim that choosing a concurrent `delegateQueue` makes the internal MQTT state machine safe for concurrent execution. Separating the private MQTT event loop from the public callback queue is tracked independently in #710.

## Verification

- `swift test --parallel --skip CocoaMQTTTests.CocoaMQTTTests` (177 tests passed)
- `swift test --sanitize=thread --filter "ConcurrentAtomicTests|ThreadSafetyRegressionTests|PublicLoggerAPITests"` (18 tests passed, no Thread Sanitizer reports)
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `xcodebuild -quiet -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath /tmp/CocoaMQTT-issue-700-derived build`
- `.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/macos/swiftlint lint --strict --config .swiftlint.yml` (0 violations)

## Follow-up

- #710 separates internal MQTT event processing from the public callback queue.

Fixes #700