### PR TITLE
Fix MQTT 5 publish property lifetime

### DIFF
--- a/CocoaMQTTTests/FrameTests.swift
+++ b/CocoaMQTTTests/FrameTests.swift
@@ -229,6 +229,42 @@ class FrameTests: XCTestCase {
         XCTAssertEqual(decoded.subscriptionIdentifiers, [1, 2])
     }
 
+    func testMQTT5PublishRejectsTruncatedUserPropertyWithoutCrashing() {
+        let truncatedProperties: [[UInt8]] = [
+            [CocoaMQTTPropertyName.userProperty.rawValue],
+            [CocoaMQTTPropertyName.userProperty.rawValue, 0x00],
+            [CocoaMQTTPropertyName.userProperty.rawValue, 0x00, 0x02],
+            [CocoaMQTTPropertyName.userProperty.rawValue, 0x00, 0x02, 0x6b],
+            [CocoaMQTTPropertyName.userProperty.rawValue, 0x00, 0x01, 0x6b, 0x00],
+            [CocoaMQTTPropertyName.userProperty.rawValue, 0x00, 0x01, 0x6b, 0x00, 0x02, 0x76]
+        ]
+
+        for properties in truncatedProperties {
+            XCTAssertNil(FramePublish(
+                packetFixedHeaderType: FrameType.publish.rawValue,
+                bytes: [0x00, 0x01, 0x74]
+                    + beVariableByteInteger(length: properties.count)
+                    + properties,
+                protocolVersion: .v5
+            ))
+        }
+    }
+
+    func testMQTT5PublishPropertySnapshotDoesNotRetainMutableProperties() throws {
+        var properties: MqttPublishProperties? = MqttPublishProperties(
+            userProperty: ["key": "value"],
+            contentType: "application/test"
+        )
+        weak var releasedProperties = properties
+        var frame = FramePublish(topic: "t/snapshot", payload: [1], qos: .qos1, msgid: 1)
+
+        frame.snapshotPublishProperties(try XCTUnwrap(properties))
+        properties = nil
+
+        XCTAssertNil(releasedProperties)
+        XCTAssertFalse(frame.properties().isEmpty)
+    }
+
     func testPublicDecodersRejectWrongFixedHeaders() {
         XCTAssertFalse(MqttDecodePublish().decodePublish(
             fixedHeader: FrameType.puback.rawValue,

--- a/CocoaMQTTTests/SendingMessageLifecycleTests.swift
+++ b/CocoaMQTTTests/SendingMessageLifecycleTests.swift
@@ -899,6 +899,53 @@ final class SendingMessageLifecycleTests: XCTestCase {
         XCTAssertEqual(mqtt.t_sendingMessagesCount(), 0)
     }
 
+    func testMQTT5SnapshotsPublishPropertiesBeforeQueuedSend() throws {
+        let socket = SocketSpy()
+        let queue = DispatchQueue(label: "tests.publish-properties-snapshot")
+        let mqtt = CocoaMQTT5(
+            clientID: "publish-properties-snapshot-\(UUID().uuidString)",
+            socket: socket
+        )
+        mqtt.delegateQueue = queue
+        let properties = MqttPublishProperties(
+            responseTopic: "reply/original",
+            correlation: "original",
+            userProperty: ["key": "original"],
+            contentType: "application/original"
+        )
+        var packetIdentifier = -1
+
+        establishSession(
+            mqtt,
+            socket: socket,
+            cleanStart: true,
+            requestedExpiry: 0,
+            preConnackAction: {
+                socket.writes.removeAll()
+                packetIdentifier = mqtt.publish(
+                    CocoaMQTT5Message(topic: "t/snapshot", payload: [1], qos: .qos1),
+                    properties: properties
+                )
+                properties.responseTopic = "reply/mutated"
+                properties.correlationData = Array("mutated".utf8)
+                properties.userProperty = ["key": "mutated"]
+                properties.contentType = "application/mutated"
+            }
+        )
+        queue.sync {}
+
+        XCTAssertGreaterThan(packetIdentifier, 0)
+        let publishData = try XCTUnwrap(socket.writes.first {
+            $0.first.map { $0 & 0xf0 } == FrameType.publish.rawValue
+        })
+        let publish = try XCTUnwrap(mqtt5Publish(from: publishData))
+        let decodedProperties = try XCTUnwrap(publish.publishRecProperties)
+        XCTAssertEqual(decodedProperties.responseTopic, "reply/original")
+        XCTAssertEqual(decodedProperties.correlationData, Array("original".utf8))
+        XCTAssertEqual(decodedProperties.userProperty, ["key": "original"])
+        XCTAssertEqual(decodedProperties.contentType, "application/original")
+    }
+
     func testMQTT5PreConnackPublishAvoidsStoredIdentifierAndSendsAfterRecovery() {
         let socket = SocketSpy()
         let queue = DispatchQueue(label: "tests.pre-connack-recovery")

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -917,7 +917,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
                                  msgid: msgid)
         frame.qos = message.qos
         frame.dup = DUP
-        frame.publishProperties = properties
+        frame.snapshotPublishProperties(properties)
         frame.retained = message.retained
         frame.deliveryToken = deliveryToken
         if message.topic.isEmpty {

--- a/Source/CocoaMQTTDeliver.swift
+++ b/Source/CocoaMQTTDeliver.swift
@@ -162,7 +162,7 @@ class CocoaMQTTDeliver: NSObject {
         let frames = storage.readAll().map { frame -> Frame in
             if var publish = frame as? FramePublish {
                 if let decodedProperties = publish.publishRecProperties {
-                    publish.publishProperties = MqttPublishProperties(recovering: decodedProperties)
+                    publish.snapshotPublishProperties(MqttPublishProperties(recovering: decodedProperties))
                 }
                 publish.dup = true
                 publish.isSessionRecovery = true

--- a/Source/FramePublish.swift
+++ b/Source/FramePublish.swift
@@ -21,6 +21,9 @@ struct FramePublish: Frame {
 
     // 3.3.2.3 PUBLISH Properties
     public var publishProperties: MqttPublishProperties?
+    /// Encoded at the publish boundary so queued and retried frames do not retain
+    /// a caller-owned, mutable properties object.
+    private var publishPropertiesSnapshot: [UInt8]?
     public var publishRecProperties: MqttDecodePublish?
 
     var packetFixedHeaderType: UInt8 = FrameType.publish.rawValue
@@ -87,9 +90,12 @@ extension FramePublish {
     func payload5() -> [UInt8] { return _payload }
 
     func properties() -> [UInt8] {
+        return publishPropertiesSnapshot ?? publishProperties?.properties ?? []
+    }
 
-        // Properties
-        return publishProperties?.properties ?? []
+    mutating func snapshotPublishProperties(_ properties: MqttPublishProperties) {
+        publishPropertiesSnapshot = properties.properties
+        publishProperties = nil
     }
 
     func allData() -> [UInt8] {

--- a/Source/MqttPublishProperties.swift
+++ b/Source/MqttPublishProperties.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+/// Mutable MQTT 5 PUBLISH properties.
+///
+/// CocoaMQTT captures these properties when `publish` is called. Later mutations
+/// affect only subsequent publishes, including when the same instance is reused.
 public class MqttPublishProperties: NSObject {
 
     // 3.3.2.3 PUBLISH Properties


### PR DESCRIPTION
## What changed

- encode MQTT 5 publish properties once at the publish boundary
- keep immutable property bytes in queued, persisted, and retried frames instead of retaining caller-owned mutable properties
- document that later mutations only affect subsequent publishes
- verify the original properties object is released after snapshotting
- add exact truncated User Property coverage for #576; its unsafe parser was already replaced by the bounds-checked MQTTByteReader in 4b2ad94

## Why

A caller can reuse one MqttPublishProperties instance for multiple publishes. Previously queued frames retained that mutable object and encoded it later on another queue, allowing mutation during encoding and causing the crash reported in #600. The byte snapshot uses Array copy-on-write storage across frame copies and retries, while releasing the larger mutable object.

## Verification

- swift test --skip CocoaMQTTTests\\.CocoaMQTTTests/
  - 211 tests, 1 AWS credential test skipped, 0 failures
- Swift 5 targeted regression tests
- Swift 6 core build
- Tools/lint.sh
- Mac Framework xcodebuild
- git diff --check

The broker-dependent CocoaMQTTTests suite requires a local broker and was excluded from the deterministic run.

Closes #600
Closes #576