### PR TITLE
Fix secure WebSocket trust challenge completion

### DIFF
--- a/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
@@ -85,7 +85,7 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
         XCTAssertEqual(builder.connection.connectCallCount, 1)
     }
 
-    func testMissingSocketDelegateQueueUsesSystemTrustHandling() throws {
+    func testMissingSocketDelegateQueueStillForwardsCustomTrustHandling() throws {
         let builder = BuilderSpy()
         let websocket = CocoaMQTTWebSocket(uri: "/mqtt", builder: builder)
         let delegate = SocketDelegateSpy()
@@ -99,13 +99,13 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
             didReceiveTrust: try makeTrust(),
             didReceiveChallenge: makeChallenge()
         ) { disposition, credential in
-            XCTAssertEqual(disposition, .performDefaultHandling)
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
             XCTAssertNil(credential)
             completed.fulfill()
         }
 
         wait(for: [completed], timeout: 1)
-        XCTAssertEqual(delegate.urlSessionTrustCallCount, 0)
+        XCTAssertEqual(delegate.urlSessionTrustCallCount, 1)
     }
 
     private func makeTrust() throws -> SecTrust {

--- a/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import XCTest
 @testable import CocoaMQTT
 #if IS_SWIFT_PACKAGE
@@ -6,6 +7,34 @@ import XCTest
 #endif
 
 final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
+    private final class ChallengeSenderStub: NSObject, URLAuthenticationChallengeSender {
+        func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+        func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+        func cancel(_ challenge: URLAuthenticationChallenge) {}
+        func performDefaultHandling(for challenge: URLAuthenticationChallenge) {}
+        func rejectProtectionSpaceAndContinue(with challenge: URLAuthenticationChallenge) {}
+    }
+
+    private final class SocketDelegateSpy: CocoaMQTTSocketDelegate {
+        private(set) var urlSessionTrustCallCount = 0
+
+        func socketConnected(_ socket: CocoaMQTTSocketProtocol) {}
+        func socket(_ socket: CocoaMQTTSocketProtocol, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void) {}
+        func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {}
+        func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {}
+        func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {}
+
+        func socketUrlSession(
+            _ socket: CocoaMQTTSocketProtocol,
+            didReceiveTrust trust: SecTrust,
+            didReceiveChallenge challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        ) {
+            urlSessionTrustCallCount += 1
+            completionHandler(.cancelAuthenticationChallenge, nil)
+        }
+    }
+
     private final class ConnectionSpy: NSObject, CocoaMQTTWebSocketConnection {
         weak var delegate: CocoaMQTTWebSocketConnectionDelegate?
         var queue = DispatchQueue(label: "tests.websocket-auth.connection")
@@ -54,6 +83,64 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
         XCTAssertEqual(builder.url, URL(string: "wss://example-ats.iot.example.com:443/mqtt"))
         XCTAssertEqual(builder.headers, headers)
         XCTAssertEqual(builder.connection.connectCallCount, 1)
+    }
+
+    func testMissingSocketDelegateQueueUsesSystemTrustHandling() throws {
+        let builder = BuilderSpy()
+        let websocket = CocoaMQTTWebSocket(uri: "/mqtt", builder: builder)
+        let delegate = SocketDelegateSpy()
+        let completed = expectation(description: "challenge completed")
+        websocket.enableSSL = true
+        websocket.setDelegate(delegate, delegateQueue: nil)
+        try websocket.connect(toHost: "broker.example.com", onPort: 443)
+
+        websocket.urlSessionConnection(
+            builder.connection,
+            didReceiveTrust: try makeTrust(),
+            didReceiveChallenge: makeChallenge()
+        ) { disposition, credential in
+            XCTAssertEqual(disposition, .performDefaultHandling)
+            XCTAssertNil(credential)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertEqual(delegate.urlSessionTrustCallCount, 0)
+    }
+
+    private func makeTrust() throws -> SecTrust {
+        #if IS_SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
+        let bundle = Bundle(for: type(of: self))
+        #endif
+        let url = try XCTUnwrap(bundle.url(forResource: "client-keycert", withExtension: "p12"))
+        let data = try Data(contentsOf: url)
+        let options = [kSecImportExportPassphrase as String: "MySecretPassword"] as CFDictionary
+        var importedItems: CFArray?
+
+        XCTAssertEqual(SecPKCS12Import(data as CFData, options, &importedItems), errSecSuccess)
+        let items = try XCTUnwrap(importedItems as? [[String: Any]])
+        let trust = try XCTUnwrap(items.first?[kSecImportItemTrust as String])
+        return trust as! SecTrust
+    }
+
+    private func makeChallenge() -> URLAuthenticationChallenge {
+        let protectionSpace = URLProtectionSpace(
+            host: "broker.example.com",
+            port: 443,
+            protocol: "https",
+            realm: nil,
+            authenticationMethod: NSURLAuthenticationMethodServerTrust
+        )
+        return URLAuthenticationChallenge(
+            protectionSpace: protectionSpace,
+            proposedCredential: nil,
+            previousFailureCount: 0,
+            failureResponse: nil,
+            error: nil,
+            sender: ChallengeSenderStub()
+        )
     }
 }
 

--- a/CocoaMQTTTests/TLSChallengeResolutionTests.swift
+++ b/CocoaMQTTTests/TLSChallengeResolutionTests.swift
@@ -216,6 +216,60 @@ final class TLSChallengeResolutionTests: XCTestCase {
         try assertSystemDefaultChallengeHandling(client: mqtt, socket: socket)
     }
 
+    func testMQTT311URLSessionChallengeCancelsIfClientIsReleasedBeforeCallback() throws {
+        let socket = SocketStub()
+        let trust = try makeTrust()
+        let challenge = makeChallenge()
+        let callbackQueue = DispatchQueue(label: "tests.tls-release-311")
+        let completed = expectation(description: "challenge cancelled")
+        callbackQueue.suspend()
+        var mqtt: CocoaMQTT? = CocoaMQTT(clientID: "tls-release-311", socket: socket)
+        mqtt?.delegateQueue = callbackQueue
+
+        mqtt?.socketUrlSession(
+            socket,
+            didReceiveTrust: trust,
+            didReceiveChallenge: challenge
+        ) { disposition, credential in
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            XCTAssertNil(credential)
+            completed.fulfill()
+        }
+
+        weak let releasedClient = mqtt
+        mqtt = nil
+        XCTAssertNil(releasedClient)
+        callbackQueue.resume()
+        wait(for: [completed], timeout: 1)
+    }
+
+    func testMQTT5URLSessionChallengeCancelsIfClientIsReleasedBeforeCallback() throws {
+        let socket = SocketStub()
+        let trust = try makeTrust()
+        let challenge = makeChallenge()
+        let callbackQueue = DispatchQueue(label: "tests.tls-release-5")
+        let completed = expectation(description: "challenge cancelled")
+        callbackQueue.suspend()
+        var mqtt: CocoaMQTT5? = CocoaMQTT5(clientID: "tls-release-5", socket: socket)
+        mqtt?.delegateQueue = callbackQueue
+
+        mqtt?.socketUrlSession(
+            socket,
+            didReceiveTrust: trust,
+            didReceiveChallenge: challenge
+        ) { disposition, credential in
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            XCTAssertNil(credential)
+            completed.fulfill()
+        }
+
+        weak let releasedClient = mqtt
+        mqtt = nil
+        XCTAssertNil(releasedClient)
+        callbackQueue.resume()
+        wait(for: [completed], timeout: 1)
+    }
+
     func testMQTT311URLSessionChallengeFallsBackToTrustClosure() throws {
         let socket = SocketStub()
         let mqtt = CocoaMQTT(clientID: "tls-closure-311", socket: socket)

--- a/CocoaMQTTTests/TLSChallengeResolutionTests.swift
+++ b/CocoaMQTTTests/TLSChallengeResolutionTests.swift
@@ -1,0 +1,344 @@
+import Foundation
+import Security
+import XCTest
+@testable import CocoaMQTT
+
+final class TLSChallengeResolutionTests: XCTestCase {
+    private final class SocketStub: CocoaMQTTSocketProtocol {
+        var enableSSL = false
+
+        func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
+        func connect(toHost host: String, onPort port: UInt16) throws {}
+        func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
+        func disconnect() {}
+        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
+        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {}
+    }
+
+    private final class ChallengeSenderStub: NSObject, URLAuthenticationChallengeSender {
+        func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+        func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+        func cancel(_ challenge: URLAuthenticationChallenge) {}
+        func performDefaultHandling(for challenge: URLAuthenticationChallenge) {}
+        func rejectProtectionSpaceAndContinue(with challenge: URLAuthenticationChallenge) {}
+    }
+
+    private final class MQTT311DelegateStub: NSObject, CocoaMQTTDelegate {
+        var legacyTrustCallCount = 0
+        var urlSessionTrustCallCount = 0
+
+        func mqtt(_ mqtt: CocoaMQTT, didConnectAck ack: CocoaMQTTConnAck) {}
+        func mqtt(_ mqtt: CocoaMQTT, didPublishMessage message: CocoaMQTTMessage, id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didPublishAck id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didReceiveMessage message: CocoaMQTTMessage, id: UInt16) {}
+        func mqtt(_ mqtt: CocoaMQTT, didSubscribeTopics success: NSDictionary, failed: [String]) {}
+        func mqtt(_ mqtt: CocoaMQTT, didUnsubscribeTopics topics: [String]) {}
+        func mqttDidPing(_ mqtt: CocoaMQTT) {}
+        func mqttDidReceivePong(_ mqtt: CocoaMQTT) {}
+        func mqttDidDisconnect(_ mqtt: CocoaMQTT, withError err: Error?) {}
+
+        func mqtt(
+            _ mqtt: CocoaMQTT,
+            didReceive trust: SecTrust,
+            completionHandler: @escaping (Bool) -> Void
+        ) {
+            legacyTrustCallCount += 1
+            completionHandler(false)
+        }
+
+        func mqttUrlSession(
+            _ mqtt: CocoaMQTT,
+            didReceiveTrust trust: SecTrust,
+            didReceiveChallenge challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping CocoaMQTTTrustHandling.URLSessionCompletion
+        ) {
+            urlSessionTrustCallCount += 1
+            completionHandler(.performDefaultHandling, nil)
+            completionHandler(.cancelAuthenticationChallenge, nil)
+        }
+    }
+
+    func testManualTrustDefaultsToRejecting() {
+        var decisions = [Bool]()
+
+        CocoaMQTTTrustHandling.resolveManualTrust(
+            handler: { _ in false },
+            completionHandler: { decisions.append($0) }
+        )
+
+        XCTAssertEqual(decisions, [false])
+    }
+
+    func testManualTrustHandlerCanCompleteOnlyOnce() {
+        var decisions = [Bool]()
+
+        CocoaMQTTTrustHandling.resolveManualTrust(
+            handler: { completion in
+                completion(true)
+                completion(false)
+                return true
+            },
+            completionHandler: { decisions.append($0) }
+        )
+
+        XCTAssertEqual(decisions, [true])
+    }
+
+    func testURLSessionChallengeDefaultsToSystemValidation() throws {
+        var dispositions = [URLSession.AuthChallengeDisposition]()
+
+        CocoaMQTTTrustHandling.resolveURLSessionChallenge(
+            urlSessionHandler: { _ in false },
+            legacyHandler: { _ in false },
+            legacyCredential: try makeCredential(),
+            completionHandler: { disposition, _ in dispositions.append(disposition) }
+        )
+
+        XCTAssertEqual(dispositions, [.performDefaultHandling])
+    }
+
+    func testURLSessionHandlerTakesPrecedenceOverLegacyHandler() throws {
+        var legacyHandlerCalled = false
+        var dispositions = [URLSession.AuthChallengeDisposition]()
+
+        CocoaMQTTTrustHandling.resolveURLSessionChallenge(
+            urlSessionHandler: { completion in
+                completion(.cancelAuthenticationChallenge, nil)
+                return true
+            },
+            legacyHandler: { _ in
+                legacyHandlerCalled = true
+                return true
+            },
+            legacyCredential: try makeCredential(),
+            completionHandler: { disposition, _ in dispositions.append(disposition) }
+        )
+
+        XCTAssertFalse(legacyHandlerCalled)
+        XCTAssertEqual(dispositions, [.cancelAuthenticationChallenge])
+    }
+
+    func testURLSessionChallengeWaitsForAsynchronousLegacyDecision() throws {
+        var legacyCompletion: ((Bool) -> Void)?
+        var dispositions = [URLSession.AuthChallengeDisposition]()
+
+        CocoaMQTTTrustHandling.resolveURLSessionChallenge(
+            urlSessionHandler: { _ in false },
+            legacyHandler: { completion in
+                legacyCompletion = completion
+                return true
+            },
+            legacyCredential: try makeCredential(),
+            completionHandler: { disposition, _ in dispositions.append(disposition) }
+        )
+
+        XCTAssertTrue(dispositions.isEmpty)
+        try XCTUnwrap(legacyCompletion)(false)
+        XCTAssertEqual(dispositions, [.rejectProtectionSpace])
+    }
+
+    func testURLSessionCompletionIsThreadSafeAndRunsOnce() throws {
+        var challengeCompletion: CocoaMQTTTrustHandling.URLSessionCompletion?
+        let callbackLock = NSLock()
+        var callbackCount = 0
+
+        CocoaMQTTTrustHandling.resolveURLSessionChallenge(
+            urlSessionHandler: { completion in
+                challengeCompletion = completion
+                return true
+            },
+            legacyHandler: { _ in false },
+            legacyCredential: try makeCredential(),
+            completionHandler: { _, _ in
+                callbackLock.lock()
+                callbackCount += 1
+                callbackLock.unlock()
+            }
+        )
+
+        let completion = try XCTUnwrap(challengeCompletion)
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            completion(.performDefaultHandling, nil)
+        }
+
+        XCTAssertEqual(callbackCount, 1)
+    }
+
+    func testMQTT311URLSessionChallengeUsesSystemValidationByDefault() throws {
+        let socket = SocketStub()
+        let mqtt = CocoaMQTT(clientID: "tls-default-311", socket: socket)
+
+        try assertSystemDefaultChallengeHandling(client: mqtt, socket: socket)
+    }
+
+    func testMQTT5URLSessionChallengeUsesSystemValidationByDefault() throws {
+        let socket = SocketStub()
+        let mqtt = CocoaMQTT5(clientID: "tls-default-5", socket: socket)
+
+        try assertSystemDefaultChallengeHandling(client: mqtt, socket: socket)
+    }
+
+    func testMQTT311URLSessionChallengeFallsBackToTrustClosure() throws {
+        let socket = SocketStub()
+        let mqtt = CocoaMQTT(clientID: "tls-closure-311", socket: socket)
+        let trust = try makeTrust()
+        let challenge = makeChallenge()
+        let completed = expectation(description: "challenge completed")
+        var closureCalled = false
+        mqtt.didReceiveTrust = { _, _, completion in
+            closureCalled = true
+            completion(false)
+        }
+
+        mqtt.socketUrlSession(
+            socket,
+            didReceiveTrust: trust,
+            didReceiveChallenge: challenge
+        ) { disposition, _ in
+            XCTAssertEqual(disposition, .rejectProtectionSpace)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertTrue(closureCalled)
+    }
+
+    func testMQTT5URLSessionChallengeFallsBackToTrustClosure() throws {
+        let socket = SocketStub()
+        let mqtt = CocoaMQTT5(clientID: "tls-closure-5", socket: socket)
+        let trust = try makeTrust()
+        let challenge = makeChallenge()
+        let completed = expectation(description: "challenge completed")
+        var closureCalled = false
+        mqtt.didReceiveTrust = { _, _, completion in
+            closureCalled = true
+            completion(true)
+        }
+
+        mqtt.socketUrlSession(
+            socket,
+            didReceiveTrust: trust,
+            didReceiveChallenge: challenge
+        ) { disposition, credential in
+            XCTAssertEqual(disposition, .useCredential)
+            XCTAssertNotNil(credential)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertTrue(closureCalled)
+    }
+
+    func testMQTT311URLSessionDelegateHasExclusivePriorityAndCompletesOnce() throws {
+        let socket = SocketStub()
+        let mqtt = CocoaMQTT(clientID: "tls-priority-311", socket: socket)
+        let delegate = MQTT311DelegateStub()
+        let completed = expectation(description: "challenge completed")
+        var closureCalled = false
+        var completionCount = 0
+        mqtt.delegate = delegate
+        mqtt.didReceiveTrust = { _, _, completion in
+            closureCalled = true
+            completion(true)
+        }
+
+        mqtt.socketUrlSession(
+            socket,
+            didReceiveTrust: try makeTrust(),
+            didReceiveChallenge: makeChallenge()
+        ) { disposition, _ in
+            completionCount += 1
+            XCTAssertEqual(disposition, .performDefaultHandling)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(delegate.urlSessionTrustCallCount, 1)
+        XCTAssertEqual(delegate.legacyTrustCallCount, 0)
+        XCTAssertFalse(closureCalled)
+    }
+
+    func testMQTT311ManualTrustDelegateHasExclusivePriority() throws {
+        let socket = SocketStub()
+        let mqtt = CocoaMQTT(clientID: "tls-manual-priority-311", socket: socket)
+        let delegate = MQTT311DelegateStub()
+        let completed = expectation(description: "trust decision completed")
+        var closureCalled = false
+        var decisions = [Bool]()
+        mqtt.delegate = delegate
+        mqtt.didReceiveTrust = { _, _, completion in
+            closureCalled = true
+            completion(true)
+        }
+
+        mqtt.socket(socket, didReceive: try makeTrust()) { decision in
+            decisions.append(decision)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertEqual(decisions, [false])
+        XCTAssertEqual(delegate.legacyTrustCallCount, 1)
+        XCTAssertFalse(closureCalled)
+    }
+
+    private func assertSystemDefaultChallengeHandling(
+        client: CocoaMQTTSocketDelegate,
+        socket: CocoaMQTTSocketProtocol,
+        line: UInt = #line
+    ) throws {
+        let completed = expectation(description: "challenge completed")
+
+        client.socketUrlSession(
+            socket,
+            didReceiveTrust: try makeTrust(),
+            didReceiveChallenge: makeChallenge()
+        ) { disposition, credential in
+            XCTAssertEqual(disposition, .performDefaultHandling, line: line)
+            XCTAssertNil(credential, line: line)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+    }
+
+    private func makeTrust() throws -> SecTrust {
+        #if IS_SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
+        let bundle = Bundle(for: type(of: self))
+        #endif
+        let url = try XCTUnwrap(bundle.url(forResource: "client-keycert", withExtension: "p12"))
+        let data = try Data(contentsOf: url)
+        let options = [kSecImportExportPassphrase as String: "MySecretPassword"] as CFDictionary
+        var importedItems: CFArray?
+
+        XCTAssertEqual(SecPKCS12Import(data as CFData, options, &importedItems), errSecSuccess)
+        let items = try XCTUnwrap(importedItems as? [[String: Any]])
+        let trust = try XCTUnwrap(items.first?[kSecImportItemTrust as String])
+        return trust as! SecTrust
+    }
+
+    private func makeChallenge() -> URLAuthenticationChallenge {
+        let protectionSpace = URLProtectionSpace(
+            host: "broker.example.com",
+            port: 443,
+            protocol: "https",
+            realm: nil,
+            authenticationMethod: NSURLAuthenticationMethodServerTrust
+        )
+        return URLAuthenticationChallenge(
+            protectionSpace: protectionSpace,
+            proposedCredential: nil,
+            previousFailureCount: 0,
+            failureResponse: nil,
+            error: nil,
+            sender: ChallengeSenderStub()
+        )
+    }
+
+    private func makeCredential() throws -> URLCredential {
+        URLCredential(trust: try makeTrust())
+    }
+}

--- a/CocoaMQTTTests/TLSChallengeResolutionTests.swift
+++ b/CocoaMQTTTests/TLSChallengeResolutionTests.swift
@@ -236,7 +236,7 @@ final class TLSChallengeResolutionTests: XCTestCase {
             completed.fulfill()
         }
 
-        weak let releasedClient = mqtt
+        weak var releasedClient = mqtt
         mqtt = nil
         XCTAssertNil(releasedClient)
         callbackQueue.resume()
@@ -263,7 +263,7 @@ final class TLSChallengeResolutionTests: XCTestCase {
             completed.fulfill()
         }
 
-        weak let releasedClient = mqtt
+        weak var releasedClient = mqtt
         mqtt = nil
         XCTAssertNil(releasedClient)
         callbackQueue.resume()

--- a/CocoaMQTTTests/TLSChallengeResolutionTests.swift
+++ b/CocoaMQTTTests/TLSChallengeResolutionTests.swift
@@ -58,6 +58,44 @@ final class TLSChallengeResolutionTests: XCTestCase {
         }
     }
 
+    private final class MQTT5DelegateStub: NSObject, CocoaMQTT5Delegate {
+        var legacyTrustCallCount = 0
+        var urlSessionTrustCallCount = 0
+
+        func mqtt5(_ mqtt5: CocoaMQTT5, didConnectAck ack: CocoaMQTTCONNACKReasonCode, connAckData: MqttDecodeConnAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishMessage message: CocoaMQTT5Message, id: UInt16) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishAck id: UInt16, pubAckData: MqttDecodePubAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didPublishRec id: UInt16, pubRecData: MqttDecodePubRec?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveMessage message: CocoaMQTT5Message, id: UInt16, publishData: MqttDecodePublish?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didSubscribeTopics success: NSDictionary, failed: [String], subAckData: MqttDecodeSubAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didUnsubscribeTopics topics: [String], unsubAckData: MqttDecodeUnsubAck?) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveDisconnectReasonCode reasonCode: CocoaMQTTDISCONNECTReasonCode) {}
+        func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveAuthReasonCode reasonCode: CocoaMQTTAUTHReasonCode) {}
+        func mqtt5DidPing(_ mqtt5: CocoaMQTT5) {}
+        func mqtt5DidReceivePong(_ mqtt5: CocoaMQTT5) {}
+        func mqtt5DidDisconnect(_ mqtt5: CocoaMQTT5, withError err: Error?) {}
+
+        func mqtt5(
+            _ mqtt5: CocoaMQTT5,
+            didReceive trust: SecTrust,
+            completionHandler: @escaping (Bool) -> Void
+        ) {
+            legacyTrustCallCount += 1
+            completionHandler(false)
+        }
+
+        func mqtt5UrlSession(
+            _ mqtt5: CocoaMQTT5,
+            didReceiveTrust trust: SecTrust,
+            didReceiveChallenge challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping CocoaMQTTTrustHandling.URLSessionCompletion
+        ) {
+            urlSessionTrustCallCount += 1
+            completionHandler(.performDefaultHandling, nil)
+            completionHandler(.cancelAuthenticationChallenge, nil)
+        }
+    }
+
     func testManualTrustDefaultsToRejecting() {
         var decisions = [Bool]()
 
@@ -233,6 +271,36 @@ final class TLSChallengeResolutionTests: XCTestCase {
         let socket = SocketStub()
         let mqtt = CocoaMQTT(clientID: "tls-priority-311", socket: socket)
         let delegate = MQTT311DelegateStub()
+        let completed = expectation(description: "challenge completed")
+        var closureCalled = false
+        var completionCount = 0
+        mqtt.delegate = delegate
+        mqtt.didReceiveTrust = { _, _, completion in
+            closureCalled = true
+            completion(true)
+        }
+
+        mqtt.socketUrlSession(
+            socket,
+            didReceiveTrust: try makeTrust(),
+            didReceiveChallenge: makeChallenge()
+        ) { disposition, _ in
+            completionCount += 1
+            XCTAssertEqual(disposition, .performDefaultHandling)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(delegate.urlSessionTrustCallCount, 1)
+        XCTAssertEqual(delegate.legacyTrustCallCount, 0)
+        XCTAssertFalse(closureCalled)
+    }
+
+    func testMQTT5URLSessionDelegateHasExclusivePriorityAndCompletesOnce() throws {
+        let socket = SocketStub()
+        let mqtt = CocoaMQTT5(clientID: "tls-priority-5", socket: socket)
+        let delegate = MQTT5DelegateStub()
         let completed = expectation(description: "challenge completed")
         var closureCalled = false
         var completionCount = 0

--- a/README.md
+++ b/README.md
@@ -234,26 +234,10 @@ class WebSocketManager {
 }
 
 extension WebSocketManager: CocoaMQTTDelegate {
-    
-    func mqtt(_ mqtt: CocoaMQTT, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void) {
-        // Implement your custom SSL validation logic here.
-        // For example, you might want to always trust the certificate for testing purposes:
-        completionHandler(true)
-    }
-    
-    func mqtt(_ mqtt: CocoaMQTT, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
-            if let serverTrust = challenge.protectionSpace.serverTrust {
-                completionHandler(.useCredential, URLCredential(trust: serverTrust))
-                return
-            }
-        }
-        completionHandler(.performDefaultHandling, nil)
-    }
-    
+
+    // Optional. Omit this method to use the system certificate validation.
     func mqttUrlSession(_ mqtt: CocoaMQTT, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        
-        print("\(#function), \n result:- \(challenge.debugDescription)")
+        completionHandler(.performDefaultHandling, nil)
     }
     
     func mqtt(_ mqtt: CocoaMQTT, didPublishAck id: UInt16) {

--- a/README.md
+++ b/README.md
@@ -235,11 +235,6 @@ class WebSocketManager {
 
 extension WebSocketManager: CocoaMQTTDelegate {
 
-    // Optional. Omit this method to use the system certificate validation.
-    func mqttUrlSession(_ mqtt: CocoaMQTT, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        completionHandler(.performDefaultHandling, nil)
-    }
-    
     func mqtt(_ mqtt: CocoaMQTT, didPublishAck id: UInt16) {
         print("Published message with ID: \(id)")
     }

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -76,9 +76,13 @@ import MqttCocoaAsyncSocket
     /// Manually validate an SSL/TLS server certificate.
     ///
     /// Raw sockets call this when `allowUntrustCACertificate` is enabled.
-    /// WebSockets use it as a fallback when `mqttUrlSession` is not implemented.
+    /// WebSockets use it when `mqttUrlSession` is not implemented. This delegate
+    /// method takes precedence over the `didReceiveTrust` closure.
     @objc optional func mqtt(_ mqtt: CocoaMQTT, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void)
 
+    /// Handle a URLSession server-trust challenge.
+    ///
+    /// This method takes precedence over the legacy trust delegate and closure.
     @objc optional func mqttUrlSession(_ mqtt: CocoaMQTT, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 
     ///
@@ -399,6 +403,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     public var didPing: (CocoaMQTT) -> Void = { _ in }
     public var didReceivePong: (CocoaMQTT) -> Void = { _ in }
     public var didDisconnect: (CocoaMQTT, Error?) -> Void = { _, _ in }
+    /// Trust fallback used when neither trust delegate method is implemented.
     public var didReceiveTrust: (CocoaMQTT, SecTrust, @escaping (Bool) -> Swift.Void) -> Void {
         get { customDidReceiveTrust ?? { _, _, _ in } }
         set { customDidReceiveTrust = newValue }
@@ -886,11 +891,15 @@ extension CocoaMQTT {
 
     func __delegate_queue(
         _ fun: @escaping (CocoaMQTT) -> Void,
-        completionOnEventLoop: ((CocoaMQTT) -> Void)? = nil
+        completionOnEventLoop: ((CocoaMQTT) -> Void)? = nil,
+        onDeallocated: (() -> Void)? = nil
     ) {
         let callbackQueue = delegateQueue
         callbackQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let self = self else {
+                onDeallocated?()
+                return
+            }
             fun(self)
             guard let completionOnEventLoop = completionOnEventLoop else { return }
             self.eventLoopQueue.async { [weak self] in
@@ -992,7 +1001,7 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
 
         printDebug("Call the SSL/TLS manually validating function")
 
-        __delegate_queue { mqtt in
+        __delegate_queue({ mqtt in
             CocoaMQTTTrustHandling.resolveManualTrust(handler: { completion in
                 if mqtt.delegate?.mqtt?(mqtt, didReceive: trust, completionHandler: completion) != nil {
                     return true
@@ -1001,13 +1010,13 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
                 handler(mqtt, trust, completion)
                 return true
             }, completionHandler: completionHandler)
-        }
+        }, onDeallocated: { completionHandler(false) })
     }
 
     public func socketUrlSession(_ socket: CocoaMQTTSocketProtocol, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
 
-        __delegate_queue { mqtt in
+        __delegate_queue({ mqtt in
             CocoaMQTTTrustHandling.resolveURLSessionChallenge(
                 urlSessionHandler: { completion in
                     mqtt.delegate?.mqttUrlSession?(
@@ -1028,7 +1037,7 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
                 legacyCredential: URLCredential(trust: trust),
                 completionHandler: completionHandler
             )
-        }
+        }, onDeallocated: { completionHandler(.cancelAuthenticationChallenge, nil) })
     }
 
     // ?

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -356,9 +356,11 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         set { (self.socket as? CocoaMQTTSocket)?.sslSettings = newValue }
     }
 
-    /// Allow self-signed ca certificate.
+    /// Allow a self-signed CA certificate on the built-in TCP socket.
     ///
-    /// Default is false
+    /// This setting does not apply to `CocoaMQTTWebSocket`. Handle a WebSocket
+    /// trust challenge with `mqttUrlSession` or `didReceiveTrust` instead.
+    /// Default is false.
     public var allowUntrustCACertificate: Bool {
         get { return (self.socket as? CocoaMQTTSocket)?.allowUntrustCACertificate ?? false }
         set { (self.socket as? CocoaMQTTSocket)?.allowUntrustCACertificate = newValue }

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -73,9 +73,10 @@ import MqttCocoaAsyncSocket
     ///
     func mqttDidDisconnect(_ mqtt: CocoaMQTT, withError err: Error?)
 
-    /// Manually validate SSL/TLS server certificate.
+    /// Manually validate an SSL/TLS server certificate.
     ///
-    /// This method will be called if enable  `allowUntrustCACertificate`
+    /// Raw sockets call this when `allowUntrustCACertificate` is enabled.
+    /// WebSockets use it as a fallback when `mqttUrlSession` is not implemented.
     @objc optional func mqtt(_ mqtt: CocoaMQTT, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void)
 
     @objc optional func mqttUrlSession(_ mqtt: CocoaMQTT, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
@@ -396,7 +397,11 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     public var didPing: (CocoaMQTT) -> Void = { _ in }
     public var didReceivePong: (CocoaMQTT) -> Void = { _ in }
     public var didDisconnect: (CocoaMQTT, Error?) -> Void = { _, _ in }
-    public var didReceiveTrust: (CocoaMQTT, SecTrust, @escaping (Bool) -> Swift.Void) -> Void = { _, _, _ in }
+    public var didReceiveTrust: (CocoaMQTT, SecTrust, @escaping (Bool) -> Swift.Void) -> Void {
+        get { customDidReceiveTrust ?? { _, _, _ in } }
+        set { customDidReceiveTrust = newValue }
+    }
+    private var customDidReceiveTrust: ((CocoaMQTT, SecTrust, @escaping (Bool) -> Swift.Void) -> Void)?
     public var didCompletePublish: (CocoaMQTT, UInt16) -> Void = { _, _ in }
     public var didChangeState: (CocoaMQTT, CocoaMQTTConnState) -> Void = { _, _ in }
     public var didScheduleReconnect: (CocoaMQTT, UInt, UInt16) -> Void = { _, _, _ in }
@@ -986,8 +991,14 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         printDebug("Call the SSL/TLS manually validating function")
 
         __delegate_queue { mqtt in
-            mqtt.delegate?.mqtt?(mqtt, didReceive: trust, completionHandler: completionHandler)
-            mqtt.didReceiveTrust(mqtt, trust, completionHandler)
+            CocoaMQTTTrustHandling.resolveManualTrust(handler: { completion in
+                if mqtt.delegate?.mqtt?(mqtt, didReceive: trust, completionHandler: completion) != nil {
+                    return true
+                }
+                guard let handler = mqtt.customDidReceiveTrust else { return false }
+                handler(mqtt, trust, completion)
+                return true
+            }, completionHandler: completionHandler)
         }
     }
 
@@ -995,7 +1006,26 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
 
         __delegate_queue { mqtt in
-            mqtt.delegate?.mqttUrlSession?(mqtt, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
+            CocoaMQTTTrustHandling.resolveURLSessionChallenge(
+                urlSessionHandler: { completion in
+                    mqtt.delegate?.mqttUrlSession?(
+                        mqtt,
+                        didReceiveTrust: trust,
+                        didReceiveChallenge: challenge,
+                        completionHandler: completion
+                    ) != nil
+                },
+                legacyHandler: { completion in
+                    if mqtt.delegate?.mqtt?(mqtt, didReceive: trust, completionHandler: completion) != nil {
+                        return true
+                    }
+                    guard let handler = mqtt.customDidReceiveTrust else { return false }
+                    handler(mqtt, trust, completion)
+                    return true
+                },
+                legacyCredential: URLCredential(trust: trust),
+                completionHandler: completionHandler
+            )
         }
     }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -83,9 +83,13 @@ import MqttCocoaAsyncSocket
     /// Manually validate an SSL/TLS server certificate.
     ///
     /// Raw sockets call this when `allowUntrustCACertificate` is enabled.
-    /// WebSockets use it as a fallback when `mqtt5UrlSession` is not implemented.
+    /// WebSockets use it when `mqtt5UrlSession` is not implemented. This delegate
+    /// method takes precedence over the `didReceiveTrust` closure.
     @objc optional func mqtt5(_ mqtt5: CocoaMQTT5, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void)
 
+    /// Handle a URLSession server-trust challenge.
+    ///
+    /// This method takes precedence over the legacy trust delegate and closure.
     @objc optional func mqtt5UrlSession(_ mqtt: CocoaMQTT5, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 
     ///
@@ -426,6 +430,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     public var didDisconnect: (CocoaMQTT5, Error?) -> Void = { _, _ in }
     public var didDisconnectReasonCode: (CocoaMQTT5, CocoaMQTTDISCONNECTReasonCode) -> Void = { _, _ in }
     public var didAuthReasonCode: (CocoaMQTT5, CocoaMQTTAUTHReasonCode) -> Void = { _, _ in }
+    /// Trust fallback used when neither trust delegate method is implemented.
     public var didReceiveTrust: (CocoaMQTT5, SecTrust, @escaping (Bool) -> Swift.Void) -> Void {
         get { customDidReceiveTrust ?? { _, _, _ in } }
         set { customDidReceiveTrust = newValue }
@@ -1150,11 +1155,15 @@ extension CocoaMQTT5 {
 
     func __delegate_queue(
         _ fun: @escaping (CocoaMQTT5) -> Void,
-        completionOnEventLoop: ((CocoaMQTT5) -> Void)? = nil
+        completionOnEventLoop: ((CocoaMQTT5) -> Void)? = nil,
+        onDeallocated: (() -> Void)? = nil
     ) {
         let callbackQueue = delegateQueue
         callbackQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let self = self else {
+                onDeallocated?()
+                return
+            }
             fun(self)
             guard let completionOnEventLoop = completionOnEventLoop else { return }
             self.eventLoopQueue.async { [weak self] in
@@ -1293,7 +1302,7 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
 
         printDebug("Call the SSL/TLS manually validating function")
 
-        __delegate_queue { mqtt5 in
+        __delegate_queue({ mqtt5 in
             CocoaMQTTTrustHandling.resolveManualTrust(handler: { completion in
                 if mqtt5.delegate?.mqtt5?(mqtt5, didReceive: trust, completionHandler: completion) != nil {
                     return true
@@ -1302,13 +1311,13 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
                 handler(mqtt5, trust, completion)
                 return true
             }, completionHandler: completionHandler)
-        }
+        }, onDeallocated: { completionHandler(false) })
     }
 
     public func socketUrlSession(_ socket: CocoaMQTTSocketProtocol, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
 
-        __delegate_queue { mqtt5 in
+        __delegate_queue({ mqtt5 in
             CocoaMQTTTrustHandling.resolveURLSessionChallenge(
                 urlSessionHandler: { completion in
                     mqtt5.delegate?.mqtt5UrlSession?(
@@ -1329,7 +1338,7 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
                 legacyCredential: URLCredential(trust: trust),
                 completionHandler: completionHandler
             )
-        }
+        }, onDeallocated: { completionHandler(.cancelAuthenticationChallenge, nil) })
     }
 
     // ?

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -80,9 +80,10 @@ import MqttCocoaAsyncSocket
     ///
     func mqtt5DidDisconnect(_ mqtt5: CocoaMQTT5, withError err: Error?)
 
-    /// Manually validate SSL/TLS server certificate.
+    /// Manually validate an SSL/TLS server certificate.
     ///
-    /// This method will be called if enable  `allowUntrustCACertificate`
+    /// Raw sockets call this when `allowUntrustCACertificate` is enabled.
+    /// WebSockets use it as a fallback when `mqtt5UrlSession` is not implemented.
     @objc optional func mqtt5(_ mqtt5: CocoaMQTT5, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void)
 
     @objc optional func mqtt5UrlSession(_ mqtt: CocoaMQTT5, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
@@ -423,7 +424,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     public var didDisconnect: (CocoaMQTT5, Error?) -> Void = { _, _ in }
     public var didDisconnectReasonCode: (CocoaMQTT5, CocoaMQTTDISCONNECTReasonCode) -> Void = { _, _ in }
     public var didAuthReasonCode: (CocoaMQTT5, CocoaMQTTAUTHReasonCode) -> Void = { _, _ in }
-    public var didReceiveTrust: (CocoaMQTT5, SecTrust, @escaping (Bool) -> Swift.Void) -> Void = { _, _, _ in }
+    public var didReceiveTrust: (CocoaMQTT5, SecTrust, @escaping (Bool) -> Swift.Void) -> Void {
+        get { customDidReceiveTrust ?? { _, _, _ in } }
+        set { customDidReceiveTrust = newValue }
+    }
+    private var customDidReceiveTrust: ((CocoaMQTT5, SecTrust, @escaping (Bool) -> Swift.Void) -> Void)?
     public var didCompletePublish: (CocoaMQTT5, UInt16, MqttDecodePubComp?) -> Void = { _, _, _ in }
     public var didChangeState: (CocoaMQTT5, CocoaMQTTConnState) -> Void = { _, _ in }
     public var didScheduleReconnect: (CocoaMQTT5, UInt, UInt16) -> Void = { _, _, _ in }
@@ -1287,8 +1292,14 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         printDebug("Call the SSL/TLS manually validating function")
 
         __delegate_queue { mqtt5 in
-            mqtt5.delegate?.mqtt5?(mqtt5, didReceive: trust, completionHandler: completionHandler)
-            mqtt5.didReceiveTrust(mqtt5, trust, completionHandler)
+            CocoaMQTTTrustHandling.resolveManualTrust(handler: { completion in
+                if mqtt5.delegate?.mqtt5?(mqtt5, didReceive: trust, completionHandler: completion) != nil {
+                    return true
+                }
+                guard let handler = mqtt5.customDidReceiveTrust else { return false }
+                handler(mqtt5, trust, completion)
+                return true
+            }, completionHandler: completionHandler)
         }
     }
 
@@ -1296,7 +1307,26 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
 
         __delegate_queue { mqtt5 in
-            mqtt5.delegate?.mqtt5UrlSession?(mqtt5, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
+            CocoaMQTTTrustHandling.resolveURLSessionChallenge(
+                urlSessionHandler: { completion in
+                    mqtt5.delegate?.mqtt5UrlSession?(
+                        mqtt5,
+                        didReceiveTrust: trust,
+                        didReceiveChallenge: challenge,
+                        completionHandler: completion
+                    ) != nil
+                },
+                legacyHandler: { completion in
+                    if mqtt5.delegate?.mqtt5?(mqtt5, didReceive: trust, completionHandler: completion) != nil {
+                        return true
+                    }
+                    guard let handler = mqtt5.customDidReceiveTrust else { return false }
+                    handler(mqtt5, trust, completion)
+                    return true
+                },
+                legacyCredential: URLCredential(trust: trust),
+                completionHandler: completionHandler
+            )
         }
     }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -388,9 +388,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         set { (self.socket as? CocoaMQTTSocket)?.sslSettings = newValue }
     }
 
-    /// Allow self-signed ca certificate.
+    /// Allow a self-signed CA certificate on the built-in TCP socket.
     ///
-    /// Default is false
+    /// This setting does not apply to `CocoaMQTTWebSocket`. Handle a WebSocket
+    /// trust challenge with `mqtt5UrlSession` or `didReceiveTrust` instead.
+    /// Default is false.
     public var allowUntrustCACertificate: Bool {
         get { return (self.socket as? CocoaMQTTSocket)?.allowUntrustCACertificate ?? false }
         set { (self.socket as? CocoaMQTTSocket)?.allowUntrustCACertificate = newValue }

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -8,6 +8,70 @@
 import Foundation
 import MqttCocoaAsyncSocket
 
+/// Selects one trust callback and prevents competing callbacks from resolving
+/// the same transport challenge more than once.
+enum CocoaMQTTTrustHandling {
+    typealias URLSessionCompletion = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+
+    private final class CompletionOnce<Value> {
+        private let lock = NSLock()
+        private var completion: ((Value) -> Void)?
+
+        init(_ completion: @escaping (Value) -> Void) {
+            self.completion = completion
+        }
+
+        func callAsFunction(_ value: Value) {
+            lock.lock()
+            guard let completion = completion else {
+                lock.unlock()
+                return
+            }
+            self.completion = nil
+            lock.unlock()
+            completion(value)
+        }
+    }
+
+    static func resolveManualTrust(
+        handler: (@escaping (Bool) -> Void) -> Bool,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        let completion = CompletionOnce(completionHandler)
+        if !handler({ completion($0) }) {
+            completion(false)
+        }
+    }
+
+    static func resolveURLSessionChallenge(
+        urlSessionHandler: (@escaping URLSessionCompletion) -> Bool,
+        legacyHandler: (@escaping (Bool) -> Void) -> Bool,
+        legacyCredential: URLCredential,
+        completionHandler: @escaping URLSessionCompletion
+    ) {
+        let completion = CompletionOnce<(URLSession.AuthChallengeDisposition, URLCredential?)> {
+            completionHandler($0.0, $0.1)
+        }
+        let urlSessionCompletion: URLSessionCompletion = {
+            completion(($0, $1))
+        }
+
+        if urlSessionHandler(urlSessionCompletion) {
+            return
+        }
+        if legacyHandler({ accepted in
+            // A legacy `true` is an explicit trust decision, not a request to
+            // repeat the system validation that may already have failed.
+            completion(accepted
+                ? (.useCredential, legacyCredential)
+                : (.rejectProtectionSpace, nil))
+        }) {
+            return
+        }
+        completion((.performDefaultHandling, nil))
+    }
+}
+
 // MARK: - Interfaces
 
 public protocol CocoaMQTTSocketDelegate: AnyObject {

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -285,17 +285,22 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
 
 extension CocoaMQTTWebSocket: CocoaMQTTWebSocketConnectionDelegate {
     public func urlSessionConnection(_ conn: CocoaMQTTWebSocketConnection, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        guard let delegate = delegate, let delegateQueue = delegateQueue else {
+        guard let delegate = delegate else {
             completionHandler(.performDefaultHandling, nil)
             return
         }
-        delegateQueue.async { [self] in
+        let forwardChallenge = { [self] in
             delegate.socketUrlSession(
                 self,
                 didReceiveTrust: trust,
                 didReceiveChallenge: challenge,
                 completionHandler: completionHandler
             )
+        }
+        if let delegateQueue = delegateQueue {
+            delegateQueue.async(execute: forwardChallenge)
+        } else {
+            forwardChallenge()
         }
     }
 

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -400,11 +400,7 @@ extension CocoaMQTTWebSocket.FoundationConnection: URLSessionWebSocketDelegate {
     public func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         queue.async {
             if let trust = challenge.protectionSpace.serverTrust, let delegate = self.delegate {
-                delegate.connection(self, didReceive: trust) { shouldTrust in
-                    completionHandler(shouldTrust ? .performDefaultHandling : .rejectProtectionSpace, nil)
-                }
                 delegate.urlSessionConnection(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
-
             } else {
                 completionHandler(.performDefaultHandling, nil)
             }

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -285,12 +285,17 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
 
 extension CocoaMQTTWebSocket: CocoaMQTTWebSocketConnectionDelegate {
     public func urlSessionConnection(_ conn: CocoaMQTTWebSocketConnection, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        if let del = delegate {
-            __delegate_queue {
-                del.socketUrlSession(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
-            }
-        } else {
+        guard let delegate = delegate, let delegateQueue = delegateQueue else {
             completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        delegateQueue.async { [self] in
+            delegate.socketUrlSession(
+                self,
+                didReceiveTrust: trust,
+                didReceiveChallenge: challenge,
+                completionHandler: completionHandler
+            )
         }
     }
 


### PR DESCRIPTION
## What changed

- route each TLS challenge to exactly one callback, with the URLSession-specific delegate taking precedence over the legacy delegate and closure
- use system certificate validation when no WSS trust callback is installed
- preserve explicit legacy trust decisions by mapping `true` to a server-trust credential and `false` to rejection
- guard transport completions so competing, repeated, or concurrent callbacks can resolve a challenge only once
- apply the same behavior to MQTT 3.1.1 and MQTT 5
- correct the README WSS example so its optional callback always completes
- clarify that `allowUntrustCACertificate` configures the built-in TCP socket, not WSS
- cancel an unresolved challenge if its MQTT client is released before callback delivery

## Reported concern coverage

| Reported concern | Resolution |
| --- | --- |
| No delegate or optional trust method leaves URLSession waiting | Complete with `.performDefaultHandling`; verified for MQTT 3.1.1 and MQTT 5 |
| Valid AWS/nginx/public-broker certificates fail without a manual override | System trust validation is now the default; live MQTT 3.1.1 and MQTT 5 connections to EMQX WSS received successful CONNACKs |
| Legacy `completionHandler(true)` still fails for self-signed/custom trust | `true` now supplies `URLCredential(trust:)`; verified against a local self-signed WSS broker with both MQTT versions; `false` rejects |
| Delegate and closure both complete the same challenge | A fixed precedence selects one owner and a lock-protected gate accepts only the first completion |
| Both URLSession-specific and legacy delegate methods are implemented | URLSession-specific delegate wins; regression-tested for both MQTT versions |
| Handler completes asynchronously | The resolver waits for it; regression-tested |
| Handler completes twice or concurrently | Downstream completion runs once; regression-tested with 100 concurrent attempts |
| WebSocket has a delegate but no delegate queue | Invokes the custom validator synchronously instead of bypassing certificate pinning or dropping the completion |
| MQTT client is released while a trust callback is queued | Completes with cancellation without retaining the client; regression-tested for both MQTT versions |
| `allowUntrustCACertificate` documentation does not match WSS behavior | Documentation now states that it is a built-in TCP setting and points WSS users to the trust callbacks |
| README callback reproduces the missing-completion bug | Removed the invalid and redundant trust callback examples; system validation needs no callback |

A custom trust handler remains an asynchronous API contract: once an application installs one, it must eventually call its completion. Automatically falling back after the handler returns would break legitimate asynchronous certificate evaluation and could override a later rejection.

## Why

The Foundation WebSocket transport could leave URLSession authentication challenges unresolved when applications did not implement a trust callback. It also invoked two callback paths with the same completion handler, creating double-completion races. This caused secure WebSocket connections with valid certificates, including AWS IoT connections, to hang or fail.

## Verification

- `swift test --skip CocoaMQTTTests.CocoaMQTTTests` (209 tests, 1 credential-gated test skipped)
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `xcodebuild -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath /tmp/CocoaMQTT-442-derived build`
- `Tools/lint.sh`
- live MQTT 3.1.1 and MQTT 5 connections over `wss://broker.emqx.io:8084/mqtt` with no trust callback (successful CONNACKs)
- live MQTT 3.1.1 and MQTT 5 connections to a local self-signed WSS broker using the legacy trust closure with `completion(true)` (TLS 1.3 and successful CONNACKs)
- CocoaPods Release Lint and SPM Release Smoke in GitHub Actions

Closes #442
Closes #344
