### PR TITLE
Replace disabled WebSocket authentication test

### DIFF
--- a/CocoaMQTTTests/CocoaMQTTTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTTests.swift
@@ -82,48 +82,6 @@ class CocoaMQTTTests: XCTestCase {
 
     }
 
-    // This is a basic test of the websocket authentication used by AWS IoT Custom Authorizers
-    // https://docs.aws.amazon.com/iot/latest/developerguide/custom-authorizer.html
-    // Requires project-specific AWS IoT credentials and is intentionally excluded from XCTest discovery.
-    func disabledWebsocketAuthConnect() {
-        let caller = Caller()
-        let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
-        websocket.headers = [
-            "x-amz-customauthorizer-name": "tokenAuthorizer",
-            "x-amz-customauthorizer-signature": "qnQ+T1i2ahSuispDMbjBPn/bN91jDpOmiRAVfTqfXTVvrEP6mNroYJLeVm6vrCp0dODgoiNYKWjwXANuseVafMALL18rMVyQOCaRTStI7xh/pFKVtnK+pdJroPto8ElJhia4cfETwmCdHq7rXLUqdvUGFiVh4+67M5R6088bfhZnjwjgcvhvG8mpTo2yONOkqDK9eA9XZcJhjrURF8DHsPrpIjIihYHq7LdsL5nFJ9FM11mA2AUj51fHZHO7uOfegprFgIeI32Tcn5KEWEDGrD3shvOrqUtDuodrfkALGtNjpGdWNOp/8XKK19KsbUJJrMaH6CDk3j6pn7S1lilz2Q==",
-            "token": "3c7a880d-0868-40dc-8183-8870323803fa",
-            "Sec-WebSocket-Protocol": "mqttv3.1"
-        ]
-        websocket.enableSSL = true
-        let mqtt = CocoaMQTT(clientID: clientID, host: "XXXXXXXXXXXX-ats.iot.eu-west-1.amazonaws.com", port: 443, socket: websocket)
-        mqtt.delegateQueue = deleQueue
-        mqtt.delegate = caller
-        mqtt.logLevel = .error
-        mqtt.autoReconnect = false
-        _ = mqtt.connect()
-        wait_for { caller.isConnected }
-        XCTAssertEqual(mqtt.connState, .connected)
-        let topic = "d/AADDS"
-        mqtt.subscribe(topic)
-        wait_for {
-            if caller.subs.count >= 1 {
-                if caller.subs[0] == topic {
-                    return true
-                }
-            }
-            return false
-        }
-        mqtt.publish(topic, withString: "0", qos: .qos0, retained: false)
-        wait_for {
-            if caller.recvs.count >= 1 {
-                let f = caller.recvs[0]
-                XCTAssertEqual(f.topic, topic)
-                return true
-            }
-            return false
-        }
-    }
-
     func testWebsocketConnect() {
         let caller = Caller()
         let websocket = CocoaMQTTWebSocket(uri: "/mqtt")

--- a/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import XCTest
+@testable import CocoaMQTT
+#if IS_SWIFT_PACKAGE
+@testable import CocoaMQTTWebSocket
+#endif
+
+final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
+    private final class ConnectionSpy: NSObject, CocoaMQTTWebSocketConnection {
+        weak var delegate: CocoaMQTTWebSocketConnectionDelegate?
+        var queue = DispatchQueue(label: "tests.websocket-auth.connection")
+        private(set) var connectCallCount = 0
+
+        func connect() {
+            connectCallCount += 1
+        }
+
+        func disconnect() {}
+
+        func write(data: Data, handler: @escaping (Error?) -> Void) {
+            handler(nil)
+        }
+    }
+
+    private final class BuilderSpy: CocoaMQTTWebSocketConnectionBuilder {
+        let connection = ConnectionSpy()
+        private(set) var url: URL?
+        private(set) var headers: [String: String]?
+
+        func buildConnection(
+            forURL url: URL,
+            withHeaders headers: [String: String]
+        ) throws -> CocoaMQTTWebSocketConnection {
+            self.url = url
+            self.headers = headers
+            return connection
+        }
+    }
+
+    func testSecureConnectForwardsCustomAuthorizerHeaders() throws {
+        let builder = BuilderSpy()
+        let websocket = CocoaMQTTWebSocket(uri: "/mqtt", builder: builder)
+        let headers = [
+            "x-amz-customauthorizer-name": "authorizer",
+            "x-amz-customauthorizer-signature": "signature",
+            "token": "token",
+            "Sec-WebSocket-Protocol": "mqttv3.1"
+        ]
+        websocket.enableSSL = true
+        websocket.headers = headers
+
+        try websocket.connect(toHost: "example-ats.iot.example.com", onPort: 443)
+
+        XCTAssertEqual(builder.url, URL(string: "wss://example-ats.iot.example.com:443/mqtt"))
+        XCTAssertEqual(builder.headers, headers)
+        XCTAssertEqual(builder.connection.connectCallCount, 1)
+    }
+}
+
+final class AWSIoTIntegrationTests: XCTestCase {
+    private final class Delegate: CocoaMQTTDelegate {
+        var connected: (() -> Void)?
+        var disconnected: (() -> Void)?
+
+        func mqtt(_ mqtt: CocoaMQTT, didConnectAck ack: CocoaMQTTConnAck) {
+            if ack == .accept {
+                connected?()
+            }
+        }
+
+        func mqtt(_ mqtt: CocoaMQTT, didPublishMessage message: CocoaMQTTMessage, id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didPublishAck id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didReceiveMessage message: CocoaMQTTMessage, id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didSubscribeTopics success: NSDictionary, failed: [String]) {}
+        func mqtt(_ mqtt: CocoaMQTT, didUnsubscribeTopics topics: [String]) {}
+        func mqttDidPing(_ mqtt: CocoaMQTT) {}
+        func mqttDidReceivePong(_ mqtt: CocoaMQTT) {}
+
+        func mqttDidDisconnect(_ mqtt: CocoaMQTT, withError err: Error?) {
+            disconnected?()
+        }
+    }
+
+    func testCustomAuthorizerConnection() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard
+            let host = environment["COCOAMQTT_AWS_IOT_HOST"], !host.isEmpty,
+            let authorizer = environment["COCOAMQTT_AWS_AUTHORIZER_NAME"], !authorizer.isEmpty,
+            let signature = environment["COCOAMQTT_AWS_AUTHORIZER_SIGNATURE"], !signature.isEmpty,
+            let token = environment["COCOAMQTT_AWS_AUTHORIZER_TOKEN"], !token.isEmpty
+        else {
+            throw XCTSkip("Set the COCOAMQTT_AWS_* variables to run the AWS IoT integration test")
+        }
+
+        let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
+        websocket.enableSSL = true
+        websocket.headers = [
+            "x-amz-customauthorizer-name": authorizer,
+            "x-amz-customauthorizer-signature": signature,
+            "token": token,
+            "Sec-WebSocket-Protocol": "mqttv3.1"
+        ]
+
+        let mqtt = CocoaMQTT(
+            clientID: "CocoaMQTT-AWS-integration-\(UUID().uuidString)",
+            host: host,
+            port: 443,
+            socket: websocket
+        )
+        let delegate = Delegate()
+        let connected = expectation(description: "AWS IoT accepted the connection")
+        let disconnected = expectation(description: "AWS IoT connection closed")
+        delegate.connected = { connected.fulfill() }
+        delegate.disconnected = { disconnected.fulfill() }
+        mqtt.delegate = delegate
+        mqtt.delegateQueue = DispatchQueue(label: "tests.aws-iot-integration.callbacks")
+        mqtt.autoReconnect = false
+        mqtt.logLevel = .error
+
+        if !mqtt.connect() {
+            XCTFail("Failed to start the AWS IoT connection")
+            return
+        }
+        wait(for: [connected], timeout: 30)
+        XCTAssertEqual(mqtt.connState, .connected)
+
+        mqtt.disconnect()
+        wait(for: [disconnected], timeout: 10)
+    }
+}

--- a/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
@@ -43,8 +43,8 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
         let headers = [
             "x-amz-customauthorizer-name": "authorizer",
             "x-amz-customauthorizer-signature": "signature",
-            "token": "token",
-            "Sec-WebSocket-Protocol": "mqttv3.1"
+            "custom-token": "token",
+            "Sec-WebSocket-Protocol": "mqtt"
         ]
         websocket.enableSSL = true
         websocket.headers = headers
@@ -79,6 +79,15 @@ final class AWSIoTIntegrationTests: XCTestCase {
         func mqttDidDisconnect(_ mqtt: CocoaMQTT, withError err: Error?) {
             disconnected?()
         }
+
+        func mqttUrlSession(
+            _ mqtt: CocoaMQTT,
+            didReceiveTrust trust: SecTrust,
+            didReceiveChallenge challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        ) {
+            completionHandler(.performDefaultHandling, nil)
+        }
     }
 
     func testCustomAuthorizerConnection() throws {
@@ -87,6 +96,7 @@ final class AWSIoTIntegrationTests: XCTestCase {
             let host = environment["COCOAMQTT_AWS_IOT_HOST"], !host.isEmpty,
             let authorizer = environment["COCOAMQTT_AWS_AUTHORIZER_NAME"], !authorizer.isEmpty,
             let signature = environment["COCOAMQTT_AWS_AUTHORIZER_SIGNATURE"], !signature.isEmpty,
+            let tokenKeyName = environment["COCOAMQTT_AWS_TOKEN_KEY_NAME"], !tokenKeyName.isEmpty,
             let token = environment["COCOAMQTT_AWS_AUTHORIZER_TOKEN"], !token.isEmpty
         else {
             throw XCTSkip("Set the COCOAMQTT_AWS_* variables to run the AWS IoT integration test")
@@ -97,8 +107,8 @@ final class AWSIoTIntegrationTests: XCTestCase {
         websocket.headers = [
             "x-amz-customauthorizer-name": authorizer,
             "x-amz-customauthorizer-signature": signature,
-            "token": token,
-            "Sec-WebSocket-Protocol": "mqttv3.1"
+            tokenKeyName: token,
+            "Sec-WebSocket-Protocol": "mqtt"
         ]
 
         let mqtt = CocoaMQTT(


### PR DESCRIPTION
## What changed

- remove the undiscovered AWS IoT authentication test and its hard-coded endpoint, token, and signature
- add a deterministic WebSocket test using connection-builder and connection spies to verify the secure URL and custom-authorizer headers
- add a discoverable `AWSIoTIntegrationTests` suite that runs only when all required environment variables are present
- use the AWS-required `mqtt` WebSocket subprotocol and system-default TLS validation
- support each authorizer configuration through its configurable token header name

The opt-in integration test requires:

- `COCOAMQTT_AWS_IOT_HOST`
- `COCOAMQTT_AWS_AUTHORIZER_NAME`
- `COCOAMQTT_AWS_AUTHORIZER_SIGNATURE`
- `COCOAMQTT_AWS_TOKEN_KEY_NAME`
- `COCOAMQTT_AWS_AUTHORIZER_TOKEN`

Closes #705

## Verification

- `swift test --filter CocoaMQTTWebSocketAuthenticationTests`
- `env -u COCOAMQTT_AWS_IOT_HOST -u COCOAMQTT_AWS_AUTHORIZER_NAME -u COCOAMQTT_AWS_AUTHORIZER_SIGNATURE -u COCOAMQTT_AWS_TOKEN_KEY_NAME -u COCOAMQTT_AWS_AUTHORIZER_TOKEN swift test --skip-build --filter AWSIoTIntegrationTests` (1 expected skip)
- `swift test --skip CocoaMQTTTests.CocoaMQTTTests` (193 tests, 1 expected skip, 0 failures)
- `Tools/lint.sh` (64 files, 0 violations)
- `git diff --check`