### PR TITLE
Separate internal event loop from callback queue

### DIFF
--- a/CocoaMQTTTests/AutoReconnectStateTests.swift
+++ b/CocoaMQTTTests/AutoReconnectStateTests.swift
@@ -6,30 +6,57 @@ final class AutoReconnectStateTests: XCTestCase {
 
     private final class SocketSpy: CocoaMQTTSocketProtocol {
         var enableSSL: Bool = false
+        private let lock = NSLock()
         private(set) weak var delegate: CocoaMQTTSocketDelegate?
-        private(set) var connectCount = 0
-        private(set) var disconnectCount = 0
-        private(set) var writes: [Data] = []
+        private var _connectCount = 0
+        private var _disconnectCount = 0
+        private var _writes: [Data] = []
+
+        var connectCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _connectCount
+        }
+
+        var disconnectCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _disconnectCount
+        }
+
+        var writes: [Data] {
+            lock.lock()
+            defer { lock.unlock() }
+            return _writes
+        }
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
             delegate = theDelegate
         }
 
         func connect(toHost host: String, onPort port: UInt16) throws {
-            connectCount += 1
+            lock.lock()
+            _connectCount += 1
+            lock.unlock()
         }
 
         func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {
-            connectCount += 1
+            lock.lock()
+            _connectCount += 1
+            lock.unlock()
         }
 
         func disconnect() {
-            disconnectCount += 1
+            lock.lock()
+            _disconnectCount += 1
+            lock.unlock()
         }
 
         func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
         func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
-            writes.append(data)
+            lock.lock()
+            _writes.append(data)
+            lock.unlock()
         }
     }
 
@@ -161,6 +188,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt.reconnectAttemptCount == 1 })
         XCTAssertEqual(mqtt.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
         XCTAssertTrue(waitForReconnectSchedules(
@@ -175,6 +203,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt.reconnectAttemptCount == 2 })
         XCTAssertEqual(mqtt.reconnectTimeInterval, 2)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 2)
         XCTAssertTrue(waitForReconnectSchedules(
@@ -243,6 +272,28 @@ final class AutoReconnectStateTests: XCTestCase {
         releaseEventLoop.signal()
         mqtt.eventLoopQueue.sync {}
 
+        XCTAssertEqual(socket.connectCount, 0)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
+    }
+
+    func testCocoaMQTTWaitsForDisconnectCallbackBeforeImmediateReconnect() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "reconnect-callback-order-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        let releaseCallback = DispatchSemaphore(value: 0)
+        delegateQueue.async { releaseCallback.wait() }
+        mqtt.delegateQueue = delegateQueue
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 0
+        mqtt.didDisconnect = { mqtt, _ in mqtt.autoReconnect = false }
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        usleep(100_000)
+        XCTAssertEqual(socket.connectCount, 0)
+
+        releaseCallback.signal()
+        delegateQueue.sync {}
+        mqtt.eventLoopQueue.sync {}
         XCTAssertEqual(socket.connectCount, 0)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
     }
@@ -367,6 +418,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt.reconnectAttemptCount == 1 })
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
         XCTAssertTrue(waitForReconnectSchedules(
             on: delegateQueue,
@@ -502,8 +554,12 @@ final class AutoReconnectStateTests: XCTestCase {
         let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
         XCTAssertFalse(mqtt.isAutoReconnectPaused)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
-        XCTAssertEqual(delegate.reconnectSchedules, expectedSchedules)
-        XCTAssertEqual(closureSchedules, expectedSchedules)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: expectedSchedules,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
         XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
     }
@@ -537,6 +593,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt.reconnectAttemptCount == 1 })
         XCTAssertEqual(mqtt.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
         XCTAssertTrue(waitForReconnectSchedules(
@@ -578,6 +635,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt.reconnectAttemptCount == 1 })
         XCTAssertEqual(mqtt.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
@@ -610,6 +668,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt5.reconnectAttemptCount == 1 })
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
         XCTAssertTrue(waitForReconnectSchedules(
@@ -624,6 +683,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt5.reconnectAttemptCount == 2 })
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 2)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 2)
         XCTAssertTrue(waitForReconnectSchedules(
@@ -692,6 +752,28 @@ final class AutoReconnectStateTests: XCTestCase {
         releaseEventLoop.signal()
         mqtt5.eventLoopQueue.sync {}
 
+        XCTAssertEqual(socket.connectCount, 0)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+    }
+
+    func testCocoaMQTT5WaitsForDisconnectCallbackBeforeImmediateReconnect() {
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-callback-order-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        let releaseCallback = DispatchSemaphore(value: 0)
+        delegateQueue.async { releaseCallback.wait() }
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 0
+        mqtt5.didDisconnect = { mqtt5, _ in mqtt5.autoReconnect = false }
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+        usleep(100_000)
+        XCTAssertEqual(socket.connectCount, 0)
+
+        releaseCallback.signal()
+        delegateQueue.sync {}
+        mqtt5.eventLoopQueue.sync {}
         XCTAssertEqual(socket.connectCount, 0)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
     }
@@ -816,6 +898,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt5.reconnectAttemptCount == 1 })
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
         XCTAssertTrue(waitForReconnectSchedules(
             on: delegateQueue,
@@ -951,8 +1034,12 @@ final class AutoReconnectStateTests: XCTestCase {
         let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
         XCTAssertFalse(mqtt5.isAutoReconnectPaused)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
-        XCTAssertEqual(delegate.reconnectSchedules, expectedSchedules)
-        XCTAssertEqual(closureSchedules, expectedSchedules)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: expectedSchedules,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
         XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
     }
@@ -986,6 +1073,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt5.reconnectAttemptCount == 1 })
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
         XCTAssertTrue(waitForReconnectSchedules(
@@ -1027,6 +1115,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
 
+        XCTAssertTrue(waitUntil { mqtt5.reconnectAttemptCount == 1 })
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 1)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })

--- a/CocoaMQTTTests/AutoReconnectStateTests.swift
+++ b/CocoaMQTTTests/AutoReconnectStateTests.swift
@@ -215,6 +215,7 @@ final class AutoReconnectStateTests: XCTestCase {
         }
 
         mqtt.socketDidDisconnect(socket, withError: nil)
+        delegateQueue.sync {}
 
         XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
@@ -224,6 +225,26 @@ final class AutoReconnectStateTests: XCTestCase {
             closureSchedules: { closureSchedules }
         )
         XCTAssertEqual(socket.connectCount, 0)
+    }
+
+    func testCocoaMQTTDisablingReconnectInvalidatesQueuedImmediateAttempt() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "reconnect-disable-immediate-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        let releaseEventLoop = DispatchSemaphore(value: 0)
+        mqtt.delegateQueue = delegateQueue
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 0
+        mqtt.didDisconnect = { mqtt, _ in mqtt.autoReconnect = false }
+        mqtt.eventLoopQueue.async { releaseEventLoop.wait() }
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        delegateQueue.sync {}
+        releaseEventLoop.signal()
+        mqtt.eventLoopQueue.sync {}
+
+        XCTAssertEqual(socket.connectCount, 0)
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
     }
 
     func testCocoaMQTTResumeAfterExpectedDisconnectDoesNotReconnect() {
@@ -433,8 +454,12 @@ final class AutoReconnectStateTests: XCTestCase {
         let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
         XCTAssertFalse(mqtt.isAutoReconnectPaused)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 1)
-        XCTAssertEqual(delegate.reconnectSchedules, expectedSchedules)
-        XCTAssertEqual(closureSchedules, expectedSchedules)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: expectedSchedules,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
         XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
     }
@@ -460,6 +485,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt.pauseAutoReconnect()
         mqtt.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(returnCode: .serverUnavailable))
+        delegateQueue.sync {}
 
         XCTAssertEqual(delegate.connectAcks, [.serverUnavailable])
         XCTAssertEqual(socket.disconnectCount, 1)
@@ -502,6 +528,7 @@ final class AutoReconnectStateTests: XCTestCase {
         }
 
         mqtt.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(returnCode: .serverUnavailable))
+        delegateQueue.sync {}
 
         XCTAssertEqual(delegate.connectAcks, [.serverUnavailable])
         XCTAssertEqual(closureAcks, [.serverUnavailable])
@@ -526,6 +553,8 @@ final class AutoReconnectStateTests: XCTestCase {
         let delegate = MQTTDelegateSpy()
         let clientID = "auth-refresh-reconnect-\(UUID().uuidString)"
         let mqtt = CocoaMQTT(clientID: clientID, socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
         mqtt.delegate = delegate
         mqtt.autoReconnect = true
         mqtt.autoReconnectTimeInterval = 1
@@ -539,6 +568,7 @@ final class AutoReconnectStateTests: XCTestCase {
         }
 
         mqtt.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(returnCode: .badUsernameOrPassword))
+        delegateQueue.sync {}
 
         XCTAssertEqual(delegate.connectAcks, [.badUsernameOrPassword])
         XCTAssertEqual(mqtt.username, "fresh-user")
@@ -634,6 +664,7 @@ final class AutoReconnectStateTests: XCTestCase {
         }
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
+        delegateQueue.sync {}
 
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
@@ -643,6 +674,26 @@ final class AutoReconnectStateTests: XCTestCase {
             closureSchedules: { closureSchedules }
         )
         XCTAssertEqual(socket.connectCount, 0)
+    }
+
+    func testCocoaMQTT5DisablingReconnectInvalidatesQueuedImmediateAttempt() {
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-disable-immediate-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        let releaseEventLoop = DispatchSemaphore(value: 0)
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 0
+        mqtt5.didDisconnect = { mqtt5, _ in mqtt5.autoReconnect = false }
+        mqtt5.eventLoopQueue.async { releaseEventLoop.wait() }
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+        delegateQueue.sync {}
+        releaseEventLoop.signal()
+        mqtt5.eventLoopQueue.sync {}
+
+        XCTAssertEqual(socket.connectCount, 0)
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
     }
 
     func testCocoaMQTT5ResumeAfterExpectedDisconnectDoesNotReconnect() {
@@ -852,8 +903,12 @@ final class AutoReconnectStateTests: XCTestCase {
         let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
         XCTAssertFalse(mqtt5.isAutoReconnectPaused)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 1)
-        XCTAssertEqual(delegate.reconnectSchedules, expectedSchedules)
-        XCTAssertEqual(closureSchedules, expectedSchedules)
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: expectedSchedules,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
         XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
     }
@@ -879,6 +934,7 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt5.pauseAutoReconnect()
         mqtt5.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(code: .serverBusy))
+        delegateQueue.sync {}
 
         XCTAssertEqual(delegate.connectAcks, [.serverBusy])
         XCTAssertEqual(socket.disconnectCount, 1)
@@ -921,6 +977,7 @@ final class AutoReconnectStateTests: XCTestCase {
         }
 
         mqtt5.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(code: .serverBusy))
+        delegateQueue.sync {}
 
         XCTAssertEqual(delegate.connectAcks, [.serverBusy])
         XCTAssertEqual(closureAcks, [.serverBusy])
@@ -945,6 +1002,8 @@ final class AutoReconnectStateTests: XCTestCase {
         let delegate = MQTT5DelegateSpy()
         let clientID = "auth-refresh-reconnect-5-\(UUID().uuidString)"
         let mqtt5 = CocoaMQTT5(clientID: clientID, socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
         mqtt5.delegate = delegate
         mqtt5.autoReconnect = true
         mqtt5.autoReconnectTimeInterval = 1
@@ -958,6 +1017,7 @@ final class AutoReconnectStateTests: XCTestCase {
         }
 
         mqtt5.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: FrameConnAck(code: .notAuthorized))
+        delegateQueue.sync {}
 
         XCTAssertEqual(delegate.connectAcks, [.notAuthorized])
         XCTAssertEqual(mqtt5.username, "fresh-user")

--- a/CocoaMQTTTests/ClientEventLoopTests.swift
+++ b/CocoaMQTTTests/ClientEventLoopTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import XCTest
+@testable import CocoaMQTT
+
+final class ClientEventLoopTests: XCTestCase {
+
+    private final class SocketSpy: CocoaMQTTSocketProtocol {
+        var enableSSL = false
+
+        private let lock = NSLock()
+        private var _delegateQueue: DispatchQueue?
+        var writeHandler: (() -> Void)?
+
+        var capturedDelegateQueue: DispatchQueue? {
+            lock.lock()
+            defer { lock.unlock() }
+            return _delegateQueue
+        }
+
+        func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
+            lock.lock()
+            _delegateQueue = delegateQueue
+            lock.unlock()
+        }
+
+        func connect(toHost host: String, onPort port: UInt16) throws {}
+        func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
+        func disconnect() {}
+        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
+        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
+            writeHandler?()
+        }
+    }
+
+    func testMQTT311SocketAndCallbacksUseSeparateQueues() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "event-loop-311", socket: socket)
+        let eventLoopKey = DispatchSpecificKey<String>()
+        let callbackKey = DispatchSpecificKey<String>()
+        let callbackQueue = DispatchQueue(label: "tests.event-loop.callback-311", attributes: .concurrent)
+        mqtt.eventLoopQueue.setSpecific(key: eventLoopKey, value: "event-loop")
+        callbackQueue.setSpecific(key: callbackKey, value: "callback")
+        mqtt.delegateQueue = callbackQueue
+
+        XCTAssertTrue(mqtt.connect())
+        XCTAssertTrue(socket.capturedDelegateQueue === mqtt.eventLoopQueue)
+        XCTAssertFalse(socket.capturedDelegateQueue === callbackQueue)
+
+        let callback = expectation(description: "PONG callback")
+        mqtt.didReceivePong = { _ in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: callbackKey), "callback")
+            XCTAssertNil(DispatchQueue.getSpecific(key: eventLoopKey))
+            callback.fulfill()
+        }
+        mqtt.eventLoopQueue.async {
+            mqtt.didReceive(
+                CocoaMQTTReader(socket: socket, delegate: nil),
+                pingresp: FramePingResp()
+            )
+        }
+
+        wait(for: [callback], timeout: 1)
+    }
+
+    func testMQTT5SocketAndCallbacksUseSeparateQueues() {
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "event-loop-5", socket: socket)
+        let eventLoopKey = DispatchSpecificKey<String>()
+        let callbackKey = DispatchSpecificKey<String>()
+        let callbackQueue = DispatchQueue(label: "tests.event-loop.callback-5", attributes: .concurrent)
+        mqtt5.eventLoopQueue.setSpecific(key: eventLoopKey, value: "event-loop")
+        callbackQueue.setSpecific(key: callbackKey, value: "callback")
+        mqtt5.delegateQueue = callbackQueue
+
+        XCTAssertTrue(mqtt5.connect())
+        XCTAssertTrue(socket.capturedDelegateQueue === mqtt5.eventLoopQueue)
+        XCTAssertFalse(socket.capturedDelegateQueue === callbackQueue)
+
+        let callback = expectation(description: "PONG callback")
+        mqtt5.didReceivePong = { _ in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: callbackKey), "callback")
+            XCTAssertNil(DispatchQueue.getSpecific(key: eventLoopKey))
+            callback.fulfill()
+        }
+        mqtt5.eventLoopQueue.async {
+            mqtt5.didReceive(
+                CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5),
+                pingresp: FramePingResp()
+            )
+        }
+
+        wait(for: [callback], timeout: 1)
+    }
+
+    func testCallbackQueueChangeDoesNotMoveAlreadySubmittedCallbacks() {
+        let mqtt = CocoaMQTT(clientID: "callback-queue-snapshot")
+        let firstQueue = DispatchQueue(label: "tests.event-loop.first-callback")
+        let secondQueue = DispatchQueue(label: "tests.event-loop.second-callback")
+        let queueKey = DispatchSpecificKey<String>()
+        let unblockFirstQueue = DispatchSemaphore(value: 0)
+        firstQueue.setSpecific(key: queueKey, value: "first")
+        secondQueue.setSpecific(key: queueKey, value: "second")
+
+        firstQueue.async {
+            unblockFirstQueue.wait()
+        }
+
+        let callbacks = expectation(description: "callbacks use event-time queue snapshots")
+        callbacks.expectedFulfillmentCount = 2
+        let lock = NSLock()
+        var observedQueues: [String] = []
+        mqtt.didReceivePong = { _ in
+            lock.lock()
+            observedQueues.append(DispatchQueue.getSpecific(key: queueKey) ?? "unknown")
+            lock.unlock()
+            callbacks.fulfill()
+        }
+
+        mqtt.delegateQueue = firstQueue
+        mqtt.didReceive(
+            CocoaMQTTReader(socket: CocoaMQTTSocket(), delegate: nil),
+            pingresp: FramePingResp()
+        )
+        mqtt.delegateQueue = secondQueue
+        mqtt.didReceive(
+            CocoaMQTTReader(socket: CocoaMQTTSocket(), delegate: nil),
+            pingresp: FramePingResp()
+        )
+        unblockFirstQueue.signal()
+
+        wait(for: [callbacks], timeout: 1)
+        XCTAssertEqual(Set(observedQueues), Set(["first", "second"]))
+    }
+
+    func testDeliveryWorkReturnsToMQTT311EventLoop() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "delivery-event-loop-311", socket: socket)
+        let eventLoopKey = DispatchSpecificKey<Bool>()
+        mqtt.eventLoopQueue.setSpecific(key: eventLoopKey, value: true)
+        let write = expectation(description: "delivery writes from event loop")
+        socket.writeHandler = {
+            XCTAssertEqual(DispatchQueue.getSpecific(key: eventLoopKey), true)
+            write.fulfill()
+        }
+
+        XCTAssertEqual(mqtt.publish("event/loop", withString: "payload", qos: .qos0), 0)
+
+        wait(for: [write], timeout: 1)
+    }
+
+    func testDeliveryWorkReturnsToMQTT5EventLoop() {
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "delivery-event-loop-5", socket: socket)
+        let eventLoopKey = DispatchSpecificKey<Bool>()
+        mqtt5.eventLoopQueue.setSpecific(key: eventLoopKey, value: true)
+        let write = expectation(description: "delivery writes from event loop")
+        socket.writeHandler = {
+            XCTAssertEqual(DispatchQueue.getSpecific(key: eventLoopKey), true)
+            write.fulfill()
+        }
+
+        XCTAssertEqual(
+            mqtt5.publish(
+                "event/loop",
+                withString: "payload",
+                qos: .qos0,
+                properties: MqttPublishProperties()
+            ),
+            0
+        )
+
+        wait(for: [write], timeout: 1)
+    }
+}

--- a/CocoaMQTTTests/ClientEventLoopTests.swift
+++ b/CocoaMQTTTests/ClientEventLoopTests.swift
@@ -4,10 +4,19 @@ import XCTest
 
 final class ClientEventLoopTests: XCTestCase {
 
+    private final class WeakBox<Value: AnyObject> {
+        weak var value: Value?
+
+        init(_ value: Value?) {
+            self.value = value
+        }
+    }
+
     private final class SocketSpy: CocoaMQTTSocketProtocol {
         var enableSSL = false
 
         private let lock = NSLock()
+        private weak var delegate: CocoaMQTTSocketDelegate?
         private var _delegateQueue: DispatchQueue?
         var writeHandler: (() -> Void)?
 
@@ -19,8 +28,16 @@ final class ClientEventLoopTests: XCTestCase {
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
             lock.lock()
+            delegate = theDelegate
             _delegateQueue = delegateQueue
             lock.unlock()
+        }
+
+        func emitConnectedIgnoringDelegateQueue() {
+            lock.lock()
+            let delegate = delegate
+            lock.unlock()
+            delegate?.socketConnected(self)
         }
 
         func connect(toHost host: String, onPort port: UInt16) throws {}
@@ -90,6 +107,76 @@ final class ClientEventLoopTests: XCTestCase {
         }
 
         wait(for: [callback], timeout: 1)
+    }
+
+    func testMQTT311CustomSocketCallbacksAreNormalizedOntoEventLoop() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "custom-socket-event-loop-311", socket: socket)
+        let eventLoopKey = DispatchSpecificKey<Bool>()
+        mqtt.eventLoopQueue.setSpecific(key: eventLoopKey, value: true)
+        let write = expectation(description: "CONNECT is written from event loop")
+        socket.writeHandler = {
+            XCTAssertEqual(DispatchQueue.getSpecific(key: eventLoopKey), true)
+            write.fulfill()
+        }
+
+        XCTAssertTrue(mqtt.connect())
+        DispatchQueue.global().async {
+            socket.emitConnectedIgnoringDelegateQueue()
+        }
+
+        wait(for: [write], timeout: 1)
+    }
+
+    func testMQTT5CustomSocketCallbacksAreNormalizedOntoEventLoop() {
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "custom-socket-event-loop-5", socket: socket)
+        let eventLoopKey = DispatchSpecificKey<Bool>()
+        mqtt5.eventLoopQueue.setSpecific(key: eventLoopKey, value: true)
+        let write = expectation(description: "CONNECT is written from event loop")
+        socket.writeHandler = {
+            XCTAssertEqual(DispatchQueue.getSpecific(key: eventLoopKey), true)
+            write.fulfill()
+        }
+
+        XCTAssertTrue(mqtt5.connect())
+        DispatchQueue.global().async {
+            socket.emitConnectedIgnoringDelegateQueue()
+        }
+
+        wait(for: [write], timeout: 1)
+    }
+
+    func testPendingCallbackDoesNotRetainMQTT311Client() {
+        let callbackQueue = DispatchQueue(label: "tests.event-loop.blocked-callback-311")
+        let releaseQueue = DispatchSemaphore(value: 0)
+        callbackQueue.async { releaseQueue.wait() }
+
+        var mqtt: CocoaMQTT? = CocoaMQTT(clientID: "callback-lifetime-311")
+        let weakMQTT = WeakBox(mqtt)
+        mqtt?.delegateQueue = callbackQueue
+        mqtt?.ping()
+        mqtt = nil
+
+        XCTAssertNil(weakMQTT.value)
+        releaseQueue.signal()
+        callbackQueue.sync {}
+    }
+
+    func testPendingCallbackDoesNotRetainMQTT5Client() {
+        let callbackQueue = DispatchQueue(label: "tests.event-loop.blocked-callback-5")
+        let releaseQueue = DispatchSemaphore(value: 0)
+        callbackQueue.async { releaseQueue.wait() }
+
+        var mqtt5: CocoaMQTT5? = CocoaMQTT5(clientID: "callback-lifetime-5")
+        let weakMQTT5 = WeakBox(mqtt5)
+        mqtt5?.delegateQueue = callbackQueue
+        mqtt5?.ping()
+        mqtt5 = nil
+
+        XCTAssertNil(weakMQTT5.value)
+        releaseQueue.signal()
+        callbackQueue.sync {}
     }
 
     func testCallbackQueueChangeDoesNotMoveAlreadySubmittedCallbacks() {

--- a/CocoaMQTTTests/CocoaMQTT5DisconnectReasonStateTests.swift
+++ b/CocoaMQTTTests/CocoaMQTT5DisconnectReasonStateTests.swift
@@ -4,6 +4,12 @@ import XCTest
 
 final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
 
+    private func installCallbackQueue(on mqtt5: CocoaMQTT5) -> DispatchQueue {
+        let queue = DispatchQueue(label: "tests.disconnect-reason.\(UUID().uuidString)")
+        mqtt5.delegateQueue = queue
+        return queue
+    }
+
     private final class SocketSpy: CocoaMQTTSocketProtocol {
         var enableSSL: Bool = false
         private(set) var disconnectCount = 0
@@ -61,6 +67,7 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "manual-disconnect-reason-\(UUID().uuidString)", socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         mqtt5.delegate = delegate
 
         mqtt5.disconnect()
@@ -70,6 +77,7 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
         XCTAssertTrue(socket.writes.contains { $0.first == FrameType.disconnect.rawValue })
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
+        callbackQueue.sync {}
 
         XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
         XCTAssertEqual(delegate.disconnectSnapshots[0].source, .local)
@@ -83,10 +91,12 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "manual-custom-disconnect-reason-\(UUID().uuidString)", socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         mqtt5.delegate = delegate
 
         mqtt5.disconnect(reasonCode: .disconnectWithWillMessage, userProperties: ["reason": "manual"])
         mqtt5.socketDidDisconnect(socket, withError: nil)
+        callbackQueue.sync {}
 
         XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
         XCTAssertEqual(delegate.disconnectSnapshots[0].source, .local)
@@ -98,10 +108,12 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "manual-disconnect-error-\(UUID().uuidString)", socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         mqtt5.delegate = delegate
 
         mqtt5.disconnect()
         mqtt5.socketDidDisconnect(socket, withError: CocoaMQTTError.writeTimeout)
+        callbackQueue.sync {}
 
         XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
         XCTAssertNil(delegate.disconnectSnapshots[0].source)
@@ -114,6 +126,7 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "remote-disconnect-reason-\(UUID().uuidString)", socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         let reader = CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5)
         let frame = FrameDisconnect(
             packetFixedHeaderType: FrameType.disconnect.rawValue,
@@ -126,6 +139,7 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
 
         mqtt5.didReceive(reader, disconnect: frame!)
         mqtt5.socketDidDisconnect(socket, withError: nil)
+        callbackQueue.sync {}
 
         XCTAssertEqual(delegate.receivedDisconnectReasonCodes, [.serverBusy])
         XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
@@ -140,6 +154,7 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "remote-disconnect-error-\(UUID().uuidString)", socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         let reader = CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5)
         let frame = FrameDisconnect(
             packetFixedHeaderType: FrameType.disconnect.rawValue,
@@ -152,6 +167,7 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
 
         mqtt5.didReceive(reader, disconnect: frame!)
         mqtt5.socketDidDisconnect(socket, withError: CocoaMQTTError.readTimeout)
+        callbackQueue.sync {}
 
         XCTAssertEqual(delegate.receivedDisconnectReasonCodes, [.serverBusy])
         XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
@@ -165,9 +181,11 @@ final class CocoaMQTT5DisconnectReasonStateTests: XCTestCase {
         let socket = SocketSpy()
         let delegate = DelegateSpy()
         let mqtt5 = CocoaMQTT5(clientID: "clean-close-no-reason-\(UUID().uuidString)", socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         mqtt5.delegate = delegate
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
+        callbackQueue.sync {}
 
         XCTAssertEqual(delegate.disconnectSnapshots.count, 1)
         XCTAssertNil(delegate.disconnectSnapshots[0].source)

--- a/CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift
+++ b/CocoaMQTTTests/CocoaMQTT5ReceiveMessageContentTypeTests.swift
@@ -4,6 +4,12 @@ import XCTest
 
 final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
 
+    private func installCallbackQueue(on mqtt5: CocoaMQTT5) -> DispatchQueue {
+        let queue = DispatchQueue(label: "tests.receive-message.\(UUID().uuidString)")
+        mqtt5.delegateQueue = queue
+        return queue
+    }
+
     private final class SocketSpy: CocoaMQTTSocketProtocol {
         var enableSSL: Bool = false
         var writes: [Data] = []
@@ -35,6 +41,7 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
 
     func testDidReceiveMessageMapsContentType() {
         let mqtt5 = CocoaMQTT5(clientID: "mq5-recv-content-type-\(UUID().uuidString)")
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         let reader = CocoaMQTTReader(socket: SocketSpy(), delegate: nil)
 
         var callbackMessageContentType: String?
@@ -54,6 +61,7 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
         }
 
         mqtt5.didReceive(reader, publish: publish)
+        callbackQueue.sync {}
 
         XCTAssertEqual(callbackPublishDataContentType, "application/json")
         XCTAssertEqual(callbackMessageContentType, "application/json")
@@ -61,6 +69,7 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
 
     func testDidReceiveMessageKeepsWillPropertiesUnsetForPublishProperties() {
         let mqtt5 = CocoaMQTT5(clientID: "mq5-recv-properties-\(UUID().uuidString)")
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         let reader = CocoaMQTTReader(socket: SocketSpy(), delegate: nil)
 
         var callbackMessage: CocoaMQTT5Message?
@@ -85,6 +94,7 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
         }
 
         mqtt5.didReceive(reader, publish: publish)
+        callbackQueue.sync {}
 
         XCTAssertEqual(callbackPublishData?.payloadFormatIndicator, .unspecified)
         XCTAssertEqual(callbackPublishData?.messageExpiryInterval, 60)
@@ -138,6 +148,7 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
 
     func testDidReceiveMessageWithContentTypeAndUnspecifiedPayloadFormatKeepsWillPropertiesUnset() {
         let mqtt5 = CocoaMQTT5(clientID: "mq5-recv-content-type-unspecified-\(UUID().uuidString)")
+        let callbackQueue = installCallbackQueue(on: mqtt5)
         let reader = CocoaMQTTReader(socket: SocketSpy(), delegate: nil)
 
         var callbackMessage: CocoaMQTT5Message?
@@ -169,6 +180,7 @@ final class CocoaMQTT5ReceiveMessageContentTypeTests: XCTestCase {
         }
 
         mqtt5.didReceive(reader, publish: publish)
+        callbackQueue.sync {}
 
         XCTAssertEqual(callbackPublishData?.payloadFormatIndicator, .unspecified)
         XCTAssertEqual(callbackPublishData?.messageExpiryInterval, 45)

--- a/CocoaMQTTTests/SendingMessageLifecycleTests.swift
+++ b/CocoaMQTTTests/SendingMessageLifecycleTests.swift
@@ -4,6 +4,18 @@ import XCTest
 
 final class SendingMessageLifecycleTests: XCTestCase {
 
+    private func installCallbackQueue(on mqtt: CocoaMQTT) -> DispatchQueue {
+        let queue = DispatchQueue(label: "tests.sending-callback.\(UUID().uuidString)")
+        mqtt.delegateQueue = queue
+        return queue
+    }
+
+    private func installCallbackQueue(on mqtt5: CocoaMQTT5) -> DispatchQueue {
+        let queue = DispatchQueue(label: "tests.sending-callback-5.\(UUID().uuidString)")
+        mqtt5.delegateQueue = queue
+        return queue
+    }
+
     private final class SocketSpy: CocoaMQTTSocketProtocol {
         var enableSSL = false
         var writes = [Data]()
@@ -283,6 +295,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         defer { clearStorage(clientID) }
         let socket = SocketSpy()
         let mqtt = CocoaMQTT5(clientID: clientID, socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt)
         establishSession(mqtt,
                          socket: socket,
                          cleanStart: true,
@@ -322,6 +335,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         let reader = CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5)
         mqtt.didReceive(reader, publish: first)
         mqtt.didReceive(reader, publish: second)
+        callbackQueue.sync {}
 
         XCTAssertEqual(receivedTopics, ["inbound/topic", "inbound/topic"])
     }
@@ -536,6 +550,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         defer { clearStorage(clientID) }
         let socket = SocketSpy()
         let mqtt = CocoaMQTT5(clientID: clientID, socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt)
         var delivered = [CocoaMQTT5Message]()
         mqtt.didReceiveMessage = { _, message, _, _ in delivered.append(message) }
         let reader = CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5)
@@ -547,6 +562,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
 
         mqtt.didReceive(reader, publish: publish)
         mqtt.didReceive(reader, publish: publish)
+        callbackQueue.sync {}
 
         XCTAssertEqual(delivered.count, 1)
         XCTAssertEqual(
@@ -574,6 +590,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
 
         let socket = SocketSpy()
         let mqtt = CocoaMQTT5(clientID: clientID, socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt)
         establishSession(
             mqtt,
             socket: socket,
@@ -592,6 +609,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
             CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5),
             publish: try mqtt5QoS2Publish(identifier: 43)
         )
+        callbackQueue.sync {}
 
         XCTAssertEqual(deliveredIdentifiers, [43])
         XCTAssertEqual(socket.writes.filter { $0.first == FrameType.pubrec.rawValue }.count, 1)
@@ -655,6 +673,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         defer { clearStorage(clientID) }
         let socket = SocketSpy()
         let mqtt = CocoaMQTT(clientID: clientID, socket: socket)
+        let callbackQueue = installCallbackQueue(on: mqtt)
         var deliveryCount = 0
         mqtt.didReceiveMessage = { _, _, _ in deliveryCount += 1 }
         let publish = try XCTUnwrap(FramePublish(
@@ -666,6 +685,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
 
         mqtt.didReceive(reader, publish: publish)
         mqtt.didReceive(reader, publish: publish)
+        callbackQueue.sync {}
 
         XCTAssertEqual(deliveryCount, 1)
         XCTAssertEqual(socket.writes.filter { $0.first == FrameType.pubrec.rawValue }.count, 2)
@@ -838,6 +858,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
             CocoaMQTT5Message(topic: "t/2", payload: [2], qos: .qos1),
             properties: MqttPublishProperties()
         )
+        mqtt.t_waitUntilDeliverIdle()
         queue.sync {}
         XCTAssertEqual(socket.writes.filter { $0.first.map { $0 & 0xf0 } == FrameType.publish.rawValue }.count, 1)
 
@@ -845,6 +866,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
             CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5),
             puback: FramePubAck(msgid: UInt16(first), reasonCode: .success)
         )
+        mqtt.t_waitUntilDeliverIdle()
         queue.sync {}
         XCTAssertEqual(socket.writes.filter { $0.first.map { $0 & 0xf0 } == FrameType.publish.rawValue }.count, 2)
     }
@@ -1020,6 +1042,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         socket.writeTags.removeAll()
 
         let packetIdentifier = mqtt.publish(CocoaMQTTMessage(topic: "t/new", payload: [1], qos: .qos1))
+        mqtt.t_waitUntilDeliverIdle()
         queue.sync {}
         XCTAssertTrue(socket.writes.isEmpty)
 
@@ -1032,6 +1055,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         if let connack = connack {
             mqtt.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: connack)
         }
+        mqtt.t_waitUntilDeliverIdle()
         queue.sync {}
 
         XCTAssertGreaterThan(packetIdentifier, 0)
@@ -1052,6 +1076,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         let packetIdentifier = mqtt.publish(
             CocoaMQTTMessage(topic: "t/after-disconnect", payload: [1], qos: .qos1)
         )
+        mqtt.t_waitUntilDeliverIdle()
         queue.sync {}
         XCTAssertGreaterThan(packetIdentifier, 0)
         XCTAssertTrue(socket.writes.isEmpty)
@@ -1071,6 +1096,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         if let connack = connack {
             mqtt.didReceive(CocoaMQTTReader(socket: socket, delegate: nil), connack: connack)
         }
+        mqtt.t_waitUntilDeliverIdle()
         queue.sync {}
 
         XCTAssertTrue(socket.writeTags.contains(packetIdentifier))
@@ -1173,6 +1199,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
             mqtt.didReceive(CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5),
                             connack: connack)
         }
+        mqtt.t_waitUntilDeliverIdle()
     }
 
     private func mqtt5QoS2Publish(identifier: UInt16) throws -> FramePublish {

--- a/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
+++ b/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
@@ -195,6 +195,24 @@ final class ThreadSafetyRegressionTests: XCTestCase {
         XCTAssertTrue([.connecting, .connected, .disconnected].contains(mqtt5.connState))
     }
 
+    func testCocoaMQTT311ConnStateConcurrentAccess() {
+        let mqtt = CocoaMQTT(clientID: "thread-safe-connstate-311-\(UUID().uuidString)")
+        let queue = DispatchQueue(label: "tests.threadsafe.connstate-311", attributes: .concurrent)
+        let group = DispatchGroup()
+
+        for idx in 0..<300 {
+            group.enter()
+            queue.async {
+                mqtt.connState = (idx % 2 == 0) ? .connecting : .connected
+                _ = mqtt.connState
+                group.leave()
+            }
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 10), .success)
+        XCTAssertTrue([.connecting, .connected].contains(mqtt.connState))
+    }
+
     func testCocoaMQTT5ConnStateCallbacksPreserveWrittenStates() {
         let mqtt5 = CocoaMQTT5(clientID: "connstate-callbacks-\(UUID().uuidString)")
         let callbackQueue = DispatchQueue(label: "tests.threadsafe.connstate-callbacks")

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -571,7 +571,6 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         markStoredPacketIdentifiersInUse()
         deliver.beginConnection()
         clientStateLock.unlock()
-        socketDelegateProxy.delegate = self
         socket.setDelegate(socketDelegateProxy, delegateQueue: eventLoopQueue)
         reader = CocoaMQTTReader(
             socket: socket,

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -175,14 +175,34 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Delegate Executed queue. Default is `DispatchQueue.main`
     ///
-    /// The delegate/closure callback function will be committed asynchronously to it
-    public var delegateQueue = DispatchQueue.main
+    /// The delegate/closure callback function will be committed asynchronously to it.
+    /// Changing the queue affects callbacks emitted after the assignment; callbacks
+    /// already submitted remain on the queue captured when their event occurred.
+    public var delegateQueue: DispatchQueue {
+        get {
+            delegateQueueLock.lock()
+            defer { delegateQueueLock.unlock() }
+            return _delegateQueue
+        }
+        set {
+            delegateQueueLock.lock()
+            _delegateQueue = newValue
+            delegateQueueLock.unlock()
+        }
+    }
+    private let delegateQueueLock = NSLock()
+    private var _delegateQueue = DispatchQueue.main
+
+    /// Owns ordered socket, reader, timer, and delivery events. Application code
+    /// cannot replace this queue through `delegateQueue`.
+    let eventLoopQueue: DispatchQueue
 
     public var connState = CocoaMQTTConnState.disconnected {
         didSet {
+            let state = connState
             __delegate_queue {
-                self.delegate?.mqtt?(self, didStateChangeTo: self.connState)
-                self.didChangeState(self, self.connState)
+                self.delegate?.mqtt?(self, didStateChangeTo: state)
+                self.didChangeState(self, state)
             }
         }
     }
@@ -221,7 +241,20 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     public var packetReadTimeout: TimeInterval = CocoaMQTTReader.defaultPacketReadTimeout
 
     /// Enable auto-reconnect mechanism
-    public var autoReconnect = false
+    public var autoReconnect: Bool {
+        get {
+            autoReconnectLock.lock()
+            defer { autoReconnectLock.unlock() }
+            return _autoReconnect
+        }
+        set {
+            autoReconnectLock.lock()
+            _autoReconnect = newValue
+            autoReconnectLock.unlock()
+            if !newValue { resetAutoReconnectState() }
+        }
+    }
+    private var _autoReconnect = false
 
     /// Reconnect time interval
     ///
@@ -259,6 +292,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     private var isAutoReconnectAttemptScheduled = false
     private var hasPausedAutoReconnectAttempt = false
     private var hasPendingAutoReconnectAttempt = false
+    private var autoReconnectGeneration: UInt64 = 0
     // Tracks the window after requesting an unexpected socket close and before socketDidDisconnect cleans it up.
     private var pendingSocketDisconnectReconnectAttemptCount: UInt?
     private var shouldResumeAutoReconnectAfterPendingDisconnect = false
@@ -345,6 +379,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         self.host = host
         self.port = port
         self.socket = socket
+        self.eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT.event-loop.\(UUID().uuidString)")
         super.init()
         deliver.delegate = self
     }
@@ -500,7 +535,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         markStoredPacketIdentifiersInUse()
         deliver.beginConnection()
         clientStateLock.unlock()
-        socket.setDelegate(self, delegateQueue: delegateQueue)
+        socket.setDelegate(self, delegateQueue: eventLoopQueue)
         reader = CocoaMQTTReader(
             socket: socket,
             delegate: self,
@@ -514,7 +549,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
                 try socket.connect(toHost: self.host, onPort: self.port)
             }
 
-            delegateQueue.async { [weak self] in
+            eventLoopQueue.async { [weak self] in
                 guard let self = self else { return }
                 self.connState = .connecting
             }
@@ -558,6 +593,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         }
         shouldResumeAutoReconnectAfterPendingDisconnect = false
         autoReconnTimer = nil
+        autoReconnectGeneration &+= 1
         autoReconnectLock.unlock()
     }
 
@@ -574,7 +610,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
         _isAutoReconnectPaused = false
 
-        guard autoReconnect, connState == .disconnected else {
+        guard _autoReconnect, connState == .disconnected else {
             hasPausedAutoReconnectAttempt = false
             hasPendingAutoReconnectAttempt = false
             shouldResumeAutoReconnectAfterPendingDisconnect = false
@@ -788,8 +824,10 @@ extension CocoaMQTT: CocoaMQTTDeliverProtocol {
             send(publish, tag: Int(msgid))
 
             if let message = message {
-                self.delegate?.mqtt(self, didPublishMessage: message, id: msgid)
-                self.didPublishMessage(self, message, msgid)
+                __delegate_queue {
+                    self.delegate?.mqtt(self, didPublishMessage: message, id: msgid)
+                    self.didPublishMessage(self, message, msgid)
+                }
             }
             if publish.qos == .qos0 {
                 sendingMessages.removeValue(forKey: deliveryToken)
@@ -804,7 +842,8 @@ extension CocoaMQTT: CocoaMQTTDeliverProtocol {
 extension CocoaMQTT {
 
     func __delegate_queue(_ fun: @escaping () -> Void) {
-        delegateQueue.async { [weak self] in
+        let callbackQueue = delegateQueue
+        callbackQueue.async { [weak self] in
             guard self != nil else { return }
             fun()
         }
@@ -833,34 +872,49 @@ extension CocoaMQTT {
         hasPendingAutoReconnectAttempt = false
         pendingSocketDisconnectReconnectAttemptCount = nil
         shouldResumeAutoReconnectAfterPendingDisconnect = false
+        autoReconnectGeneration &+= 1
         autoReconnectLock.unlock()
     }
 
-    private func notifyAutoReconnectScheduled(_ schedule: (attemptCount: UInt, interval: UInt16)) {
+    private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
         __delegate_queue {
+            self.autoReconnectLock.lock()
+            let isCurrent = self._autoReconnect && self.autoReconnectGeneration == schedule.generation
+            self.autoReconnectLock.unlock()
+            guard isCurrent else { return }
             self.delegate?.mqtt?(self, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
             self.didScheduleReconnect(self, schedule.attemptCount, schedule.interval)
         }
     }
 
-    private func scheduleAutoReconnectAttemptLocked(after interval: UInt16? = nil) -> (attemptCount: UInt, interval: UInt16) {
+    private func scheduleAutoReconnectAttemptLocked(after interval: UInt16? = nil) -> CocoaMQTTAutoReconnectSchedule {
         let delay = interval ?? reconnectTimeInterval
 
         printInfo("Try reconnect to server after \(delay)s")
         isAutoReconnectAttemptScheduled = true
+        autoReconnectGeneration &+= 1
+        let generation = autoReconnectGeneration
         autoReconnTimer = CocoaMQTTTimer.after(Double(delay), name: "autoReconnTimer", { [weak self] in
-            guard let self = self, self.prepareScheduledAutoReconnectFire() else { return }
-            _ = self.connect()
+            self?.eventLoopQueue.async { [weak self] in
+                guard let self = self,
+                      self.prepareScheduledAutoReconnectFire(generation: generation) else { return }
+                _ = self.connect()
+            }
         })
 
-        return (reconnectAttemptCount, delay)
+        return CocoaMQTTAutoReconnectSchedule(
+            attemptCount: reconnectAttemptCount,
+            interval: delay,
+            generation: generation
+        )
     }
 
-    private func prepareScheduledAutoReconnectFire() -> Bool {
+    private func prepareScheduledAutoReconnectFire(generation: UInt64) -> Bool {
         autoReconnectLock.lock()
         defer { autoReconnectLock.unlock() }
 
-        guard !_isAutoReconnectPaused else {
+        guard autoReconnectGeneration == generation else { return false }
+        guard _autoReconnect, !_isAutoReconnectPaused else {
             isAutoReconnectAttemptScheduled = false
             return false
         }
@@ -887,14 +941,18 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
 
         printDebug("Call the SSL/TLS manually validating function")
 
-        delegate?.mqtt?(self, didReceive: trust, completionHandler: completionHandler)
-        didReceiveTrust(self, trust, completionHandler)
+        __delegate_queue {
+            self.delegate?.mqtt?(self, didReceive: trust, completionHandler: completionHandler)
+            self.didReceiveTrust(self, trust, completionHandler)
+        }
     }
 
     public func socketUrlSession(_ socket: CocoaMQTTSocketProtocol, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
 
-        delegate?.mqttUrlSession?(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
+        __delegate_queue {
+            self.delegate?.mqttUrlSession?(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
+        }
     }
 
     // ?
@@ -947,12 +1005,14 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         connState = .disconnected
         autoReconnectLock.lock()
         let reconnectAttemptCountBeforeCallbacks = pendingSocketDisconnectReconnectAttemptCount ?? reconnectAttemptCount
-        if !is_internal_disconnected && autoReconnect {
+        if !is_internal_disconnected && _autoReconnect {
             pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCountBeforeCallbacks
         }
         autoReconnectLock.unlock()
-        delegate?.mqttDidDisconnect(self, withError: err)
-        didDisconnect(self, err)
+        __delegate_queue {
+            self.delegate?.mqttDidDisconnect(self, withError: err)
+            self.didDisconnect(self, err)
+        }
 
         guard !is_internal_disconnected else {
             is_internal_disconnected = false
@@ -1012,7 +1072,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
             aliveTimer = CocoaMQTTTimer.every(interval, name: "aliveTimer") { [weak self] in
                 guard let self = self else { return }
-                self.delegateQueue.async {
+                self.eventLoopQueue.async {
                     guard self.connState == .connected else {
                         self.aliveTimer = nil
                         return
@@ -1057,8 +1117,11 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
             internal_disconnect()
         }
 
-        delegate?.mqtt(self, didConnectAck: connack.returnCode ?? CocoaMQTTConnAck.serverUnavailable)
-        didConnectAck(self, connack.returnCode ?? CocoaMQTTConnAck.serverUnavailable)
+        let returnCode = connack.returnCode ?? CocoaMQTTConnAck.serverUnavailable
+        __delegate_queue {
+            self.delegate?.mqtt(self, didConnectAck: returnCode)
+            self.didConnectAck(self, returnCode)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, publish: FramePublish) {
@@ -1078,8 +1141,11 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
         if shouldDeliver {
             printInfo("Received message: \(message)")
-            delegate?.mqtt(self, didReceiveMessage: message, id: publish.msgid)
-            didReceiveMessage(self, message, publish.msgid)
+            let messageID = publish.msgid
+            __delegate_queue {
+                self.delegate?.mqtt(self, didReceiveMessage: message, id: messageID)
+                self.didReceiveMessage(self, message, messageID)
+            }
         }
 
         if message.qos == .qos1 {
@@ -1099,8 +1165,11 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         }
         clientStateLock.unlock()
 
-        delegate?.mqtt(self, didPublishAck: puback.msgid)
-        didPublishAck(self, puback.msgid)
+        let messageID = puback.msgid
+        __delegate_queue {
+            self.delegate?.mqtt(self, didPublishAck: messageID)
+            self.didPublishAck(self, messageID)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, pubrec: FramePubRec) {
@@ -1131,8 +1200,11 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         }
         clientStateLock.unlock()
 
-        delegate?.mqtt?(self, didPublishComplete: pubcomp.msgid)
-        didCompletePublish(self, pubcomp.msgid)
+        let messageID = pubcomp.msgid
+        __delegate_queue {
+            self.delegate?.mqtt?(self, didPublishComplete: messageID)
+            self.didCompletePublish(self, messageID)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, suback: FrameSubAck) {
@@ -1163,8 +1235,10 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
             }
         }
 
-        delegate?.mqtt(self, didSubscribeTopics: success, failed: failed)
-        didSubscribeTopics(self, success, failed)
+        __delegate_queue {
+            self.delegate?.mqtt(self, didSubscribeTopics: success, failed: failed)
+            self.didSubscribeTopics(self, success, failed)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, unsuback: FrameUnsubAck) {
@@ -1182,15 +1256,19 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         for t in topics {
             subscriptionsStorage.removeValue(forKey: t)
         }
-        delegate?.mqtt(self, didUnsubscribeTopics: topics)
-        didUnsubscribeTopics(self, topics)
+        __delegate_queue {
+            self.delegate?.mqtt(self, didUnsubscribeTopics: topics)
+            self.didUnsubscribeTopics(self, topics)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
 
-        delegate?.mqttDidReceivePong(self)
-        didReceivePong(self)
+        __delegate_queue {
+            self.delegate?.mqttDidReceivePong(self)
+            self.didReceivePong(self)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, disconnect: FrameDisconnect) {
@@ -1212,5 +1290,10 @@ extension CocoaMQTT {
 
     func t_reservedPacketIdentifierCount() -> Int {
         packetIdentifiers.reservedCount
+    }
+
+    func t_waitUntilDeliverIdle() {
+        deliver.t_waitUntilIdle()
+        eventLoopQueue.sync {}
     }
 }

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -196,16 +196,26 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Owns ordered socket, reader, timer, and delivery events. Application code
     /// cannot replace this queue through `delegateQueue`.
     let eventLoopQueue: DispatchQueue
+    private var socketDelegateProxy: CocoaMQTTSocketDelegateProxy!
 
-    public var connState = CocoaMQTTConnState.disconnected {
-        didSet {
-            let state = connState
-            __delegate_queue {
-                self.delegate?.mqtt?(self, didStateChangeTo: state)
-                self.didChangeState(self, state)
+    public var connState: CocoaMQTTConnState {
+        get {
+            connStateLock.lock()
+            defer { connStateLock.unlock() }
+            return _connState
+        }
+        set {
+            connStateLock.lock()
+            _connState = newValue
+            connStateLock.unlock()
+            __delegate_queue { mqtt in
+                mqtt.delegate?.mqtt?(mqtt, didStateChangeTo: newValue)
+                mqtt.didChangeState(mqtt, newValue)
             }
         }
     }
+    private let connStateLock = NSLock()
+    private var _connState = CocoaMQTTConnState.disconnected
 
     // deliver
     private var deliver = CocoaMQTTDeliver()
@@ -272,12 +282,36 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     ///
     /// This value is advanced for the next reconnect attempt while auto-reconnect is active,
     /// and resets to `0` when auto-reconnect is inactive.
-    public private(set) var reconnectTimeInterval: UInt16 = 0
+    public private(set) var reconnectTimeInterval: UInt16 {
+        get {
+            autoReconnectLock.lock()
+            defer { autoReconnectLock.unlock() }
+            return _reconnectTimeInterval
+        }
+        set {
+            autoReconnectLock.lock()
+            _reconnectTimeInterval = newValue
+            autoReconnectLock.unlock()
+        }
+    }
+    private var _reconnectTimeInterval: UInt16 = 0
 
     /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.
     ///
     /// The value resets to `0` after a successful connection or expected disconnect.
-    public private(set) var reconnectAttemptCount: UInt = 0
+    public private(set) var reconnectAttemptCount: UInt {
+        get {
+            autoReconnectLock.lock()
+            defer { autoReconnectLock.unlock() }
+            return _reconnectAttemptCount
+        }
+        set {
+            autoReconnectLock.lock()
+            _reconnectAttemptCount = newValue
+            autoReconnectLock.unlock()
+        }
+    }
+    private var _reconnectAttemptCount: UInt = 0
 
     /// Whether auto-reconnect is currently paused by the application.
     public var isAutoReconnectPaused: Bool {
@@ -286,7 +320,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         return _isAutoReconnectPaused
     }
 
-    private let autoReconnectLock = NSLock()
+    private let autoReconnectLock = NSRecursiveLock()
     private var _isAutoReconnectPaused = false
     private var autoReconnTimer: CocoaMQTTTimer?
     private var isAutoReconnectAttemptScheduled = false
@@ -381,6 +415,8 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         self.socket = socket
         self.eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT.event-loop.\(UUID().uuidString)")
         super.init()
+        socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
+        socketDelegateProxy.delegate = self
         deliver.delegate = self
     }
 
@@ -535,7 +571,8 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         markStoredPacketIdentifiersInUse()
         deliver.beginConnection()
         clientStateLock.unlock()
-        socket.setDelegate(self, delegateQueue: eventLoopQueue)
+        socketDelegateProxy.delegate = self
+        socket.setDelegate(socketDelegateProxy, delegateQueue: eventLoopQueue)
         reader = CocoaMQTTReader(
             socket: socket,
             delegate: self,
@@ -658,9 +695,9 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         printDebug("ping")
         send(FramePingReq(), tag: -0xC0)
 
-        __delegate_queue {
-            self.delegate?.mqttDidPing(self)
-            self.didPing(self)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqttDidPing(mqtt)
+            mqtt.didPing(mqtt)
         }
     }
 
@@ -824,9 +861,9 @@ extension CocoaMQTT: CocoaMQTTDeliverProtocol {
             send(publish, tag: Int(msgid))
 
             if let message = message {
-                __delegate_queue {
-                    self.delegate?.mqtt(self, didPublishMessage: message, id: msgid)
-                    self.didPublishMessage(self, message, msgid)
+                __delegate_queue { mqtt in
+                    mqtt.delegate?.mqtt(mqtt, didPublishMessage: message, id: msgid)
+                    mqtt.didPublishMessage(mqtt, message, msgid)
                 }
             }
             if publish.qos == .qos0 {
@@ -841,11 +878,19 @@ extension CocoaMQTT: CocoaMQTTDeliverProtocol {
 
 extension CocoaMQTT {
 
-    func __delegate_queue(_ fun: @escaping () -> Void) {
+    func __delegate_queue(
+        _ fun: @escaping (CocoaMQTT) -> Void,
+        completionOnEventLoop: ((CocoaMQTT) -> Void)? = nil
+    ) {
         let callbackQueue = delegateQueue
         callbackQueue.async { [weak self] in
-            guard self != nil else { return }
-            fun()
+            guard let self = self else { return }
+            fun(self)
+            guard let completionOnEventLoop = completionOnEventLoop else { return }
+            self.eventLoopQueue.async { [weak self] in
+                guard let self = self else { return }
+                completionOnEventLoop(self)
+            }
         }
     }
 
@@ -877,13 +922,13 @@ extension CocoaMQTT {
     }
 
     private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
-        __delegate_queue {
-            self.autoReconnectLock.lock()
-            let isCurrent = self._autoReconnect && self.autoReconnectGeneration == schedule.generation
-            self.autoReconnectLock.unlock()
+        __delegate_queue { mqtt in
+            mqtt.autoReconnectLock.lock()
+            let isCurrent = mqtt._autoReconnect && mqtt.autoReconnectGeneration == schedule.generation
+            mqtt.autoReconnectLock.unlock()
             guard isCurrent else { return }
-            self.delegate?.mqtt?(self, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
-            self.didScheduleReconnect(self, schedule.attemptCount, schedule.interval)
+            mqtt.delegate?.mqtt?(mqtt, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
+            mqtt.didScheduleReconnect(mqtt, schedule.attemptCount, schedule.interval)
         }
     }
 
@@ -941,17 +986,17 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
 
         printDebug("Call the SSL/TLS manually validating function")
 
-        __delegate_queue {
-            self.delegate?.mqtt?(self, didReceive: trust, completionHandler: completionHandler)
-            self.didReceiveTrust(self, trust, completionHandler)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqtt?(mqtt, didReceive: trust, completionHandler: completionHandler)
+            mqtt.didReceiveTrust(mqtt, trust, completionHandler)
         }
     }
 
     public func socketUrlSession(_ socket: CocoaMQTTSocketProtocol, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
 
-        __delegate_queue {
-            self.delegate?.mqttUrlSession?(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqttUrlSession?(mqtt, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
         }
     }
 
@@ -1009,11 +1054,15 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
             pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCountBeforeCallbacks
         }
         autoReconnectLock.unlock()
-        __delegate_queue {
-            self.delegate?.mqttDidDisconnect(self, withError: err)
-            self.didDisconnect(self, err)
-        }
+        __delegate_queue({ mqtt in
+            mqtt.delegate?.mqttDidDisconnect(mqtt, withError: err)
+            mqtt.didDisconnect(mqtt, err)
+        }, completionOnEventLoop: { mqtt in
+            mqtt.continueAfterDisconnectCallbacks(reconnectAttemptCountBeforeCallbacks)
+        })
+    }
 
+    private func continueAfterDisconnectCallbacks(_ reconnectAttemptCountBeforeCallbacks: UInt) {
         guard !is_internal_disconnected else {
             is_internal_disconnected = false
             return
@@ -1118,9 +1167,9 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         }
 
         let returnCode = connack.returnCode ?? CocoaMQTTConnAck.serverUnavailable
-        __delegate_queue {
-            self.delegate?.mqtt(self, didConnectAck: returnCode)
-            self.didConnectAck(self, returnCode)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqtt(mqtt, didConnectAck: returnCode)
+            mqtt.didConnectAck(mqtt, returnCode)
         }
     }
 
@@ -1142,9 +1191,9 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         if shouldDeliver {
             printInfo("Received message: \(message)")
             let messageID = publish.msgid
-            __delegate_queue {
-                self.delegate?.mqtt(self, didReceiveMessage: message, id: messageID)
-                self.didReceiveMessage(self, message, messageID)
+            __delegate_queue { mqtt in
+                mqtt.delegate?.mqtt(mqtt, didReceiveMessage: message, id: messageID)
+                mqtt.didReceiveMessage(mqtt, message, messageID)
             }
         }
 
@@ -1166,9 +1215,9 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         clientStateLock.unlock()
 
         let messageID = puback.msgid
-        __delegate_queue {
-            self.delegate?.mqtt(self, didPublishAck: messageID)
-            self.didPublishAck(self, messageID)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqtt(mqtt, didPublishAck: messageID)
+            mqtt.didPublishAck(mqtt, messageID)
         }
     }
 
@@ -1201,9 +1250,9 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         clientStateLock.unlock()
 
         let messageID = pubcomp.msgid
-        __delegate_queue {
-            self.delegate?.mqtt?(self, didPublishComplete: messageID)
-            self.didCompletePublish(self, messageID)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqtt?(mqtt, didPublishComplete: messageID)
+            mqtt.didCompletePublish(mqtt, messageID)
         }
     }
 
@@ -1235,9 +1284,9 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
             }
         }
 
-        __delegate_queue {
-            self.delegate?.mqtt(self, didSubscribeTopics: success, failed: failed)
-            self.didSubscribeTopics(self, success, failed)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqtt(mqtt, didSubscribeTopics: success, failed: failed)
+            mqtt.didSubscribeTopics(mqtt, success, failed)
         }
     }
 
@@ -1256,18 +1305,18 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         for t in topics {
             subscriptionsStorage.removeValue(forKey: t)
         }
-        __delegate_queue {
-            self.delegate?.mqtt(self, didUnsubscribeTopics: topics)
-            self.didUnsubscribeTopics(self, topics)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqtt(mqtt, didUnsubscribeTopics: topics)
+            mqtt.didUnsubscribeTopics(mqtt, topics)
         }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
 
-        __delegate_queue {
-            self.delegate?.mqttDidReceivePong(self)
-            self.didReceivePong(self)
+        __delegate_queue { mqtt in
+            mqtt.delegate?.mqttDidReceivePong(mqtt)
+            mqtt.didReceivePong(mqtt)
         }
     }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -205,6 +205,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Owns ordered socket, reader, timer, and delivery events. Application code
     /// cannot replace this queue through `delegateQueue`.
     let eventLoopQueue: DispatchQueue
+    private var socketDelegateProxy: CocoaMQTTSocketDelegateProxy!
 
     @ConcurrentAtomic(wrappedValue: CocoaMQTTConnState.disconnected, label: "CocoaMQTT5.connState")
     public var connState
@@ -280,12 +281,36 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     ///
     /// This value is advanced for the next reconnect attempt while auto-reconnect is active,
     /// and resets to `0` when auto-reconnect is inactive.
-    public private(set) var reconnectTimeInterval: UInt16 = 0
+    public private(set) var reconnectTimeInterval: UInt16 {
+        get {
+            autoReconnectLock.lock()
+            defer { autoReconnectLock.unlock() }
+            return _reconnectTimeInterval
+        }
+        set {
+            autoReconnectLock.lock()
+            _reconnectTimeInterval = newValue
+            autoReconnectLock.unlock()
+        }
+    }
+    private var _reconnectTimeInterval: UInt16 = 0
 
     /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.
     ///
     /// The value resets to `0` after a successful connection or expected disconnect.
-    public private(set) var reconnectAttemptCount: UInt = 0
+    public private(set) var reconnectAttemptCount: UInt {
+        get {
+            autoReconnectLock.lock()
+            defer { autoReconnectLock.unlock() }
+            return _reconnectAttemptCount
+        }
+        set {
+            autoReconnectLock.lock()
+            _reconnectAttemptCount = newValue
+            autoReconnectLock.unlock()
+        }
+    }
+    private var _reconnectAttemptCount: UInt = 0
 
     /// Whether auto-reconnect is currently paused by the application.
     public var isAutoReconnectPaused: Bool {
@@ -294,7 +319,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         return _isAutoReconnectPaused
     }
 
-    private let autoReconnectLock = NSLock()
+    private let autoReconnectLock = NSRecursiveLock()
     private var _isAutoReconnectPaused = false
     private var autoReconnTimer: CocoaMQTTTimer?
     private var isAutoReconnectAttemptScheduled = false
@@ -417,11 +442,13 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         self.socket = socket
         self.eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT5.event-loop.\(UUID().uuidString)")
         super.init()
+        socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
+        socketDelegateProxy.delegate = self
         $connState.setMutationObserver { [weak self] state in
             guard let self = self else { return }
-            self.__delegate_queue {
-                self.delegate?.mqtt5?(self, didStateChangeTo: state)
-                self.didChangeState(self, state)
+            self.__delegate_queue { mqtt5 in
+                mqtt5.delegate?.mqtt5?(mqtt5, didStateChangeTo: state)
+                mqtt5.didChangeState(mqtt5, state)
             }
         }
         configureSessionExpiryController(for: clientID)
@@ -655,7 +682,8 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         clientStateLock.unlock()
         resetDisconnectReasonState()
         sessionExpiryController?.prepareStoredSessionForConnect()
-        socket.setDelegate(self, delegateQueue: eventLoopQueue)
+        socketDelegateProxy.delegate = self
+        socket.setDelegate(socketDelegateProxy, delegateQueue: eventLoopQueue)
         reader = CocoaMQTTReader(
             socket: socket,
             delegate: self,
@@ -803,9 +831,9 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
             return
         }
 
-        __delegate_queue {
-            self.delegate?.mqtt5DidPing(self)
-            self.didPing(self)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5DidPing(mqtt5)
+            mqtt5.didPing(mqtt5)
         }
     }
 
@@ -1095,9 +1123,9 @@ extension CocoaMQTT5: CocoaMQTTDeliverProtocol {
             }
 
             if let message = message {
-                __delegate_queue {
-                    self.delegate?.mqtt5(self, didPublishMessage: message, id: msgid)
-                    self.didPublishMessage(self, message, msgid)
+                __delegate_queue { mqtt5 in
+                    mqtt5.delegate?.mqtt5(mqtt5, didPublishMessage: message, id: msgid)
+                    mqtt5.didPublishMessage(mqtt5, message, msgid)
                 }
             }
             if publish.qos == .qos0 {
@@ -1114,11 +1142,19 @@ extension CocoaMQTT5: CocoaMQTTDeliverProtocol {
 
 extension CocoaMQTT5 {
 
-    func __delegate_queue(_ fun: @escaping () -> Void) {
+    func __delegate_queue(
+        _ fun: @escaping (CocoaMQTT5) -> Void,
+        completionOnEventLoop: ((CocoaMQTT5) -> Void)? = nil
+    ) {
         let callbackQueue = delegateQueue
         callbackQueue.async { [weak self] in
-            guard self != nil else { return }
-            fun()
+            guard let self = self else { return }
+            fun(self)
+            guard let completionOnEventLoop = completionOnEventLoop else { return }
+            self.eventLoopQueue.async { [weak self] in
+                guard let self = self else { return }
+                completionOnEventLoop(self)
+            }
         }
     }
 
@@ -1150,13 +1186,13 @@ extension CocoaMQTT5 {
     }
 
     private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
-        __delegate_queue {
-            self.autoReconnectLock.lock()
-            let isCurrent = self._autoReconnect && self.autoReconnectGeneration == schedule.generation
-            self.autoReconnectLock.unlock()
+        __delegate_queue { mqtt5 in
+            mqtt5.autoReconnectLock.lock()
+            let isCurrent = mqtt5._autoReconnect && mqtt5.autoReconnectGeneration == schedule.generation
+            mqtt5.autoReconnectLock.unlock()
             guard isCurrent else { return }
-            self.delegate?.mqtt5?(self, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
-            self.didScheduleReconnect(self, schedule.attemptCount, schedule.interval)
+            mqtt5.delegate?.mqtt5?(mqtt5, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
+            mqtt5.didScheduleReconnect(mqtt5, schedule.attemptCount, schedule.interval)
         }
     }
 
@@ -1251,17 +1287,17 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
 
         printDebug("Call the SSL/TLS manually validating function")
 
-        __delegate_queue {
-            self.delegate?.mqtt5?(self, didReceive: trust, completionHandler: completionHandler)
-            self.didReceiveTrust(self, trust, completionHandler)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5?(mqtt5, didReceive: trust, completionHandler: completionHandler)
+            mqtt5.didReceiveTrust(mqtt5, trust, completionHandler)
         }
     }
 
     public func socketUrlSession(_ socket: CocoaMQTTSocketProtocol, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
 
-        __delegate_queue {
-            self.delegate?.mqtt5UrlSession?(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5UrlSession?(mqtt5, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
         }
     }
 
@@ -1321,11 +1357,15 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         }
         autoReconnectLock.unlock()
 
-        __delegate_queue {
-            self.delegate?.mqtt5DidDisconnect(self, withError: err)
-            self.didDisconnect(self, err)
-        }
+        __delegate_queue({ mqtt5 in
+            mqtt5.delegate?.mqtt5DidDisconnect(mqtt5, withError: err)
+            mqtt5.didDisconnect(mqtt5, err)
+        }, completionOnEventLoop: { mqtt5 in
+            mqtt5.continueAfterDisconnectCallbacks(reconnectAttemptCountBeforeCallbacks)
+        })
+    }
 
+    private func continueAfterDisconnectCallbacks(_ reconnectAttemptCountBeforeCallbacks: UInt) {
         guard !is_internal_disconnected else {
             is_internal_disconnected = false
             return
@@ -1371,9 +1411,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
     func didReceive(_ reader: CocoaMQTTReader, disconnect: FrameDisconnect) {
         let reasonCode = disconnect.receiveReasonCode ?? .normalDisconnection
         recordRemoteDisconnect(reasonCode: reasonCode)
-        __delegate_queue {
-            self.delegate?.mqtt5(self, didReceiveDisconnectReasonCode: reasonCode)
-            self.didDisconnectReasonCode(self, reasonCode)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5(mqtt5, didReceiveDisconnectReasonCode: reasonCode)
+            mqtt5.didDisconnectReasonCode(mqtt5, reasonCode)
         }
     }
 
@@ -1385,9 +1425,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             return
         }
         let reasonCode = auth.receiveReasonCode ?? .success
-        __delegate_queue {
-            self.delegate?.mqtt5(self, didReceiveAuthReasonCode: reasonCode)
-            self.didAuthReasonCode(self, reasonCode)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5(mqtt5, didReceiveAuthReasonCode: reasonCode)
+            mqtt5.didAuthReasonCode(mqtt5, reasonCode)
         }
     }
 
@@ -1514,9 +1554,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
         let reasonCode = connack.reasonCode ?? CocoaMQTTCONNACKReasonCode.unspecifiedError
         let properties = connack.connackProperties
-        __delegate_queue {
-            self.delegate?.mqtt5(self, didConnectAck: reasonCode, connAckData: properties)
-            self.didConnectAck(self, reasonCode, properties)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5(mqtt5, didConnectAck: reasonCode, connAckData: properties)
+            mqtt5.didConnectAck(mqtt5, reasonCode, properties)
         }
     }
 
@@ -1557,9 +1597,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             printInfo("Received message: \(message)")
             let messageID = publish.msgid
             let properties = publish.publishRecProperties
-            __delegate_queue {
-                self.delegate?.mqtt5(self, didReceiveMessage: message, id: messageID, publishData: properties)
-                self.didReceiveMessage(self, message, messageID, properties)
+            __delegate_queue { mqtt5 in
+                mqtt5.delegate?.mqtt5(mqtt5, didReceiveMessage: message, id: messageID, publishData: properties)
+                mqtt5.didReceiveMessage(mqtt5, message, messageID, properties)
             }
         }
 
@@ -1582,9 +1622,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
         let messageID = puback.msgid
         let properties = puback.pubAckProperties
-        __delegate_queue {
-            self.delegate?.mqtt5(self, didPublishAck: messageID, pubAckData: properties)
-            self.didPublishAck(self, messageID, properties)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5(mqtt5, didPublishAck: messageID, pubAckData: properties)
+            mqtt5.didPublishAck(mqtt5, messageID, properties)
         }
     }
 
@@ -1600,9 +1640,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
         let messageID = pubrec.msgid
         let properties = pubrec.pubRecProperties
-        __delegate_queue {
-            self.delegate?.mqtt5(self, didPublishRec: messageID, pubRecData: properties)
-            self.didPublishRec(self, messageID, properties)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5(mqtt5, didPublishRec: messageID, pubRecData: properties)
+            mqtt5.didPublishRec(mqtt5, messageID, properties)
         }
     }
 
@@ -1633,9 +1673,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
         let messageID = pubcomp.msgid
         let properties = pubcomp.pubCompProperties
-        __delegate_queue {
-            self.delegate?.mqtt5?(self, didPublishComplete: messageID, pubCompData: properties)
-            self.didCompletePublish(self, messageID, properties)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5?(mqtt5, didPublishComplete: messageID, pubCompData: properties)
+            mqtt5.didCompletePublish(mqtt5, messageID, properties)
         }
     }
 
@@ -1668,9 +1708,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
         }
 
         let properties = suback.subAckProperties
-        __delegate_queue {
-            self.delegate?.mqtt5(self, didSubscribeTopics: success, failed: failed, subAckData: properties)
-            self.didSubscribeTopics(self, success, failed, properties)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5(mqtt5, didSubscribeTopics: success, failed: failed, subAckData: properties)
+            mqtt5.didSubscribeTopics(mqtt5, success, failed, properties)
         }
     }
 
@@ -1701,18 +1741,18 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
         }
 
         let properties = unsuback.unSubAckProperties
-        __delegate_queue {
-            self.delegate?.mqtt5(self, didUnsubscribeTopics: removeTopics, unsubAckData: properties)
-            self.didUnsubscribeTopics(self, removeTopics, properties)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5(mqtt5, didUnsubscribeTopics: removeTopics, unsubAckData: properties)
+            mqtt5.didUnsubscribeTopics(mqtt5, removeTopics, properties)
         }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
 
-        __delegate_queue {
-            self.delegate?.mqtt5DidReceivePong(self)
-            self.didReceivePong(self)
+        __delegate_queue { mqtt5 in
+            mqtt5.delegate?.mqtt5DidReceivePong(mqtt5)
+            mqtt5.didReceivePong(mqtt5)
         }
     }
 }

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -184,8 +184,27 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Delegate Executed queue. Default is `DispatchQueue.main`
     ///
-    /// The delegate/closure callback function will be committed asynchronously to it
-    public var delegateQueue = DispatchQueue.main
+    /// The delegate/closure callback function will be committed asynchronously to it.
+    /// Changing the queue affects callbacks emitted after the assignment; callbacks
+    /// already submitted remain on the queue captured when their event occurred.
+    public var delegateQueue: DispatchQueue {
+        get {
+            delegateQueueLock.lock()
+            defer { delegateQueueLock.unlock() }
+            return _delegateQueue
+        }
+        set {
+            delegateQueueLock.lock()
+            _delegateQueue = newValue
+            delegateQueueLock.unlock()
+        }
+    }
+    private let delegateQueueLock = NSLock()
+    private var _delegateQueue = DispatchQueue.main
+
+    /// Owns ordered socket, reader, timer, and delivery events. Application code
+    /// cannot replace this queue through `delegateQueue`.
+    let eventLoopQueue: DispatchQueue
 
     @ConcurrentAtomic(wrappedValue: CocoaMQTTConnState.disconnected, label: "CocoaMQTT5.connState")
     public var connState
@@ -224,7 +243,20 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     public var packetReadTimeout: TimeInterval = CocoaMQTTReader.defaultPacketReadTimeout
 
     /// Enable auto-reconnect mechanism
-    public var autoReconnect = false
+    public var autoReconnect: Bool {
+        get {
+            autoReconnectLock.lock()
+            defer { autoReconnectLock.unlock() }
+            return _autoReconnect
+        }
+        set {
+            autoReconnectLock.lock()
+            _autoReconnect = newValue
+            autoReconnectLock.unlock()
+            if !newValue { resetAutoReconnectState() }
+        }
+    }
+    private var _autoReconnect = false
 
     /// Reconnect time interval
     ///
@@ -268,6 +300,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     private var isAutoReconnectAttemptScheduled = false
     private var hasPausedAutoReconnectAttempt = false
     private var hasPendingAutoReconnectAttempt = false
+    private var autoReconnectGeneration: UInt64 = 0
     // Tracks the window after requesting an unexpected socket close and before socketDidDisconnect cleans it up.
     private var pendingSocketDisconnectReconnectAttemptCount: UInt?
     private var shouldResumeAutoReconnectAfterPendingDisconnect = false
@@ -382,6 +415,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         self.host = host
         self.port = port
         self.socket = socket
+        self.eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT5.event-loop.\(UUID().uuidString)")
         super.init()
         $connState.setMutationObserver { [weak self] state in
             guard let self = self else { return }
@@ -621,7 +655,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         clientStateLock.unlock()
         resetDisconnectReasonState()
         sessionExpiryController?.prepareStoredSessionForConnect()
-        socket.setDelegate(self, delegateQueue: delegateQueue)
+        socket.setDelegate(self, delegateQueue: eventLoopQueue)
         reader = CocoaMQTTReader(
             socket: socket,
             delegate: self,
@@ -636,7 +670,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
                 try socket.connect(toHost: self.host, onPort: self.port)
             }
 
-            delegateQueue.async { [weak self] in
+            eventLoopQueue.async { [weak self] in
                 guard let self = self else { return }
                 self.connState = .connecting
             }
@@ -688,6 +722,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         }
         shouldResumeAutoReconnectAfterPendingDisconnect = false
         autoReconnTimer = nil
+        autoReconnectGeneration &+= 1
         autoReconnectLock.unlock()
     }
 
@@ -704,7 +739,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
         _isAutoReconnectPaused = false
 
-        guard autoReconnect, connState == .disconnected else {
+        guard _autoReconnect, connState == .disconnected else {
             hasPausedAutoReconnectAttempt = false
             hasPendingAutoReconnectAttempt = false
             shouldResumeAutoReconnectAfterPendingDisconnect = false
@@ -1060,8 +1095,10 @@ extension CocoaMQTT5: CocoaMQTTDeliverProtocol {
             }
 
             if let message = message {
-                self.delegate?.mqtt5(self, didPublishMessage: message, id: msgid)
-                self.didPublishMessage(self, message, msgid)
+                __delegate_queue {
+                    self.delegate?.mqtt5(self, didPublishMessage: message, id: msgid)
+                    self.didPublishMessage(self, message, msgid)
+                }
             }
             if publish.qos == .qos0 {
                 sendingMessages.removeValue(forKey: deliveryToken)
@@ -1078,7 +1115,8 @@ extension CocoaMQTT5: CocoaMQTTDeliverProtocol {
 extension CocoaMQTT5 {
 
     func __delegate_queue(_ fun: @escaping () -> Void) {
-        delegateQueue.async { [weak self] in
+        let callbackQueue = delegateQueue
+        callbackQueue.async { [weak self] in
             guard self != nil else { return }
             fun()
         }
@@ -1107,34 +1145,49 @@ extension CocoaMQTT5 {
         hasPendingAutoReconnectAttempt = false
         pendingSocketDisconnectReconnectAttemptCount = nil
         shouldResumeAutoReconnectAfterPendingDisconnect = false
+        autoReconnectGeneration &+= 1
         autoReconnectLock.unlock()
     }
 
-    private func notifyAutoReconnectScheduled(_ schedule: (attemptCount: UInt, interval: UInt16)) {
+    private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
         __delegate_queue {
+            self.autoReconnectLock.lock()
+            let isCurrent = self._autoReconnect && self.autoReconnectGeneration == schedule.generation
+            self.autoReconnectLock.unlock()
+            guard isCurrent else { return }
             self.delegate?.mqtt5?(self, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
             self.didScheduleReconnect(self, schedule.attemptCount, schedule.interval)
         }
     }
 
-    private func scheduleAutoReconnectAttemptLocked(after interval: UInt16? = nil) -> (attemptCount: UInt, interval: UInt16) {
+    private func scheduleAutoReconnectAttemptLocked(after interval: UInt16? = nil) -> CocoaMQTTAutoReconnectSchedule {
         let delay = interval ?? reconnectTimeInterval
 
         printInfo("Try reconnect to server after \(delay)s")
         isAutoReconnectAttemptScheduled = true
+        autoReconnectGeneration &+= 1
+        let generation = autoReconnectGeneration
         autoReconnTimer = CocoaMQTTTimer.after(Double(delay), name: "autoReconnTimer", { [weak self] in
-            guard let self = self, self.prepareScheduledAutoReconnectFire() else { return }
-            _ = self.connect()
+            self?.eventLoopQueue.async { [weak self] in
+                guard let self = self,
+                      self.prepareScheduledAutoReconnectFire(generation: generation) else { return }
+                _ = self.connect()
+            }
         })
 
-        return (reconnectAttemptCount, delay)
+        return CocoaMQTTAutoReconnectSchedule(
+            attemptCount: reconnectAttemptCount,
+            interval: delay,
+            generation: generation
+        )
     }
 
-    private func prepareScheduledAutoReconnectFire() -> Bool {
+    private func prepareScheduledAutoReconnectFire(generation: UInt64) -> Bool {
         autoReconnectLock.lock()
         defer { autoReconnectLock.unlock() }
 
-        guard !_isAutoReconnectPaused else {
+        guard autoReconnectGeneration == generation else { return false }
+        guard _autoReconnect, !_isAutoReconnectPaused else {
             isAutoReconnectAttemptScheduled = false
             return false
         }
@@ -1198,14 +1251,18 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
 
         printDebug("Call the SSL/TLS manually validating function")
 
-        delegate?.mqtt5?(self, didReceive: trust, completionHandler: completionHandler)
-        didReceiveTrust(self, trust, completionHandler)
+        __delegate_queue {
+            self.delegate?.mqtt5?(self, didReceive: trust, completionHandler: completionHandler)
+            self.didReceiveTrust(self, trust, completionHandler)
+        }
     }
 
     public func socketUrlSession(_ socket: CocoaMQTTSocketProtocol, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
 
-        delegate?.mqtt5UrlSession?(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
+        __delegate_queue {
+            self.delegate?.mqtt5UrlSession?(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
+        }
     }
 
     // ?
@@ -1259,13 +1316,15 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         connState = .disconnected
         autoReconnectLock.lock()
         let reconnectAttemptCountBeforeCallbacks = pendingSocketDisconnectReconnectAttemptCount ?? reconnectAttemptCount
-        if !is_internal_disconnected && autoReconnect {
+        if !is_internal_disconnected && _autoReconnect {
             pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCountBeforeCallbacks
         }
         autoReconnectLock.unlock()
 
-        delegate?.mqtt5DidDisconnect(self, withError: err)
-        didDisconnect(self, err)
+        __delegate_queue {
+            self.delegate?.mqtt5DidDisconnect(self, withError: err)
+            self.didDisconnect(self, err)
+        }
 
         guard !is_internal_disconnected else {
             is_internal_disconnected = false
@@ -1312,8 +1371,10 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
     func didReceive(_ reader: CocoaMQTTReader, disconnect: FrameDisconnect) {
         let reasonCode = disconnect.receiveReasonCode ?? .normalDisconnection
         recordRemoteDisconnect(reasonCode: reasonCode)
-        delegate?.mqtt5(self, didReceiveDisconnectReasonCode: reasonCode)
-        didDisconnectReasonCode(self, reasonCode)
+        __delegate_queue {
+            self.delegate?.mqtt5(self, didReceiveDisconnectReasonCode: reasonCode)
+            self.didDisconnectReasonCode(self, reasonCode)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, auth: FrameAuth) {
@@ -1324,8 +1385,10 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             return
         }
         let reasonCode = auth.receiveReasonCode ?? .success
-        delegate?.mqtt5(self, didReceiveAuthReasonCode: reasonCode)
-        didAuthReasonCode(self, reasonCode)
+        __delegate_queue {
+            self.delegate?.mqtt5(self, didReceiveAuthReasonCode: reasonCode)
+            self.didAuthReasonCode(self, reasonCode)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, connack: FrameConnAck) {
@@ -1395,7 +1458,7 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             if negotiatedKeepAlive > 0 {
                 aliveTimer = CocoaMQTTTimer.every(Double(negotiatedKeepAlive), name: "aliveTimer") { [weak self] in
                     guard let self = self else { return }
-                    self.delegateQueue.async {
+                    self.eventLoopQueue.async {
                         guard self.connState == .connected else {
                             self.aliveTimer = nil
                             return
@@ -1449,8 +1512,12 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             internal_disconnect()
         }
 
-        delegate?.mqtt5(self, didConnectAck: connack.reasonCode ?? CocoaMQTTCONNACKReasonCode.unspecifiedError, connAckData: connack.connackProperties ?? nil)
-        didConnectAck(self, connack.reasonCode ?? CocoaMQTTCONNACKReasonCode.unspecifiedError, connack.connackProperties ?? nil)
+        let reasonCode = connack.reasonCode ?? CocoaMQTTCONNACKReasonCode.unspecifiedError
+        let properties = connack.connackProperties
+        __delegate_queue {
+            self.delegate?.mqtt5(self, didConnectAck: reasonCode, connAckData: properties)
+            self.didConnectAck(self, reasonCode, properties)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, publish: FramePublish) {
@@ -1488,8 +1555,12 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
         if shouldDeliver {
             printInfo("Received message: \(message)")
-            delegate?.mqtt5(self, didReceiveMessage: message, id: publish.msgid, publishData: publish.publishRecProperties ?? nil)
-            didReceiveMessage(self, message, publish.msgid, publish.publishRecProperties ?? nil)
+            let messageID = publish.msgid
+            let properties = publish.publishRecProperties
+            __delegate_queue {
+                self.delegate?.mqtt5(self, didReceiveMessage: message, id: messageID, publishData: properties)
+                self.didReceiveMessage(self, message, messageID, properties)
+            }
         }
 
         if message.qos == .qos1 {
@@ -1509,8 +1580,12 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
         }
         clientStateLock.unlock()
 
-        delegate?.mqtt5(self, didPublishAck: puback.msgid, pubAckData: puback.pubAckProperties ?? nil)
-        didPublishAck(self, puback.msgid, puback.pubAckProperties ?? nil)
+        let messageID = puback.msgid
+        let properties = puback.pubAckProperties
+        __delegate_queue {
+            self.delegate?.mqtt5(self, didPublishAck: messageID, pubAckData: properties)
+            self.didPublishAck(self, messageID, properties)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, pubrec: FramePubRec) {
@@ -1523,8 +1598,12 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
         }
         clientStateLock.unlock()
 
-        delegate?.mqtt5(self, didPublishRec: pubrec.msgid, pubRecData: pubrec.pubRecProperties ?? nil)
-        didPublishRec(self, pubrec.msgid, pubrec.pubRecProperties ?? nil)
+        let messageID = pubrec.msgid
+        let properties = pubrec.pubRecProperties
+        __delegate_queue {
+            self.delegate?.mqtt5(self, didPublishRec: messageID, pubRecData: properties)
+            self.didPublishRec(self, messageID, properties)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, pubrel: FramePubRel) {
@@ -1552,8 +1631,12 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
         }
         clientStateLock.unlock()
 
-        delegate?.mqtt5?(self, didPublishComplete: pubcomp.msgid, pubCompData: pubcomp.pubCompProperties ?? nil)
-        didCompletePublish(self, pubcomp.msgid, pubcomp.pubCompProperties ?? nil)
+        let messageID = pubcomp.msgid
+        let properties = pubcomp.pubCompProperties
+        __delegate_queue {
+            self.delegate?.mqtt5?(self, didPublishComplete: messageID, pubCompData: properties)
+            self.didCompletePublish(self, messageID, properties)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, suback: FrameSubAck) {
@@ -1584,8 +1667,11 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             }
         }
 
-        delegate?.mqtt5(self, didSubscribeTopics: success, failed: failed, subAckData: suback.subAckProperties ?? nil)
-        didSubscribeTopics(self, success, failed, suback.subAckProperties ?? nil)
+        let properties = suback.subAckProperties
+        __delegate_queue {
+            self.delegate?.mqtt5(self, didSubscribeTopics: success, failed: failed, subAckData: properties)
+            self.didSubscribeTopics(self, success, failed, properties)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, unsuback: FrameUnsubAck) {
@@ -1614,15 +1700,20 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             }
         }
 
-        delegate?.mqtt5(self, didUnsubscribeTopics: removeTopics, unsubAckData: unsuback.unSubAckProperties ?? nil)
-        didUnsubscribeTopics(self, removeTopics, unsuback.unSubAckProperties ?? nil)
+        let properties = unsuback.unSubAckProperties
+        __delegate_queue {
+            self.delegate?.mqtt5(self, didUnsubscribeTopics: removeTopics, unsubAckData: properties)
+            self.didUnsubscribeTopics(self, removeTopics, properties)
+        }
     }
 
     func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
 
-        delegate?.mqtt5DidReceivePong(self)
-        didReceivePong(self)
+        __delegate_queue {
+            self.delegate?.mqtt5DidReceivePong(self)
+            self.didReceivePong(self)
+        }
     }
 }
 
@@ -1648,5 +1739,6 @@ extension CocoaMQTT5 {
 
     func t_waitUntilDeliverIdle() {
         deliver.t_waitUntilIdle()
+        eventLoopQueue.sync {}
     }
 }

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -682,7 +682,6 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         clientStateLock.unlock()
         resetDisconnectReasonState()
         sessionExpiryController?.prepareStoredSessionForConnect()
-        socketDelegateProxy.delegate = self
         socket.setDelegate(socketDelegateProxy, delegateQueue: eventLoopQueue)
         reader = CocoaMQTTReader(
             socket: socket,

--- a/Source/CocoaMQTTDeliver.swift
+++ b/Source/CocoaMQTTDeliver.swift
@@ -13,12 +13,17 @@ protocol CocoaMQTTDeliverProtocol: AnyObject {
 
     var delegateQueue: DispatchQueue { get set }
 
+    /// Serial queue that owns client-side protocol and transport work.
+    var eventLoopQueue: DispatchQueue { get }
+
     func deliver(_ deliver: CocoaMQTTDeliver, wantToSend frame: Frame)
 
     func deliver(_ deliver: CocoaMQTTDeliver, didReject frame: Frame)
 }
 
 extension CocoaMQTTDeliverProtocol {
+    var eventLoopQueue: DispatchQueue { delegateQueue }
+
     func deliver(_ deliver: CocoaMQTTDeliver, didReject frame: Frame) {}
 }
 
@@ -324,7 +329,7 @@ extension CocoaMQTTDeliver {
         }
         storage?.remove(frame)
         if let delegate = delegate {
-            delegate.delegateQueue.async {
+            delegate.eventLoopQueue.async {
                 delegate.deliver(self, didReject: frame)
             }
         }
@@ -468,7 +473,7 @@ extension CocoaMQTTDeliver {
             if let p = frame as? FramePublish { storage?.remove(p) }
         }
 
-        delegate.delegateQueue.async {
+        delegate.eventLoopQueue.async {
             delegate.deliver(self, wantToSend: frame)
         }
     }

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -31,6 +31,79 @@ public protocol CocoaMQTTSocketProtocol {
     func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int)
 }
 
+/// Normalizes callbacks from built-in and custom transports onto the client's
+/// private event loop. Custom transports are not required to honor the queue
+/// passed to `setDelegate`; correctness is enforced at this boundary instead.
+final class CocoaMQTTSocketDelegateProxy: CocoaMQTTSocketDelegate {
+    weak var delegate: CocoaMQTTSocketDelegate?
+
+    private let eventLoopQueue: DispatchQueue
+    private let eventLoopQueueKey = DispatchSpecificKey<Void>()
+
+    init(eventLoopQueue: DispatchQueue) {
+        self.eventLoopQueue = eventLoopQueue
+        eventLoopQueue.setSpecific(key: eventLoopQueueKey, value: ())
+    }
+
+    private func forward(_ callback: @escaping (CocoaMQTTSocketDelegate?) -> Void) {
+        if DispatchQueue.getSpecific(key: eventLoopQueueKey) != nil {
+            callback(delegate)
+        } else {
+            eventLoopQueue.async { [self] in callback(delegate) }
+        }
+    }
+
+    func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+        forward { $0?.socketConnected(socket) }
+    }
+
+    func socket(
+        _ socket: CocoaMQTTSocketProtocol,
+        didReceive trust: SecTrust,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        forward { delegate in
+            guard let delegate = delegate else {
+                completionHandler(false)
+                return
+            }
+            delegate.socket(socket, didReceive: trust, completionHandler: completionHandler)
+        }
+    }
+
+    func socketUrlSession(
+        _ socket: CocoaMQTTSocketProtocol,
+        didReceiveTrust trust: SecTrust,
+        didReceiveChallenge challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        forward { delegate in
+            guard let delegate = delegate else {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+                return
+            }
+            delegate.socketUrlSession(
+                socket,
+                didReceiveTrust: trust,
+                didReceiveChallenge: challenge,
+                completionHandler: completionHandler
+            )
+        }
+    }
+
+    func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {
+        forward { $0?.socket(socket, didWriteDataWithTag: tag) }
+    }
+
+    func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {
+        forward { $0?.socket(socket, didRead: data, withTag: tag) }
+    }
+
+    func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
+        forward { $0?.socketDidDisconnect(socket, withError: err) }
+    }
+}
+
 /// A socket transport that can close only after its final write has drained.
 public protocol CocoaMQTTDisconnectAfterWritingSocket: CocoaMQTTSocketProtocol {
     func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int)

--- a/Source/CocoaMQTTTimer.swift
+++ b/Source/CocoaMQTTTimer.swift
@@ -19,6 +19,19 @@ class CocoaMQTTTimer {
     let startDelay: TimeInterval
     let name: String
 
+    private let lock = NSLock()
+    private let timer: DispatchSourceTimer
+    private var eventHandler: (() -> Void)?
+    private var retainedUntilCanceled: CocoaMQTTTimer?
+
+    private enum State {
+        case suspended
+        case resumed
+        case canceled
+    }
+
+    private var state: State = .suspended
+
     init(delay: TimeInterval?=nil, name: String, timeInterval: TimeInterval) {
         self.name = name
         self.timeInterval = timeInterval
@@ -26,6 +39,19 @@ class CocoaMQTTTimer {
             self.startDelay = delay
         } else {
             self.startDelay = timeInterval
+        }
+        let queue = DispatchQueue(label: "io.emqx.CocoaMQTT." + name, target: CocoaMQTTTimer.target_queue)
+        timer = DispatchSource.makeTimerSource(flags: .strict, queue: queue)
+        timer.schedule(
+            deadline: .now() + startDelay,
+            repeating: timeInterval > 0 ? timeInterval : .infinity
+        )
+        timer.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            self.lock.lock()
+            let eventHandler = self.eventHandler
+            self.lock.unlock()
+            eventHandler?()
         }
     }
 
@@ -38,53 +64,38 @@ class CocoaMQTTTimer {
 
     @discardableResult
     class func after(_ interval: TimeInterval, name: String, _ block: @escaping () -> Void) -> CocoaMQTTTimer {
-        let timer: CocoaMQTTTimer? = CocoaMQTTTimer(delay: interval, name: name, timeInterval: 0)
-        timer?.eventHandler = { [weak timer] in
+        let timer = CocoaMQTTTimer(delay: interval, name: name, timeInterval: 0)
+        timer.lock.lock()
+        timer.retainedUntilCanceled = timer
+        timer.eventHandler = { [weak timer] in
             block()
-            timer?.suspend()
-            timer = nil
+            timer?.cancel()
         }
-        timer?.resume()
-        return timer!
+        timer.lock.unlock()
+        timer.resume()
+        return timer
     }
 
     /// Execute the tasks concurrently on the target_queue with default QOS
     private static let target_queue = DispatchQueue(label: "io.emqx.CocoaMQTT.TimerQueue", qos: .default, attributes: .concurrent)
 
-    /// Execute each timer tasks serially and use the target queue for concurrency among timers
-    private lazy var timer: DispatchSourceTimer = {
-        let queue = DispatchQueue(label: "io.emqx.CocoaMQTT." + name, target: CocoaMQTTTimer.target_queue)
-        let t = DispatchSource.makeTimerSource(flags: .strict, queue: queue)
-        t.schedule(deadline: .now() + self.startDelay, repeating: self.timeInterval > 0 ? Double(self.timeInterval) : Double.infinity)
-        t.setEventHandler(handler: { [weak self] in
-            self?.eventHandler?()
-        })
-        return t
-    }()
-
-    var eventHandler: (() -> Void)?
-
-    private enum State {
-        case suspended
-        case resumed
-        case canceled
-    }
-
-    private var state: State = .suspended
-
     deinit {
+        lock.lock()
         timer.setEventHandler {}
-        timer.cancel()
-        /*
-         If the timer is suspended, calling cancel without resuming
-         triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
-         */
-        resume()
         eventHandler = nil
+        if state != .canceled {
+            if state == .suspended {
+                timer.resume()
+            }
+            timer.cancel()
+        }
+        lock.unlock()
     }
 
     func resume() {
-        if state == .resumed {
+        lock.lock()
+        defer { lock.unlock() }
+        guard state == .suspended else {
             return
         }
         state = .resumed
@@ -92,7 +103,9 @@ class CocoaMQTTTimer {
     }
 
     func suspend() {
-        if state == .suspended {
+        lock.lock()
+        defer { lock.unlock() }
+        guard state == .resumed else {
             return
         }
         state = .suspended
@@ -101,10 +114,19 @@ class CocoaMQTTTimer {
 
     /// Manually cancel timer
     func cancel() {
-        if state == .canceled {
+        lock.lock()
+        guard state != .canceled else {
+            lock.unlock()
             return
         }
+        if state == .suspended {
+            timer.resume()
+        }
         state = .canceled
+        timer.setEventHandler {}
+        eventHandler = nil
         timer.cancel()
+        retainedUntilCanceled = nil
+        lock.unlock()
     }
 }

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -18,6 +18,12 @@ enum CocoaMQTTResources {
     }
 }
 
+struct CocoaMQTTAutoReconnectSchedule {
+    let attemptCount: UInt
+    let interval: UInt16
+    let generation: UInt64
+}
+
 /// Encode and Decode big-endian UInt16
 extension UInt16 {
     /// Most Significant Byte (MSB)


### PR DESCRIPTION
## What changed

- add a private serial event loop to both MQTT 3.1.1 and MQTT 5 clients
- normalize built-in and custom socket callbacks through a client-owned delegate proxy
- route socket, reader, keepalive, reconnect, and delivery work through the internal event loop
- dispatch every application delegate/closure callback explicitly to the public `delegateQueue` without retaining the client while callbacks are pending
- make `delegateQueue`, MQTT 3.1.1 connection state, and public reconnect state safe for concurrent access
- preserve disconnect-callback control over automatic reconnect, including zero-delay attempts
- make `CocoaMQTTTimer` initialization, state transitions, and cancellation race-free
- add MQTT 3/5 regression coverage for custom sockets, callback lifetime, state access, queue changes, and reconnect ordering

## Why

`delegateQueue` previously controlled both application callbacks and internal MQTT processing. A user-selected concurrent queue could therefore change protocol ordering and connection-state concurrency. The internal state machine now has queue ownership independent of callback policy while preserving existing callback and reconnect behavior.

Closes #710

## Verification

- `swift test --skip CocoaMQTTTests.CocoaMQTTTests` — 191 tests passed
- `swift test --sanitize=thread --filter ClientEventLoopTests\|AutoReconnectStateTests\|ThreadSafetyRegressionTests` — 44 tests passed with no races
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `swift package plugin --allow-writing-to-package-directory swiftlint --config .swiftlint.yml --strict --reporter github-actions-logging` — 0 violations