### PR TITLE
Move SwiftLint to an opt-in tooling package

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -10,6 +10,7 @@ on:
       - ".swiftlint.yml"
       - "Package.swift"
       - "Package.resolved"
+      - "Tools/**"
       - ".github/workflows/swiftlint.yml"
   workflow_dispatch:
 
@@ -26,12 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run SwiftLint
-        run: |
-          swift package plugin --allow-writing-to-package-directory \
-            swiftlint \
-            --config .swiftlint.yml \
-            --strict \
-            --reporter github-actions-logging
+        run: Tools/lint.sh
 
       - name: Verify build is unaffected
         run: swift build

--- a/Package.resolved
+++ b/Package.resolved
@@ -17,15 +17,6 @@
         "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
         "version" : "4.0.8"
       }
-    },
-    {
-      "identity" : "swiftlintplugins",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
-      "state" : {
-        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
-        "version" : "0.63.2"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -18,9 +18,6 @@ let package = Package(
         // Allow Starscream 4.x and 5.x to avoid version conflicts in client apps
         .package(url: "https://github.com/daltoniam/Starscream.git", "4.0.8"..<"6.0.0"),
         .package(url: "https://github.com/leeway1208/MqttCocoaAsyncSocket", from: "1.0.8"),
-        // SwiftLint command plugin used by CI/local lint commands only.
-        // We do not attach it as a build tool plugin to avoid affecting build outputs.
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.63.2"),
     ],
     targets: [
         .target(

--- a/Tools/Package.resolved
+++ b/Tools/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
+        "version" : "0.63.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tools/Package.swift
+++ b/Tools/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "CocoaMQTTTools",
+    dependencies: [
+        .package(
+            url: "https://github.com/SimplyDanny/SwiftLintPlugins",
+            exact: "0.63.2"
+        )
+    ]
+)

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -1,0 +1,13 @@
+# Development tools
+
+Development-only Swift package dependencies live here so that CocoaMQTT users do
+not resolve or download them.
+
+Run SwiftLint from the repository root with:
+
+```sh
+Tools/lint.sh
+```
+
+The package lock file pins the SwiftLint plugin version, making the local command
+and CI use the same tool.

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -11,3 +11,7 @@ Tools/lint.sh
 
 The package lock file pins the SwiftLint plugin version, making the local command
 and CI use the same tool.
+
+Swift 5.9 or newer is required to run this tooling package because
+SwiftLintPlugins 0.63.2 itself requires SwiftPM 5.9. This does not change the
+main CocoaMQTT package's Swift 5.7 minimum.

--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+exec swift package --package-path "$repository_root/Tools" \
+    plugin --allow-writing-to-package-directory \
+    swiftlint \
+    --config "$repository_root/.swiftlint.yml" \
+    --strict \
+    --reporter github-actions-logging \
+    "$repository_root"

--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+repository_root=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 
 exec swift package --package-path "$repository_root/Tools" \
     plugin --allow-writing-to-package-directory \


### PR DESCRIPTION
## What changed

- remove SwiftLintPlugins from the CocoaMQTT package dependency graph and lock file
- add a dedicated, version-locked package under `Tools/`
- provide `Tools/lint.sh` as the documented, location-independent lint entry point
- update the SwiftLint workflow to use the opt-in tool package

## Why

SwiftLint is development tooling, but declaring it in the root package forced every SwiftPM consumer to resolve the plugin and its binary artifact. Keeping it in a separate package removes that download from normal resolve, build, and test workflows while retaining reproducible linting.

Closes #703

## Verification

- `Tools/lint.sh` (63 files, 0 violations)
- `swift build --scratch-path /tmp/cocoamqtt-703-build`
- `swift test --scratch-path /tmp/cocoamqtt-703-test --skip CocoaMQTTTests.CocoaMQTTTests` (191 tests passed)
- `swift package dump-package`
- `swift package --package-path Tools dump-package`
- root package resolution with newly created empty cache, config, security, and scratch directories; output and dependency graph contained no SwiftLint dependency
- `git diff --check`