### PR TITLE
Extract shared MQTT auto-reconnect controller

### DIFF
--- a/CocoaMQTT.xcodeproj/project.pbxproj
+++ b/CocoaMQTT.xcodeproj/project.pbxproj
@@ -159,6 +159,10 @@
 		F0A200000000000000000002 /* MQTT5SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A200000000000000000001 /* MQTT5SessionState.swift */; };
 		F0A200000000000000000003 /* MQTT5SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A200000000000000000001 /* MQTT5SessionState.swift */; };
 		F0A200000000000000000004 /* MQTT5SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A200000000000000000001 /* MQTT5SessionState.swift */; };
+		F0A300000000000000000002 /* MQTTAutoReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300000000000000000001 /* MQTTAutoReconnectController.swift */; };
+		F0A300000000000000000003 /* MQTTAutoReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300000000000000000001 /* MQTTAutoReconnectController.swift */; };
+		F0A300000000000000000004 /* MQTTAutoReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300000000000000000001 /* MQTTAutoReconnectController.swift */; };
+		F0A300000000000000000006 /* MQTTAutoReconnectControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300000000000000000005 /* MQTTAutoReconnectControllerTests.swift */; };
 		A1B2C3D4E5F60718293A0001 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
 		A1B2C3D4E5F60718293A0002 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
 		A1B2C3D4E5F60718293A0003 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
@@ -248,6 +252,8 @@
 		92445BEB2ADFBEA4009D16AB /* ThreadSafeDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafeDictionary.swift; sourceTree = "<group>"; };
 		F0A100000000000000000001 /* MQTTPacketIdentifierAllocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MQTTPacketIdentifierAllocator.swift; sourceTree = "<group>"; };
 		F0A200000000000000000001 /* MQTT5SessionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MQTT5SessionState.swift; sourceTree = "<group>"; };
+		F0A300000000000000000001 /* MQTTAutoReconnectController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MQTTAutoReconnectController.swift; sourceTree = "<group>"; };
+		F0A300000000000000000005 /* MQTTAutoReconnectControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MQTTAutoReconnectControllerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = utilities/ConcurrentAtomic.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0012 /* ConcurrentAtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentAtomicTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0013 /* ThreadSafetyRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafetyRegressionTests.swift; sourceTree = "<group>"; };
@@ -318,6 +324,7 @@
 			children = (
 				8D7A262D23AF2FEA00CE7442 /* client-keycert.p12 */,
 				0409971E1C1B0B96006B5A6D /* CocoaMQTTTests.swift */,
+				F0A300000000000000000005 /* MQTTAutoReconnectControllerTests.swift */,
 				A1B2C3D4E5F60718293A0012 /* ConcurrentAtomicTests.swift */,
 				A1B2C3D4E5F60718293A0014 /* PublicLoggerAPITests.swift */,
 				8D14C7622345CAB5002D959E /* CocoaMQTTDeliverTests.swift */,
@@ -395,6 +402,7 @@
 				92445BEB2ADFBEA4009D16AB /* ThreadSafeDictionary.swift */,
 				F0A100000000000000000001 /* MQTTPacketIdentifierAllocator.swift */,
 				F0A200000000000000000001 /* MQTT5SessionState.swift */,
+				F0A300000000000000000001 /* MQTTAutoReconnectController.swift */,
 				A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */,
 				9228E8C827610A9100063DF2 /* CocoaMQTTReasonCode.swift */,
 				9228E8C427610A8500063DF2 /* CocoaMQTTProperty.swift */,
@@ -640,6 +648,7 @@
 			files = (
 				F0A100000000000000000003 /* MQTTPacketIdentifierAllocator.swift in Sources */,
 				F0A200000000000000000003 /* MQTT5SessionState.swift in Sources */,
+				F0A300000000000000000003 /* MQTTAutoReconnectController.swift in Sources */,
 				1111248E24BB515E00E2DFBC /* CocoaMQTT.swift in Sources */,
 				9228E8CF27610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
 				1111248F24BB515E00E2DFBC /* FrameConnAck.swift in Sources */,
@@ -693,6 +702,7 @@
 			files = (
 				F0A100000000000000000004 /* MQTTPacketIdentifierAllocator.swift in Sources */,
 				F0A200000000000000000004 /* MQTT5SessionState.swift in Sources */,
+				F0A300000000000000000004 /* MQTTAutoReconnectController.swift in Sources */,
 				111124B824BB516300E2DFBC /* CocoaMQTT.swift in Sources */,
 				9228E8D027610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
 				111124B924BB516300E2DFBC /* FrameConnAck.swift in Sources */,
@@ -746,6 +756,7 @@
 			files = (
 				F0A100000000000000000002 /* MQTTPacketIdentifierAllocator.swift in Sources */,
 				F0A200000000000000000002 /* MQTT5SessionState.swift in Sources */,
+				F0A300000000000000000002 /* MQTTAutoReconnectController.swift in Sources */,
 				8225B53A227C2FC600E4DB51 /* CocoaMQTT.swift in Sources */,
 				9228E8CE27610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
 				8D43DE4E22FAEC6700D9A06B /* FrameConnAck.swift in Sources */,
@@ -798,6 +809,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D14C7632345CAB5002D959E /* CocoaMQTTDeliverTests.swift in Sources */,
+				F0A300000000000000000006 /* MQTTAutoReconnectControllerTests.swift in Sources */,
 				8D14C7672349C2A3002D959E /* CocoaMQTTStorageTests.swift in Sources */,
 				8225B556227C334700E4DB51 /* CocoaMQTTTests.swift in Sources */,
 				A1B2C3D4E5F60718293A0004 /* ConcurrentAtomicTests.swift in Sources */,

--- a/CocoaMQTTTests/AutoReconnectStateTests.swift
+++ b/CocoaMQTTTests/AutoReconnectStateTests.swift
@@ -8,9 +8,14 @@ final class AutoReconnectStateTests: XCTestCase {
         var enableSSL: Bool = false
         private let lock = NSLock()
         private(set) weak var delegate: CocoaMQTTSocketDelegate?
+        private var connectFailuresRemaining: Int
         private var _connectCount = 0
         private var _disconnectCount = 0
         private var _writes: [Data] = []
+
+        init(connectFailuresRemaining: Int = 0) {
+            self.connectFailuresRemaining = connectFailuresRemaining
+        }
 
         var connectCount: Int {
             lock.lock()
@@ -35,15 +40,24 @@ final class AutoReconnectStateTests: XCTestCase {
         }
 
         func connect(toHost host: String, onPort port: UInt16) throws {
-            lock.lock()
-            _connectCount += 1
-            lock.unlock()
+            try recordConnect()
         }
 
         func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {
+            try recordConnect()
+        }
+
+        private func recordConnect() throws {
             lock.lock()
             _connectCount += 1
+            let shouldFail = connectFailuresRemaining > 0
+            if shouldFail {
+                connectFailuresRemaining -= 1
+            }
             lock.unlock()
+            if shouldFail {
+                throw CocoaMQTTError.invalidURL
+            }
         }
 
         func disconnect() {
@@ -223,6 +237,38 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
         XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
+    }
+
+    func testCocoaMQTTRetriesWhenReconnectFailsSynchronously() {
+        let socket = SocketSpy(connectFailuresRemaining: 1)
+        let mqtt = CocoaMQTT(clientID: "reconnect-sync-failure-\(UUID().uuidString)", socket: socket)
+        mqtt.delegateQueue = makeDelegateQueue()
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 0
+        mqtt.maxAutoReconnectTimeInterval = 0
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertTrue(waitUntil { socket.connectCount == 2 })
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 2)
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
+    }
+
+    func testCocoaMQTTDisconnectCancelsPendingReconnect() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "disconnect-cancels-reconnect-\(UUID().uuidString)", socket: socket)
+        mqtt.delegateQueue = makeDelegateQueue()
+        mqtt.autoReconnect = true
+        mqtt.autoReconnectTimeInterval = 10
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        XCTAssertTrue(waitUntil { mqtt.reconnectAttemptCount == 1 })
+
+        mqtt.disconnect()
+
+        XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
+        XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
+        XCTAssertFalse(waitUntil(timeout: 0.1) { socket.connectCount > 0 })
     }
 
     func testCocoaMQTTDoesNotScheduleReconnectWhenDisabledInDisconnectCallback() {
@@ -703,6 +749,38 @@ final class AutoReconnectStateTests: XCTestCase {
 
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+    }
+
+    func testCocoaMQTT5RetriesWhenReconnectFailsSynchronously() {
+        let socket = SocketSpy(connectFailuresRemaining: 1)
+        let mqtt5 = CocoaMQTT5(clientID: "reconnect-sync-failure-5-\(UUID().uuidString)", socket: socket)
+        mqtt5.delegateQueue = makeDelegateQueue()
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 0
+        mqtt5.maxAutoReconnectTimeInterval = 0
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        XCTAssertTrue(waitUntil { socket.connectCount == 2 })
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 2)
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
+    }
+
+    func testCocoaMQTT5DisconnectCancelsPendingReconnect() {
+        let socket = SocketSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "disconnect-cancels-reconnect-5-\(UUID().uuidString)", socket: socket)
+        mqtt5.delegateQueue = makeDelegateQueue()
+        mqtt5.autoReconnect = true
+        mqtt5.autoReconnectTimeInterval = 10
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+        XCTAssertTrue(waitUntil { mqtt5.reconnectAttemptCount == 1 })
+
+        mqtt5.disconnect()
+
+        XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
+        XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
+        XCTAssertFalse(waitUntil(timeout: 0.1) { socket.connectCount > 0 })
     }
 
     func testCocoaMQTT5DoesNotScheduleReconnectWhenDisabledInDisconnectCallback() {

--- a/CocoaMQTTTests/AutoReconnectStateTests.swift
+++ b/CocoaMQTTTests/AutoReconnectStateTests.swift
@@ -239,8 +239,8 @@ final class AutoReconnectStateTests: XCTestCase {
         XCTAssertEqual(mqtt.reconnectAttemptCount, 0)
     }
 
-    func testCocoaMQTTRetriesWhenReconnectFailsSynchronously() {
-        let socket = SocketSpy(connectFailuresRemaining: 1)
+    func testCocoaMQTTThrottlesRepeatedSynchronousReconnectFailures() {
+        let socket = SocketSpy(connectFailuresRemaining: 2)
         let mqtt = CocoaMQTT(clientID: "reconnect-sync-failure-\(UUID().uuidString)", socket: socket)
         mqtt.delegateQueue = makeDelegateQueue()
         mqtt.autoReconnect = true
@@ -249,7 +249,9 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt.socketDidDisconnect(socket, withError: nil)
 
-        XCTAssertTrue(waitUntil { socket.connectCount == 2 })
+        XCTAssertTrue(waitUntil { mqtt.reconnectAttemptCount == 2 })
+        XCTAssertEqual(socket.connectCount, 1)
+        XCTAssertFalse(waitUntil(timeout: 0.1) { socket.connectCount > 1 })
         XCTAssertEqual(mqtt.reconnectAttemptCount, 2)
         XCTAssertEqual(mqtt.reconnectTimeInterval, 0)
     }
@@ -790,8 +792,8 @@ final class AutoReconnectStateTests: XCTestCase {
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 0)
     }
 
-    func testCocoaMQTT5RetriesWhenReconnectFailsSynchronously() {
-        let socket = SocketSpy(connectFailuresRemaining: 1)
+    func testCocoaMQTT5ThrottlesRepeatedSynchronousReconnectFailures() {
+        let socket = SocketSpy(connectFailuresRemaining: 2)
         let mqtt5 = CocoaMQTT5(clientID: "reconnect-sync-failure-5-\(UUID().uuidString)", socket: socket)
         mqtt5.delegateQueue = makeDelegateQueue()
         mqtt5.autoReconnect = true
@@ -800,7 +802,9 @@ final class AutoReconnectStateTests: XCTestCase {
 
         mqtt5.socketDidDisconnect(socket, withError: nil)
 
-        XCTAssertTrue(waitUntil { socket.connectCount == 2 })
+        XCTAssertTrue(waitUntil { mqtt5.reconnectAttemptCount == 2 })
+        XCTAssertEqual(socket.connectCount, 1)
+        XCTAssertFalse(waitUntil(timeout: 0.1) { socket.connectCount > 1 })
         XCTAssertEqual(mqtt5.reconnectAttemptCount, 2)
         XCTAssertEqual(mqtt5.reconnectTimeInterval, 0)
     }

--- a/CocoaMQTTTests/AutoReconnectStateTests.swift
+++ b/CocoaMQTTTests/AutoReconnectStateTests.swift
@@ -562,6 +562,45 @@ final class AutoReconnectStateTests: XCTestCase {
         XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
     }
 
+    func testCocoaMQTTResumeBeforeUnexpectedSocketDisconnectPreservesReconnect() {
+        let socket = SocketSpy()
+        let delegate = MQTTDelegateSpy()
+        let mqtt = CocoaMQTT(clientID: "resume-before-disconnect-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt.delegateQueue = delegateQueue
+        mqtt.delegate = delegate
+        mqtt.autoReconnect = true
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        XCTAssertTrue(mqtt.connect())
+        mqtt.eventLoopQueue.sync {}
+        XCTAssertEqual(mqtt.connState, .connecting)
+
+        mqtt.internal_disconnect()
+        mqtt.pauseAutoReconnect()
+        mqtt.resumeAutoReconnect()
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+
+        let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: expectedSchedules,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
+        XCTAssertTrue(waitUntil { socket.connectCount == 2 })
+    }
+
     func testCocoaMQTTResumeInConnackFailureCallbackSchedulesReconnectAfterDisconnectOnce() {
         let socket = SocketSpy()
         let delegate = MQTTDelegateSpy()
@@ -1072,6 +1111,45 @@ final class AutoReconnectStateTests: XCTestCase {
         ))
         XCTAssertTrue(waitUntil { socket.connectCount == 1 })
         XCTAssertFalse(waitUntil(timeout: 1.2) { socket.connectCount > 1 })
+    }
+
+    func testCocoaMQTT5ResumeBeforeUnexpectedSocketDisconnectPreservesReconnect() {
+        let socket = SocketSpy()
+        let delegate = MQTT5DelegateSpy()
+        let mqtt5 = CocoaMQTT5(clientID: "resume-before-disconnect-5-\(UUID().uuidString)", socket: socket)
+        let delegateQueue = makeDelegateQueue()
+        mqtt5.delegateQueue = delegateQueue
+        mqtt5.delegate = delegate
+        mqtt5.autoReconnect = true
+
+        var closureSchedules: [ReconnectSchedule] = []
+        mqtt5.didScheduleReconnect = { _, attemptCount, interval in
+            closureSchedules.append(ReconnectSchedule(attemptCount: attemptCount, interval: interval))
+        }
+
+        XCTAssertTrue(mqtt5.connect())
+        mqtt5.eventLoopQueue.sync {}
+        XCTAssertEqual(mqtt5.connState, .connecting)
+
+        mqtt5.internal_disconnect()
+        mqtt5.pauseAutoReconnect()
+        mqtt5.resumeAutoReconnect()
+        assertNoReconnectSchedules(
+            on: delegateQueue,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        )
+
+        mqtt5.socketDidDisconnect(socket, withError: nil)
+
+        let expectedSchedules = [ReconnectSchedule(attemptCount: 1, interval: 0)]
+        XCTAssertTrue(waitForReconnectSchedules(
+            on: delegateQueue,
+            expected: expectedSchedules,
+            delegateSchedules: { delegate.reconnectSchedules },
+            closureSchedules: { closureSchedules }
+        ))
+        XCTAssertTrue(waitUntil { socket.connectCount == 2 })
     }
 
     func testCocoaMQTT5ResumeInConnackFailureCallbackSchedulesReconnectAfterDisconnectOnce() {

--- a/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
+++ b/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
@@ -174,7 +174,7 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertEqual(scheduler.intervals, [0])
     }
 
-    func testOverlappingDisconnectCallbacksWaitForEveryLifecycle() {
+    func testStaleDisconnectCallbackDoesNotBlockCurrentLifecycle() {
         let eventLoop = DispatchQueue(label: "tests.reconnect-controller.overlapping-disconnects")
         let scheduler = Scheduler()
         let controller = MQTTAutoReconnectController(
@@ -188,13 +188,13 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         controller.isEnabled = true
         let currentContext = controller.socketDidDisconnect()
 
-        XCTAssertNil(controller.completeDisconnectCallbacks(currentContext))
-        XCTAssertTrue(scheduler.tasks.isEmpty)
-
-        let schedule = controller.completeDisconnectCallbacks(staleContext)
+        let schedule = controller.completeDisconnectCallbacks(currentContext)
         XCTAssertEqual(schedule?.attemptCount, 1)
         XCTAssertEqual(schedule?.interval, 1)
         XCTAssertEqual(scheduler.intervals, [1])
+
+        XCTAssertNil(controller.completeDisconnectCallbacks(staleContext))
+        XCTAssertEqual(scheduler.tasks.count, 1)
     }
 
     func testConcurrentDisconnectCallbackCompletionsScheduleOnce() {
@@ -293,5 +293,94 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertNil(controller.completeDisconnectCallbacks(context))
         XCTAssertTrue(scheduler.tasks.isEmpty)
         XCTAssertEqual(controller.reconnectAttemptCount, 0)
+    }
+
+    func testExpectedDisconnectCancelsScheduledReconnect() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.expected-cancels-scheduled")
+        let scheduler = Scheduler()
+        let delegate = Delegate()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.delegate = delegate
+        controller.isEnabled = true
+
+        let context = controller.socketDidDisconnect()
+        XCTAssertNotNil(controller.completeDisconnectCallbacks(context))
+        let scheduledTask = scheduler.tasks[0]
+
+        XCTAssertTrue(controller.beginExpectedDisconnect())
+        XCTAssertTrue(scheduledTask.isCancelled)
+        XCTAssertEqual(controller.reconnectAttemptCount, 0)
+        XCTAssertEqual(controller.reconnectTimeInterval, 0)
+
+        scheduledTask.fire()
+        eventLoop.sync {}
+        XCTAssertEqual(delegate.reconnectCount, 0)
+    }
+
+    func testExpectedDisconnectDiscardsPausedReconnect() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.expected-discards-paused")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.isEnabled = true
+
+        let context = controller.socketDidDisconnect()
+        XCTAssertNotNil(controller.completeDisconnectCallbacks(context))
+        controller.pause()
+
+        XCTAssertTrue(controller.beginExpectedDisconnect())
+        XCTAssertFalse(controller.isPaused)
+        XCTAssertNil(controller.resume(connectionIsDisconnected: true))
+        XCTAssertEqual(scheduler.tasks.count, 1)
+    }
+
+    func testSynchronousReconnectFailureSchedulesNextBackoff() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.synchronous-failure")
+        let scheduler = Scheduler()
+        let delegate = Delegate()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.delegate = delegate
+        controller.isEnabled = true
+
+        let context = controller.socketDidDisconnect()
+        XCTAssertEqual(controller.completeDisconnectCallbacks(context)?.interval, 1)
+        scheduler.tasks[0].fire()
+        eventLoop.sync {}
+
+        let retry = controller.reconnectAttemptFailedToStart()
+        XCTAssertEqual(retry?.attemptCount, 2)
+        XCTAssertEqual(retry?.interval, 2)
+        XCTAssertEqual(scheduler.intervals, [1, 2])
+    }
+
+    func testPauseDuringSynchronousReconnectFailurePreservesRetry() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.paused-synchronous-failure")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.isEnabled = true
+
+        let context = controller.socketDidDisconnect()
+        XCTAssertNotNil(controller.completeDisconnectCallbacks(context))
+        scheduler.tasks[0].fire()
+        eventLoop.sync {}
+
+        controller.pause()
+        XCTAssertNil(controller.reconnectAttemptFailedToStart())
+        let retry = controller.resume(connectionIsDisconnected: true)
+
+        XCTAssertEqual(retry?.attemptCount, 2)
+        XCTAssertEqual(retry?.interval, 0)
+        XCTAssertEqual(scheduler.intervals, [1, 0])
     }
 }

--- a/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
+++ b/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
@@ -44,15 +44,23 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         }
     }
 
+    private final class Delegate: MQTTAutoReconnectControllerDelegate {
+        private(set) var reconnectCount = 0
+
+        func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController) {
+            reconnectCount += 1
+        }
+    }
+
     func testReconnectBackoffIsSharedAndClamped() {
         let eventLoop = DispatchQueue(label: "tests.reconnect-controller.backoff")
         let scheduler = Scheduler()
-        var reconnectCount = 0
+        let delegate = Delegate()
         let controller = MQTTAutoReconnectController(
             eventLoopQueue: eventLoop,
-            scheduler: scheduler,
-            reconnect: { reconnectCount += 1 }
+            scheduler: scheduler
         )
+        controller.delegate = delegate
         controller.isEnabled = true
         controller.autoReconnectTimeInterval = 1
         controller.maxAutoReconnectTimeInterval = 3
@@ -63,7 +71,7 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertEqual(firstSchedule?.interval, 1)
         scheduler.tasks[0].fire()
         eventLoop.sync {}
-        XCTAssertEqual(reconnectCount, 1)
+        XCTAssertEqual(delegate.reconnectCount, 1)
         XCTAssertEqual(controller.reconnectTimeInterval, 2)
 
         let second = controller.socketDidDisconnect()
@@ -72,7 +80,7 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertEqual(secondSchedule?.interval, 2)
         scheduler.tasks[1].fire()
         eventLoop.sync {}
-        XCTAssertEqual(reconnectCount, 2)
+        XCTAssertEqual(delegate.reconnectCount, 2)
         XCTAssertEqual(controller.reconnectTimeInterval, 3)
 
         controller.connectionSucceeded()
@@ -85,8 +93,7 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         let scheduler = Scheduler()
         let controller = MQTTAutoReconnectController(
             eventLoopQueue: eventLoop,
-            scheduler: scheduler,
-            reconnect: {}
+            scheduler: scheduler
         )
         controller.isEnabled = true
 
@@ -103,8 +110,7 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         let scheduler = Scheduler()
         let controller = MQTTAutoReconnectController(
             eventLoopQueue: eventLoop,
-            scheduler: scheduler,
-            reconnect: {}
+            scheduler: scheduler
         )
         controller.isEnabled = true
 
@@ -120,12 +126,12 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
     func testPauseCancelsAttemptAndResumeRunsItImmediately() {
         let eventLoop = DispatchQueue(label: "tests.reconnect-controller.pause")
         let scheduler = Scheduler()
-        var reconnectCount = 0
+        let delegate = Delegate()
         let controller = MQTTAutoReconnectController(
             eventLoopQueue: eventLoop,
-            scheduler: scheduler,
-            reconnect: { reconnectCount += 1 }
+            scheduler: scheduler
         )
+        controller.delegate = delegate
         controller.isEnabled = true
 
         let context = controller.socketDidDisconnect()
@@ -143,7 +149,7 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         scheduler.tasks[1].fire()
         eventLoop.sync {}
 
-        XCTAssertEqual(reconnectCount, 1)
+        XCTAssertEqual(delegate.reconnectCount, 1)
         XCTAssertEqual(controller.reconnectTimeInterval, 2)
     }
 
@@ -152,8 +158,7 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         let scheduler = Scheduler()
         let controller = MQTTAutoReconnectController(
             eventLoopQueue: eventLoop,
-            scheduler: scheduler,
-            reconnect: {}
+            scheduler: scheduler
         )
         controller.isEnabled = true
         controller.beginUnexpectedDisconnect()
@@ -169,13 +174,114 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertEqual(scheduler.intervals, [0])
     }
 
+    func testOverlappingDisconnectCallbacksWaitForEveryLifecycle() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.overlapping-disconnects")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.isEnabled = true
+
+        let staleContext = controller.socketDidDisconnect()
+        controller.isEnabled = false
+        controller.isEnabled = true
+        let currentContext = controller.socketDidDisconnect()
+
+        XCTAssertNil(controller.completeDisconnectCallbacks(currentContext))
+        XCTAssertTrue(scheduler.tasks.isEmpty)
+
+        let schedule = controller.completeDisconnectCallbacks(staleContext)
+        XCTAssertEqual(schedule?.attemptCount, 1)
+        XCTAssertEqual(schedule?.interval, 1)
+        XCTAssertEqual(scheduler.intervals, [1])
+    }
+
+    func testConcurrentDisconnectCallbackCompletionsScheduleOnce() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.concurrent-disconnects")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.isEnabled = true
+        let contexts = [controller.socketDidDisconnect(), controller.socketDidDisconnect()]
+
+        DispatchQueue.concurrentPerform(iterations: contexts.count) { index in
+            _ = controller.completeDisconnectCallbacks(contexts[index])
+        }
+
+        XCTAssertEqual(scheduler.tasks.count, 1)
+        XCTAssertEqual(scheduler.intervals, [1])
+        XCTAssertEqual(controller.reconnectAttemptCount, 1)
+    }
+
+    func testResetDoesNotReviveStaleDisconnectCallback() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.stale-disconnect")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.isEnabled = true
+
+        let staleContext = controller.socketDidDisconnect()
+        controller.isEnabled = false
+        controller.isEnabled = true
+
+        XCTAssertNil(controller.completeDisconnectCallbacks(staleContext))
+        XCTAssertTrue(scheduler.tasks.isEmpty)
+        XCTAssertEqual(controller.reconnectAttemptCount, 0)
+    }
+
+    func testDisconnectCallbackDoesNotScheduleWhileReconnectIsConnecting() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.connecting")
+        let scheduler = Scheduler()
+        let delegate = Delegate()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.delegate = delegate
+        controller.isEnabled = true
+
+        let firstContext = controller.socketDidDisconnect()
+        XCTAssertNotNil(controller.completeDisconnectCallbacks(firstContext))
+        let overlappingContext = controller.socketDidDisconnect()
+
+        scheduler.tasks[0].fire()
+        eventLoop.sync {}
+        XCTAssertEqual(delegate.reconnectCount, 1)
+        XCTAssertNil(controller.completeDisconnectCallbacks(overlappingContext))
+        XCTAssertEqual(scheduler.tasks.count, 1)
+    }
+
+    func testDeinitializingControllerCancelsScheduledTask() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.deinit")
+        let scheduler = Scheduler()
+        var controller: MQTTAutoReconnectController? = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller?.isEnabled = true
+        let context = controller?.socketDidDisconnect()
+        XCTAssertNotNil(context.flatMap { controller?.completeDisconnectCallbacks($0) })
+        let task = scheduler.tasks[0]
+
+        weak var releasedController: MQTTAutoReconnectController?
+        releasedController = controller
+        controller = nil
+
+        XCTAssertNil(releasedController)
+        XCTAssertTrue(task.isCancelled)
+    }
+
     func testExpectedDisconnectNeverSchedulesReconnect() {
         let eventLoop = DispatchQueue(label: "tests.reconnect-controller.expected")
         let scheduler = Scheduler()
         let controller = MQTTAutoReconnectController(
             eventLoopQueue: eventLoop,
-            scheduler: scheduler,
-            reconnect: {}
+            scheduler: scheduler
         )
         controller.isEnabled = true
 

--- a/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
+++ b/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import XCTest
+@testable import CocoaMQTT
+
+final class MQTTAutoReconnectControllerTests: XCTestCase {
+    private final class Task: MQTTReconnectScheduledTask {
+        private let lock = NSLock()
+        private var action: (() -> Void)?
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        var isCancelled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return action == nil
+        }
+
+        func fire() {
+            lock.lock()
+            let pendingAction = action
+            action = nil
+            lock.unlock()
+            pendingAction?()
+        }
+
+        func cancel() {
+            lock.lock()
+            action = nil
+            lock.unlock()
+        }
+    }
+
+    private final class Scheduler: MQTTReconnectScheduling {
+        private(set) var intervals = [TimeInterval]()
+        private(set) var tasks = [Task]()
+
+        func schedule(after interval: TimeInterval, _ action: @escaping () -> Void) -> MQTTReconnectScheduledTask {
+            let task = Task(action: action)
+            intervals.append(interval)
+            tasks.append(task)
+            return task
+        }
+    }
+
+    func testReconnectBackoffIsSharedAndClamped() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.backoff")
+        let scheduler = Scheduler()
+        var reconnectCount = 0
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler,
+            reconnect: { reconnectCount += 1 }
+        )
+        controller.isEnabled = true
+        controller.autoReconnectTimeInterval = 1
+        controller.maxAutoReconnectTimeInterval = 3
+
+        let first = controller.socketDidDisconnect()
+        let firstSchedule = controller.completeDisconnectCallbacks(first)
+        XCTAssertEqual(firstSchedule?.attemptCount, 1)
+        XCTAssertEqual(firstSchedule?.interval, 1)
+        scheduler.tasks[0].fire()
+        eventLoop.sync {}
+        XCTAssertEqual(reconnectCount, 1)
+        XCTAssertEqual(controller.reconnectTimeInterval, 2)
+
+        let second = controller.socketDidDisconnect()
+        let secondSchedule = controller.completeDisconnectCallbacks(second)
+        XCTAssertEqual(secondSchedule?.attemptCount, 2)
+        XCTAssertEqual(secondSchedule?.interval, 2)
+        scheduler.tasks[1].fire()
+        eventLoop.sync {}
+        XCTAssertEqual(reconnectCount, 2)
+        XCTAssertEqual(controller.reconnectTimeInterval, 3)
+
+        controller.connectionSucceeded()
+        XCTAssertEqual(controller.reconnectAttemptCount, 0)
+        XCTAssertEqual(controller.reconnectTimeInterval, 0)
+    }
+
+    func testReconnectWaitsForDisconnectCallbacks() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.callbacks")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler,
+            reconnect: {}
+        )
+        controller.isEnabled = true
+
+        let context = controller.socketDidDisconnect()
+        XCTAssertTrue(scheduler.tasks.isEmpty)
+
+        let schedule = controller.completeDisconnectCallbacks(context)
+        XCTAssertEqual(schedule?.attemptCount, 1)
+        XCTAssertEqual(scheduler.intervals, [1])
+    }
+
+    func testDisablingReconnectDuringDisconnectCallbackInvalidatesAttempt() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.disable")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler,
+            reconnect: {}
+        )
+        controller.isEnabled = true
+
+        let context = controller.socketDidDisconnect()
+        controller.isEnabled = false
+
+        XCTAssertNil(controller.completeDisconnectCallbacks(context))
+        XCTAssertTrue(scheduler.tasks.isEmpty)
+        XCTAssertEqual(controller.reconnectAttemptCount, 0)
+        XCTAssertEqual(controller.reconnectTimeInterval, 0)
+    }
+
+    func testPauseCancelsAttemptAndResumeRunsItImmediately() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.pause")
+        let scheduler = Scheduler()
+        var reconnectCount = 0
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler,
+            reconnect: { reconnectCount += 1 }
+        )
+        controller.isEnabled = true
+
+        let context = controller.socketDidDisconnect()
+        XCTAssertEqual(controller.completeDisconnectCallbacks(context)?.interval, 1)
+        let delayedTask = scheduler.tasks[0]
+
+        controller.pause()
+        XCTAssertTrue(delayedTask.isCancelled)
+        XCTAssertTrue(controller.isPaused)
+
+        let resumed = controller.resume(connectionIsDisconnected: true)
+        XCTAssertEqual(resumed?.attemptCount, 1)
+        XCTAssertEqual(resumed?.interval, 0)
+        XCTAssertEqual(scheduler.intervals, [1, 0])
+        scheduler.tasks[1].fire()
+        eventLoop.sync {}
+
+        XCTAssertEqual(reconnectCount, 1)
+        XCTAssertEqual(controller.reconnectTimeInterval, 2)
+    }
+
+    func testResumeDuringDisconnectCallbacksWaitsForSocketCleanup() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.pending-disconnect")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler,
+            reconnect: {}
+        )
+        controller.isEnabled = true
+        controller.beginUnexpectedDisconnect()
+        let context = controller.socketDidDisconnect()
+
+        controller.pause()
+        XCTAssertNil(controller.resume(connectionIsDisconnected: true))
+        XCTAssertTrue(scheduler.tasks.isEmpty)
+
+        let schedule = controller.completeDisconnectCallbacks(context)
+        XCTAssertEqual(schedule?.attemptCount, 1)
+        XCTAssertEqual(schedule?.interval, 0)
+        XCTAssertEqual(scheduler.intervals, [0])
+    }
+
+    func testExpectedDisconnectNeverSchedulesReconnect() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.expected")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler,
+            reconnect: {}
+        )
+        controller.isEnabled = true
+
+        XCTAssertTrue(controller.beginExpectedDisconnect())
+        XCTAssertFalse(controller.beginExpectedDisconnect())
+        let context = controller.socketDidDisconnect()
+
+        XCTAssertTrue(context.suppressesReconnect)
+        XCTAssertNil(controller.completeDisconnectCallbacks(context))
+        XCTAssertTrue(scheduler.tasks.isEmpty)
+        XCTAssertEqual(controller.reconnectAttemptCount, 0)
+    }
+}

--- a/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
+++ b/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
@@ -174,6 +174,27 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertEqual(scheduler.intervals, [0])
     }
 
+    func testResumeBeforeUnexpectedSocketDisconnectPreservesPendingReconnect() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.resume-before-disconnect")
+        let scheduler = Scheduler()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.isEnabled = true
+        controller.beginUnexpectedDisconnect()
+
+        controller.pause()
+        XCTAssertNil(controller.resume(connectionIsDisconnected: false))
+        XCTAssertTrue(scheduler.tasks.isEmpty)
+
+        let context = controller.socketDidDisconnect()
+        let schedule = controller.completeDisconnectCallbacks(context)
+        XCTAssertEqual(schedule?.attemptCount, 1)
+        XCTAssertEqual(schedule?.interval, 0)
+        XCTAssertEqual(scheduler.intervals, [0])
+    }
+
     func testStaleDisconnectCallbackDoesNotBlockCurrentLifecycle() {
         let eventLoop = DispatchQueue(label: "tests.reconnect-controller.overlapping-disconnects")
         let scheduler = Scheduler()
@@ -234,7 +255,7 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertEqual(controller.reconnectAttemptCount, 0)
     }
 
-    func testDisconnectCallbackDoesNotScheduleWhileReconnectIsConnecting() {
+    func testOverlappingDisconnectWhileConnectingRecoversFromSynchronousFailure() {
         let eventLoop = DispatchQueue(label: "tests.reconnect-controller.connecting")
         let scheduler = Scheduler()
         let delegate = Delegate()
@@ -254,6 +275,11 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertEqual(delegate.reconnectCount, 1)
         XCTAssertNil(controller.completeDisconnectCallbacks(overlappingContext))
         XCTAssertEqual(scheduler.tasks.count, 1)
+
+        let retry = controller.reconnectAttemptFailedToStart()
+        XCTAssertEqual(retry?.attemptCount, 2)
+        XCTAssertEqual(retry?.interval, 2)
+        XCTAssertEqual(scheduler.intervals, [1, 2])
     }
 
     func testDeinitializingControllerCancelsScheduledTask() {
@@ -289,7 +315,6 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertFalse(controller.beginExpectedDisconnect())
         let context = controller.socketDidDisconnect()
 
-        XCTAssertTrue(context.suppressesReconnect)
         XCTAssertNil(controller.completeDisconnectCallbacks(context))
         XCTAssertTrue(scheduler.tasks.isEmpty)
         XCTAssertEqual(controller.reconnectAttemptCount, 0)

--- a/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
+++ b/CocoaMQTTTests/MQTTAutoReconnectControllerTests.swift
@@ -386,6 +386,37 @@ final class MQTTAutoReconnectControllerTests: XCTestCase {
         XCTAssertEqual(scheduler.intervals, [1, 2])
     }
 
+    func testRepeatedSynchronousReconnectFailureUsesMinimumPositiveDelay() {
+        let eventLoop = DispatchQueue(label: "tests.reconnect-controller.repeated-synchronous-failure")
+        let scheduler = Scheduler()
+        let delegate = Delegate()
+        let controller = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+        controller.delegate = delegate
+        controller.autoReconnectTimeInterval = 0
+        controller.maxAutoReconnectTimeInterval = 0
+        controller.isEnabled = true
+
+        let context = controller.socketDidDisconnect()
+        XCTAssertEqual(controller.completeDisconnectCallbacks(context)?.interval, 0)
+        scheduler.tasks[0].fire()
+        eventLoop.sync {}
+
+        let firstRetry = controller.reconnectAttemptFailedToStart()
+        XCTAssertEqual(firstRetry?.attemptCount, 2)
+        XCTAssertEqual(firstRetry?.interval, 1)
+        scheduler.tasks[1].fire()
+        eventLoop.sync {}
+
+        let secondRetry = controller.reconnectAttemptFailedToStart()
+        XCTAssertEqual(secondRetry?.attemptCount, 3)
+        XCTAssertEqual(secondRetry?.interval, 1)
+        XCTAssertEqual(scheduler.intervals, [0, 1, 1])
+        XCTAssertEqual(controller.reconnectTimeInterval, 0)
+    }
+
     func testPauseDuringSynchronousReconnectFailurePreservesRetry() {
         let eventLoop = DispatchQueue(label: "tests.reconnect-controller.paused-synchronous-failure")
         let scheduler = Scheduler()

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -257,86 +257,45 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Enable auto-reconnect mechanism
     public var autoReconnect: Bool {
-        get {
-            autoReconnectLock.lock()
-            defer { autoReconnectLock.unlock() }
-            return _autoReconnect
-        }
-        set {
-            autoReconnectLock.lock()
-            _autoReconnect = newValue
-            autoReconnectLock.unlock()
-            if !newValue { resetAutoReconnectState() }
-        }
+        get { autoReconnectController.isEnabled }
+        set { autoReconnectController.isEnabled = newValue }
     }
-    private var _autoReconnect = false
 
     /// Reconnect time interval
     ///
     /// - note: This value will be increased with `autoReconnectTimeInterval *= 2`
     ///         if reconnect failed
-    public var autoReconnectTimeInterval: UInt16 = 1 // starts from 1 second
+    public var autoReconnectTimeInterval: UInt16 {
+        get { autoReconnectController.autoReconnectTimeInterval }
+        set { autoReconnectController.autoReconnectTimeInterval = newValue }
+    }
 
     /// Maximum auto reconnect time interval
     ///
     /// The timer starts from `autoReconnectTimeInterval` second and grows exponentially until this value
     /// After that, it uses this value for subsequent requests.
-    public var maxAutoReconnectTimeInterval: UInt16 = 128 // 128 seconds
+    public var maxAutoReconnectTimeInterval: UInt16 {
+        get { autoReconnectController.maxAutoReconnectTimeInterval }
+        set { autoReconnectController.maxAutoReconnectTimeInterval = newValue }
+    }
 
     /// Auto-reconnect backoff interval in seconds for the current reconnect cycle.
     ///
     /// This value is advanced for the next reconnect attempt while auto-reconnect is active,
     /// and resets to `0` when auto-reconnect is inactive.
-    public private(set) var reconnectTimeInterval: UInt16 {
-        get {
-            autoReconnectLock.lock()
-            defer { autoReconnectLock.unlock() }
-            return _reconnectTimeInterval
-        }
-        set {
-            autoReconnectLock.lock()
-            _reconnectTimeInterval = newValue
-            autoReconnectLock.unlock()
-        }
-    }
-    private var _reconnectTimeInterval: UInt16 = 0
+    public var reconnectTimeInterval: UInt16 { autoReconnectController.reconnectTimeInterval }
 
     /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.
     ///
     /// The value resets to `0` after a successful connection or expected disconnect.
-    public private(set) var reconnectAttemptCount: UInt {
-        get {
-            autoReconnectLock.lock()
-            defer { autoReconnectLock.unlock() }
-            return _reconnectAttemptCount
-        }
-        set {
-            autoReconnectLock.lock()
-            _reconnectAttemptCount = newValue
-            autoReconnectLock.unlock()
-        }
-    }
-    private var _reconnectAttemptCount: UInt = 0
+    public var reconnectAttemptCount: UInt { autoReconnectController.reconnectAttemptCount }
 
     /// Whether auto-reconnect is currently paused by the application.
     public var isAutoReconnectPaused: Bool {
-        autoReconnectLock.lock()
-        defer { autoReconnectLock.unlock() }
-        return _isAutoReconnectPaused
+        autoReconnectController.isPaused
     }
 
-    private let autoReconnectLock = NSRecursiveLock()
-    private var _isAutoReconnectPaused = false
-    private var autoReconnTimer: CocoaMQTTTimer?
-    private var isAutoReconnectAttemptScheduled = false
-    private var hasPausedAutoReconnectAttempt = false
-    private var hasPendingAutoReconnectAttempt = false
-    private var autoReconnectGeneration: UInt64 = 0
-    // Tracks the window after requesting an unexpected socket close and before socketDidDisconnect cleans it up.
-    private var pendingSocketDisconnectReconnectAttemptCount: UInt?
-    private var shouldResumeAutoReconnectAfterPendingDisconnect = false
-    private var is_internal_disconnected = false
-    private var isExpectedDisconnectPending = false
+    private var autoReconnectController: MQTTAutoReconnectController!
 
     /// Console log level
     public var logLevel: CocoaMQTTLoggerLevel {
@@ -454,6 +413,10 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         self.socket = socket
         self.eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT.event-loop.\(UUID().uuidString)")
         super.init()
+        autoReconnectController = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoopQueue,
+            reconnect: { [weak self] in _ = self?.connect() }
+        )
         socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
         socketDelegateProxy.delegate = self
         deliver.delegate = self
@@ -461,7 +424,6 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     deinit {
         aliveTimer?.suspend()
-        autoReconnTimer?.suspend()
 
         socket.setDelegate(nil, delegateQueue: nil)
         socket.disconnect()
@@ -647,11 +609,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Disconnect unexpectedly.
     /// This keeps auto-reconnect behavior enabled.
     func internal_disconnect() {
-        autoReconnectLock.lock()
-        pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCount
-        autoReconnectLock.unlock()
-
-        is_internal_disconnected = false
+        autoReconnectController.beginUnexpectedDisconnect()
         socket.disconnect()
     }
 
@@ -660,16 +618,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Use this when the application knows reconnect attempts should not run yet,
     /// for example while waiting for network reachability to recover.
     public func pauseAutoReconnect() {
-        autoReconnectLock.lock()
-        _isAutoReconnectPaused = true
-        if isAutoReconnectAttemptScheduled {
-            hasPausedAutoReconnectAttempt = true
-            isAutoReconnectAttemptScheduled = false
-        }
-        shouldResumeAutoReconnectAfterPendingDisconnect = false
-        autoReconnTimer = nil
-        autoReconnectGeneration &+= 1
-        autoReconnectLock.unlock()
+        autoReconnectController.pause()
     }
 
     /// Resume auto-reconnect attempts after `pauseAutoReconnect()`.
@@ -677,54 +626,14 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// If an auto-reconnect attempt is pending, this schedules the next reconnect
     /// attempt immediately.
     public func resumeAutoReconnect() {
-        autoReconnectLock.lock()
-        guard _isAutoReconnectPaused else {
-            autoReconnectLock.unlock()
-            return
-        }
-
-        _isAutoReconnectPaused = false
-
-        guard _autoReconnect, connState == .disconnected else {
-            hasPausedAutoReconnectAttempt = false
-            hasPendingAutoReconnectAttempt = false
-            shouldResumeAutoReconnectAfterPendingDisconnect = false
-            autoReconnectLock.unlock()
-            return
-        }
-
-        if pendingSocketDisconnectReconnectAttemptCount != nil {
-            // Avoid reconnecting before socketDidDisconnect clears the old socket delegate.
-            shouldResumeAutoReconnectAfterPendingDisconnect = true
-            autoReconnectLock.unlock()
-            return
-        }
-
-        guard hasPausedAutoReconnectAttempt || hasPendingAutoReconnectAttempt else {
-            autoReconnectLock.unlock()
-            return
-        }
-
-        if !hasPausedAutoReconnectAttempt {
-            prepareAutoReconnectAttempt()
-        }
-        hasPausedAutoReconnectAttempt = false
-        hasPendingAutoReconnectAttempt = false
-        let schedule = scheduleAutoReconnectAttemptLocked(after: 0)
-        autoReconnectLock.unlock()
-
+        guard let schedule = autoReconnectController.resume(
+            connectionIsDisconnected: connState == .disconnected
+        ) else { return }
         notifyAutoReconnectScheduled(schedule)
     }
 
     private func expected_disconnect() {
-        clientStateLock.lock()
-        guard !isExpectedDisconnectPending else {
-            clientStateLock.unlock()
-            return
-        }
-        isExpectedDisconnectPending = true
-        is_internal_disconnected = true
-        clientStateLock.unlock()
+        guard autoReconnectController.beginExpectedDisconnect() else { return }
         send(FrameDisconnect(), tag: -0xE0, disconnectAfterWriting: true)
     }
 
@@ -936,79 +845,12 @@ extension CocoaMQTT {
         }
     }
 
-    private func prepareAutoReconnectAttempt() {
-        if reconnectTimeInterval == 0 {
-            reconnectTimeInterval = min(autoReconnectTimeInterval, maxAutoReconnectTimeInterval)
-        }
-        reconnectAttemptCount += 1
-    }
-
-    private func updateAutoReconnectIntervalForNextAttempt() {
-        let doubledInterval = UInt32(reconnectTimeInterval) * 2
-        reconnectTimeInterval = UInt16(min(doubledInterval, UInt32(maxAutoReconnectTimeInterval)))
-    }
-
-    private func resetAutoReconnectState() {
-        autoReconnectLock.lock()
-        reconnectTimeInterval = 0
-        reconnectAttemptCount = 0
-        _isAutoReconnectPaused = false
-        autoReconnTimer = nil
-        isAutoReconnectAttemptScheduled = false
-        hasPausedAutoReconnectAttempt = false
-        hasPendingAutoReconnectAttempt = false
-        pendingSocketDisconnectReconnectAttemptCount = nil
-        shouldResumeAutoReconnectAfterPendingDisconnect = false
-        autoReconnectGeneration &+= 1
-        autoReconnectLock.unlock()
-    }
-
     private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
         __delegate_queue { mqtt in
-            mqtt.autoReconnectLock.lock()
-            let isCurrent = mqtt._autoReconnect && mqtt.autoReconnectGeneration == schedule.generation
-            mqtt.autoReconnectLock.unlock()
-            guard isCurrent else { return }
+            guard mqtt.autoReconnectController.isCurrent(schedule) else { return }
             mqtt.delegate?.mqtt?(mqtt, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
             mqtt.didScheduleReconnect(mqtt, schedule.attemptCount, schedule.interval)
         }
-    }
-
-    private func scheduleAutoReconnectAttemptLocked(after interval: UInt16? = nil) -> CocoaMQTTAutoReconnectSchedule {
-        let delay = interval ?? reconnectTimeInterval
-
-        printInfo("Try reconnect to server after \(delay)s")
-        isAutoReconnectAttemptScheduled = true
-        autoReconnectGeneration &+= 1
-        let generation = autoReconnectGeneration
-        autoReconnTimer = CocoaMQTTTimer.after(Double(delay), name: "autoReconnTimer", { [weak self] in
-            self?.eventLoopQueue.async { [weak self] in
-                guard let self = self,
-                      self.prepareScheduledAutoReconnectFire(generation: generation) else { return }
-                _ = self.connect()
-            }
-        })
-
-        return CocoaMQTTAutoReconnectSchedule(
-            attemptCount: reconnectAttemptCount,
-            interval: delay,
-            generation: generation
-        )
-    }
-
-    private func prepareScheduledAutoReconnectFire(generation: UInt64) -> Bool {
-        autoReconnectLock.lock()
-        defer { autoReconnectLock.unlock() }
-
-        guard autoReconnectGeneration == generation else { return false }
-        guard _autoReconnect, !_isAutoReconnectPaused else {
-            isAutoReconnectAttemptScheduled = false
-            return false
-        }
-
-        isAutoReconnectAttemptScheduled = false
-        updateAutoReconnectIntervalForNextAttempt()
-        return true
     }
 }
 
@@ -1016,9 +858,7 @@ extension CocoaMQTT {
 extension CocoaMQTT: CocoaMQTTSocketDelegate {
 
     public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
-        clientStateLock.lock()
-        isExpectedDisconnectPending = false
-        clientStateLock.unlock()
+        autoReconnectController.socketConnected()
         sendConnectFrame()
     }
 
@@ -1099,7 +939,6 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
         clientStateLock.lock()
-        isExpectedDisconnectPending = false
         // Publish uses the same lock, so queue admission cannot race with the
         // transition from the disconnected session to the next connection.
         deliver.beginConnection()
@@ -1115,61 +954,19 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
             discardInMemorySession(preservingConnectionQueue: true)
         }
         clientStateLock.unlock()
-        if is_internal_disconnected || !autoReconnect {
-            resetAutoReconnectState()
-        }
+        let reconnectContext = autoReconnectController.socketDidDisconnect()
 
         connState = .disconnected
-        autoReconnectLock.lock()
-        let reconnectAttemptCountBeforeCallbacks = pendingSocketDisconnectReconnectAttemptCount ?? reconnectAttemptCount
-        if !is_internal_disconnected && _autoReconnect {
-            pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCountBeforeCallbacks
-        }
-        autoReconnectLock.unlock()
         __delegate_queue({ mqtt in
             mqtt.delegate?.mqttDidDisconnect(mqtt, withError: err)
             mqtt.didDisconnect(mqtt, err)
         }, completionOnEventLoop: { mqtt in
-            mqtt.continueAfterDisconnectCallbacks(reconnectAttemptCountBeforeCallbacks)
+            mqtt.continueAfterDisconnectCallbacks(reconnectContext)
         })
     }
 
-    private func continueAfterDisconnectCallbacks(_ reconnectAttemptCountBeforeCallbacks: UInt) {
-        guard !is_internal_disconnected else {
-            is_internal_disconnected = false
-            return
-        }
-
-        guard autoReconnect else {
-            resetAutoReconnectState()
-            return
-        }
-
-        autoReconnectLock.lock()
-        pendingSocketDisconnectReconnectAttemptCount = nil
-        guard !_isAutoReconnectPaused,
-              !isAutoReconnectAttemptScheduled,
-              reconnectAttemptCount == reconnectAttemptCountBeforeCallbacks else {
-            if _isAutoReconnectPaused,
-               !isAutoReconnectAttemptScheduled,
-               reconnectAttemptCount == reconnectAttemptCountBeforeCallbacks {
-                hasPendingAutoReconnectAttempt = true
-            }
-            shouldResumeAutoReconnectAfterPendingDisconnect = false
-            autoReconnectLock.unlock()
-            return
-        }
-
-        let shouldResumeAfterPendingDisconnect = shouldResumeAutoReconnectAfterPendingDisconnect
-        shouldResumeAutoReconnectAfterPendingDisconnect = false
-        if !hasPausedAutoReconnectAttempt {
-            prepareAutoReconnectAttempt()
-        }
-        hasPausedAutoReconnectAttempt = false
-        hasPendingAutoReconnectAttempt = false
-        let schedule = scheduleAutoReconnectAttemptLocked(after: shouldResumeAfterPendingDisconnect ? 0 : nil)
-        autoReconnectLock.unlock()
-
+    private func continueAfterDisconnectCallbacks(_ context: MQTTAutoReconnectDisconnectContext) {
+        guard let schedule = autoReconnectController.completeDisconnectCallbacks(context) else { return }
         notifyAutoReconnectScheduled(schedule)
     }
 }
@@ -1184,8 +981,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
             // Disable auto-reconnect
 
-            resetAutoReconnectState()
-            is_internal_disconnected = false
+            autoReconnectController.connectionSucceeded()
 
             // Start keepalive timer
 

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -855,7 +855,9 @@ extension CocoaMQTT {
 
 extension CocoaMQTT: MQTTAutoReconnectControllerDelegate {
     func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController) {
-        _ = connect()
+        guard !connect(),
+              let schedule = controller.reconnectAttemptFailedToStart() else { return }
+        notifyAutoReconnectScheduled(schedule)
     }
 }
 

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -295,7 +295,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         autoReconnectController.isPaused
     }
 
-    private var autoReconnectController: MQTTAutoReconnectController!
+    private let autoReconnectController: MQTTAutoReconnectController
 
     /// Console log level
     public var logLevel: CocoaMQTTLoggerLevel {
@@ -411,12 +411,11 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         self.host = host
         self.port = port
         self.socket = socket
-        self.eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT.event-loop.\(UUID().uuidString)")
+        let eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT.event-loop.\(UUID().uuidString)")
+        self.eventLoopQueue = eventLoopQueue
+        self.autoReconnectController = MQTTAutoReconnectController(eventLoopQueue: eventLoopQueue)
         super.init()
-        autoReconnectController = MQTTAutoReconnectController(
-            eventLoopQueue: eventLoopQueue,
-            reconnect: { [weak self] in _ = self?.connect() }
-        )
+        autoReconnectController.delegate = self
         socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
         socketDelegateProxy.delegate = self
         deliver.delegate = self
@@ -851,6 +850,12 @@ extension CocoaMQTT {
             mqtt.delegate?.mqtt?(mqtt, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
             mqtt.didScheduleReconnect(mqtt, schedule.attemptCount, schedule.interval)
         }
+    }
+}
+
+extension CocoaMQTT: MQTTAutoReconnectControllerDelegate {
+    func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController) {
+        _ = connect()
     }
 }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -1155,7 +1155,9 @@ extension CocoaMQTT5 {
 
 extension CocoaMQTT5: MQTTAutoReconnectControllerDelegate {
     func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController) {
-        _ = connect()
+        guard !connect(),
+              let schedule = controller.reconnectAttemptFailedToStart() else { return }
+        notifyAutoReconnectScheduled(schedule)
     }
 }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -250,31 +250,27 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Enable auto-reconnect mechanism
     public var autoReconnect: Bool {
-        get {
-            autoReconnectLock.lock()
-            defer { autoReconnectLock.unlock() }
-            return _autoReconnect
-        }
-        set {
-            autoReconnectLock.lock()
-            _autoReconnect = newValue
-            autoReconnectLock.unlock()
-            if !newValue { resetAutoReconnectState() }
-        }
+        get { autoReconnectController.isEnabled }
+        set { autoReconnectController.isEnabled = newValue }
     }
-    private var _autoReconnect = false
 
     /// Reconnect time interval
     ///
     /// - note: This value will be increased with `autoReconnectTimeInterval *= 2`
     ///         if reconnect failed
-    public var autoReconnectTimeInterval: UInt16 = 1 // starts from 1 second
+    public var autoReconnectTimeInterval: UInt16 {
+        get { autoReconnectController.autoReconnectTimeInterval }
+        set { autoReconnectController.autoReconnectTimeInterval = newValue }
+    }
 
     /// Maximum auto reconnect time interval
     ///
     /// The timer starts from `autoReconnectTimeInterval` second and grows exponentially until this value
     /// After that, it uses this value for subsequent requests.
-    public var maxAutoReconnectTimeInterval: UInt16 = 128 // 128 seconds
+    public var maxAutoReconnectTimeInterval: UInt16 {
+        get { autoReconnectController.maxAutoReconnectTimeInterval }
+        set { autoReconnectController.maxAutoReconnectTimeInterval = newValue }
+    }
 
     /// 3.1.2.11 CONNECT Properties
     public var connectProperties: MqttConnectProperties?
@@ -286,56 +282,19 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     ///
     /// This value is advanced for the next reconnect attempt while auto-reconnect is active,
     /// and resets to `0` when auto-reconnect is inactive.
-    public private(set) var reconnectTimeInterval: UInt16 {
-        get {
-            autoReconnectLock.lock()
-            defer { autoReconnectLock.unlock() }
-            return _reconnectTimeInterval
-        }
-        set {
-            autoReconnectLock.lock()
-            _reconnectTimeInterval = newValue
-            autoReconnectLock.unlock()
-        }
-    }
-    private var _reconnectTimeInterval: UInt16 = 0
+    public var reconnectTimeInterval: UInt16 { autoReconnectController.reconnectTimeInterval }
 
     /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.
     ///
     /// The value resets to `0` after a successful connection or expected disconnect.
-    public private(set) var reconnectAttemptCount: UInt {
-        get {
-            autoReconnectLock.lock()
-            defer { autoReconnectLock.unlock() }
-            return _reconnectAttemptCount
-        }
-        set {
-            autoReconnectLock.lock()
-            _reconnectAttemptCount = newValue
-            autoReconnectLock.unlock()
-        }
-    }
-    private var _reconnectAttemptCount: UInt = 0
+    public var reconnectAttemptCount: UInt { autoReconnectController.reconnectAttemptCount }
 
     /// Whether auto-reconnect is currently paused by the application.
     public var isAutoReconnectPaused: Bool {
-        autoReconnectLock.lock()
-        defer { autoReconnectLock.unlock() }
-        return _isAutoReconnectPaused
+        autoReconnectController.isPaused
     }
 
-    private let autoReconnectLock = NSRecursiveLock()
-    private var _isAutoReconnectPaused = false
-    private var autoReconnTimer: CocoaMQTTTimer?
-    private var isAutoReconnectAttemptScheduled = false
-    private var hasPausedAutoReconnectAttempt = false
-    private var hasPendingAutoReconnectAttempt = false
-    private var autoReconnectGeneration: UInt64 = 0
-    // Tracks the window after requesting an unexpected socket close and before socketDidDisconnect cleans it up.
-    private var pendingSocketDisconnectReconnectAttemptCount: UInt?
-    private var shouldResumeAutoReconnectAfterPendingDisconnect = false
-    private var is_internal_disconnected = false
-    private var isExpectedDisconnectPending = false
+    private var autoReconnectController: MQTTAutoReconnectController!
     private let disconnectReasonLock = NSLock()
     private var pendingLocalDisconnectReasonCode: CocoaMQTTDISCONNECTReasonCode?
     private var _lastDisconnectReason: CocoaMQTT5DisconnectReason?
@@ -481,6 +440,10 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         self.socket = socket
         self.eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT5.event-loop.\(UUID().uuidString)")
         super.init()
+        autoReconnectController = MQTTAutoReconnectController(
+            eventLoopQueue: eventLoopQueue,
+            reconnect: { [weak self] in _ = self?.connect() }
+        )
         socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
         socketDelegateProxy.delegate = self
         $connState.setMutationObserver { [weak self] state in
@@ -497,7 +460,6 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     deinit {
         aliveTimer?.suspend()
-        autoReconnTimer?.suspend()
         sessionExpiryController?.handleDisconnect()
         socket.setDelegate(nil, delegateQueue: nil)
         socket.disconnect()
@@ -767,11 +729,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Disconnect unexpectedly.
     /// This keeps auto-reconnect behavior enabled.
     func internal_disconnect() {
-        autoReconnectLock.lock()
-        pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCount
-        autoReconnectLock.unlock()
-
-        is_internal_disconnected = false
+        autoReconnectController.beginUnexpectedDisconnect()
         socket.disconnect()
     }
 
@@ -780,16 +738,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Use this when the application knows reconnect attempts should not run yet,
     /// for example while waiting for network reachability to recover.
     public func pauseAutoReconnect() {
-        autoReconnectLock.lock()
-        _isAutoReconnectPaused = true
-        if isAutoReconnectAttemptScheduled {
-            hasPausedAutoReconnectAttempt = true
-            isAutoReconnectAttemptScheduled = false
-        }
-        shouldResumeAutoReconnectAfterPendingDisconnect = false
-        autoReconnTimer = nil
-        autoReconnectGeneration &+= 1
-        autoReconnectLock.unlock()
+        autoReconnectController.pause()
     }
 
     /// Resume auto-reconnect attempts after `pauseAutoReconnect()`.
@@ -797,42 +746,9 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// If an auto-reconnect attempt is pending, this schedules the next reconnect
     /// attempt immediately.
     public func resumeAutoReconnect() {
-        autoReconnectLock.lock()
-        guard _isAutoReconnectPaused else {
-            autoReconnectLock.unlock()
-            return
-        }
-
-        _isAutoReconnectPaused = false
-
-        guard _autoReconnect, connState == .disconnected else {
-            hasPausedAutoReconnectAttempt = false
-            hasPendingAutoReconnectAttempt = false
-            shouldResumeAutoReconnectAfterPendingDisconnect = false
-            autoReconnectLock.unlock()
-            return
-        }
-
-        if pendingSocketDisconnectReconnectAttemptCount != nil {
-            // Avoid reconnecting before socketDidDisconnect clears the old socket delegate.
-            shouldResumeAutoReconnectAfterPendingDisconnect = true
-            autoReconnectLock.unlock()
-            return
-        }
-
-        guard hasPausedAutoReconnectAttempt || hasPendingAutoReconnectAttempt else {
-            autoReconnectLock.unlock()
-            return
-        }
-
-        if !hasPausedAutoReconnectAttempt {
-            prepareAutoReconnectAttempt()
-        }
-        hasPausedAutoReconnectAttempt = false
-        hasPendingAutoReconnectAttempt = false
-        let schedule = scheduleAutoReconnectAttemptLocked(after: 0)
-        autoReconnectLock.unlock()
-
+        guard let schedule = autoReconnectController.resume(
+            connectionIsDisconnected: connState == .disconnected
+        ) else { return }
         notifyAutoReconnectScheduled(schedule)
     }
 
@@ -843,14 +759,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     private func expected_disconnect(reasonCode: CocoaMQTTDISCONNECTReasonCode,
                                      userProperties: [String: String]? = nil,
                                      recordsLocalReason: Bool = false) {
-        clientStateLock.lock()
-        guard !isExpectedDisconnectPending else {
-            clientStateLock.unlock()
-            return
-        }
-        isExpectedDisconnectPending = true
-        is_internal_disconnected = true
-        clientStateLock.unlock()
+        guard autoReconnectController.beginExpectedDisconnect() else { return }
         if recordsLocalReason {
             markPendingLocalDisconnect(reasonCode: reasonCode)
         }
@@ -1200,81 +1109,13 @@ extension CocoaMQTT5 {
         }
     }
 
-    private func prepareAutoReconnectAttempt() {
-        if reconnectTimeInterval == 0 {
-            reconnectTimeInterval = min(autoReconnectTimeInterval, maxAutoReconnectTimeInterval)
-        }
-        reconnectAttemptCount += 1
-    }
-
-    private func updateAutoReconnectIntervalForNextAttempt() {
-        let doubledInterval = UInt32(reconnectTimeInterval) * 2
-        reconnectTimeInterval = UInt16(min(doubledInterval, UInt32(maxAutoReconnectTimeInterval)))
-    }
-
-    private func resetAutoReconnectState() {
-        autoReconnectLock.lock()
-        reconnectTimeInterval = 0
-        reconnectAttemptCount = 0
-        _isAutoReconnectPaused = false
-        autoReconnTimer = nil
-        isAutoReconnectAttemptScheduled = false
-        hasPausedAutoReconnectAttempt = false
-        hasPendingAutoReconnectAttempt = false
-        pendingSocketDisconnectReconnectAttemptCount = nil
-        shouldResumeAutoReconnectAfterPendingDisconnect = false
-        autoReconnectGeneration &+= 1
-        autoReconnectLock.unlock()
-    }
-
     private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
         __delegate_queue { mqtt5 in
-            mqtt5.autoReconnectLock.lock()
-            let isCurrent = mqtt5._autoReconnect && mqtt5.autoReconnectGeneration == schedule.generation
-            mqtt5.autoReconnectLock.unlock()
-            guard isCurrent else { return }
+            guard mqtt5.autoReconnectController.isCurrent(schedule) else { return }
             mqtt5.delegate?.mqtt5?(mqtt5, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
             mqtt5.didScheduleReconnect(mqtt5, schedule.attemptCount, schedule.interval)
         }
     }
-
-    private func scheduleAutoReconnectAttemptLocked(after interval: UInt16? = nil) -> CocoaMQTTAutoReconnectSchedule {
-        let delay = interval ?? reconnectTimeInterval
-
-        printInfo("Try reconnect to server after \(delay)s")
-        isAutoReconnectAttemptScheduled = true
-        autoReconnectGeneration &+= 1
-        let generation = autoReconnectGeneration
-        autoReconnTimer = CocoaMQTTTimer.after(Double(delay), name: "autoReconnTimer", { [weak self] in
-            self?.eventLoopQueue.async { [weak self] in
-                guard let self = self,
-                      self.prepareScheduledAutoReconnectFire(generation: generation) else { return }
-                _ = self.connect()
-            }
-        })
-
-        return CocoaMQTTAutoReconnectSchedule(
-            attemptCount: reconnectAttemptCount,
-            interval: delay,
-            generation: generation
-        )
-    }
-
-    private func prepareScheduledAutoReconnectFire(generation: UInt64) -> Bool {
-        autoReconnectLock.lock()
-        defer { autoReconnectLock.unlock() }
-
-        guard autoReconnectGeneration == generation else { return false }
-        guard _autoReconnect, !_isAutoReconnectPaused else {
-            isAutoReconnectAttemptScheduled = false
-            return false
-        }
-
-        isAutoReconnectAttemptScheduled = false
-        updateAutoReconnectIntervalForNextAttempt()
-        return true
-    }
-
     private func resetDisconnectReasonState() {
         disconnectReasonLock.lock()
         pendingLocalDisconnectReasonCode = nil
@@ -1317,9 +1158,7 @@ extension CocoaMQTT5 {
 extension CocoaMQTT5: CocoaMQTTSocketDelegate {
 
     public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
-        clientStateLock.lock()
-        isExpectedDisconnectPending = false
-        clientStateLock.unlock()
+        autoReconnectController.socketConnected()
         sendConnectFrame()
     }
 
@@ -1400,7 +1239,6 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         // Clean up
         socket.setDelegate(nil, delegateQueue: nil)
         clientStateLock.lock()
-        isExpectedDisconnectPending = false
         // Publish uses the same lock, so no frame can enter the new connection
         // queue while it still observes aliases or limits from the old one.
         deliver.beginConnection()
@@ -1417,62 +1255,19 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         clientStateLock.unlock()
         sessionExpiryController?.handleDisconnect()
         updateDisconnectReasonAfterSocketDisconnect(error: err)
-        if is_internal_disconnected || !autoReconnect {
-            resetAutoReconnectState()
-        }
+        let reconnectContext = autoReconnectController.socketDidDisconnect()
 
         connState = .disconnected
-        autoReconnectLock.lock()
-        let reconnectAttemptCountBeforeCallbacks = pendingSocketDisconnectReconnectAttemptCount ?? reconnectAttemptCount
-        if !is_internal_disconnected && _autoReconnect {
-            pendingSocketDisconnectReconnectAttemptCount = reconnectAttemptCountBeforeCallbacks
-        }
-        autoReconnectLock.unlock()
-
         __delegate_queue({ mqtt5 in
             mqtt5.delegate?.mqtt5DidDisconnect(mqtt5, withError: err)
             mqtt5.didDisconnect(mqtt5, err)
         }, completionOnEventLoop: { mqtt5 in
-            mqtt5.continueAfterDisconnectCallbacks(reconnectAttemptCountBeforeCallbacks)
+            mqtt5.continueAfterDisconnectCallbacks(reconnectContext)
         })
     }
 
-    private func continueAfterDisconnectCallbacks(_ reconnectAttemptCountBeforeCallbacks: UInt) {
-        guard !is_internal_disconnected else {
-            is_internal_disconnected = false
-            return
-        }
-
-        guard autoReconnect else {
-            resetAutoReconnectState()
-            return
-        }
-
-        autoReconnectLock.lock()
-        pendingSocketDisconnectReconnectAttemptCount = nil
-        guard !_isAutoReconnectPaused,
-              !isAutoReconnectAttemptScheduled,
-              reconnectAttemptCount == reconnectAttemptCountBeforeCallbacks else {
-            if _isAutoReconnectPaused,
-               !isAutoReconnectAttemptScheduled,
-               reconnectAttemptCount == reconnectAttemptCountBeforeCallbacks {
-                hasPendingAutoReconnectAttempt = true
-            }
-            shouldResumeAutoReconnectAfterPendingDisconnect = false
-            autoReconnectLock.unlock()
-            return
-        }
-
-        let shouldResumeAfterPendingDisconnect = shouldResumeAutoReconnectAfterPendingDisconnect
-        shouldResumeAutoReconnectAfterPendingDisconnect = false
-        if !hasPausedAutoReconnectAttempt {
-            prepareAutoReconnectAttempt()
-        }
-        hasPausedAutoReconnectAttempt = false
-        hasPendingAutoReconnectAttempt = false
-        let schedule = scheduleAutoReconnectAttemptLocked(after: shouldResumeAfterPendingDisconnect ? 0 : nil)
-        autoReconnectLock.unlock()
-
+    private func continueAfterDisconnectCallbacks(_ context: MQTTAutoReconnectDisconnectContext) {
+        guard let schedule = autoReconnectController.completeDisconnectCallbacks(context) else { return }
         notifyAutoReconnectScheduled(schedule)
     }
 }
@@ -1560,8 +1355,7 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
             // Disable auto-reconnect
 
-            resetAutoReconnectState()
-            is_internal_disconnected = false
+            autoReconnectController.connectionSucceeded()
 
             // Start keepalive timer
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -294,7 +294,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         autoReconnectController.isPaused
     }
 
-    private var autoReconnectController: MQTTAutoReconnectController!
+    private let autoReconnectController: MQTTAutoReconnectController
     private let disconnectReasonLock = NSLock()
     private var pendingLocalDisconnectReasonCode: CocoaMQTTDISCONNECTReasonCode?
     private var _lastDisconnectReason: CocoaMQTT5DisconnectReason?
@@ -438,12 +438,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         self.host = host
         self.port = port
         self.socket = socket
-        self.eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT5.event-loop.\(UUID().uuidString)")
+        let eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT5.event-loop.\(UUID().uuidString)")
+        self.eventLoopQueue = eventLoopQueue
+        self.autoReconnectController = MQTTAutoReconnectController(eventLoopQueue: eventLoopQueue)
         super.init()
-        autoReconnectController = MQTTAutoReconnectController(
-            eventLoopQueue: eventLoopQueue,
-            reconnect: { [weak self] in _ = self?.connect() }
-        )
+        autoReconnectController.delegate = self
         socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
         socketDelegateProxy.delegate = self
         $connState.setMutationObserver { [weak self] state in
@@ -1151,6 +1150,12 @@ extension CocoaMQTT5 {
         } else if _lastDisconnectReason?.source != .remote {
             _lastDisconnectReason = nil
         }
+    }
+}
+
+extension CocoaMQTT5: MQTTAutoReconnectControllerDelegate {
+    func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController) {
+        _ = connect()
     }
 }
 

--- a/Source/MQTTAutoReconnectController.swift
+++ b/Source/MQTTAutoReconnectController.swift
@@ -13,6 +13,10 @@ protocol MQTTReconnectScheduling {
     func schedule(after interval: TimeInterval, _ action: @escaping () -> Void) -> MQTTReconnectScheduledTask
 }
 
+protocol MQTTAutoReconnectControllerDelegate: AnyObject {
+    func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController)
+}
+
 extension CocoaMQTTTimer: MQTTReconnectScheduledTask {}
 
 private struct CocoaMQTTReconnectScheduler: MQTTReconnectScheduling {
@@ -22,45 +26,90 @@ private struct CocoaMQTTReconnectScheduler: MQTTReconnectScheduling {
 }
 
 struct MQTTAutoReconnectDisconnectContext {
-    let attemptCountBeforeCallbacks: UInt
+    fileprivate let token: UInt64
     let suppressesReconnect: Bool
 }
 
 /// Owns protocol-neutral reconnect state for both MQTT 3.1.1 and MQTT 5 clients.
 final class MQTTAutoReconnectController {
-    private let lock = NSRecursiveLock()
+    private enum PendingAttempt: Equatable {
+        case none
+        case unprepared
+        case prepared
+
+        func merging(_ other: PendingAttempt) -> PendingAttempt {
+            switch (self, other) {
+            case (.prepared, _), (_, .prepared):
+                return .prepared
+            case (.unprepared, _), (_, .unprepared):
+                return .unprepared
+            case (.none, .none):
+                return .none
+            }
+        }
+    }
+
+    private struct ScheduledAttempt {
+        let generation: UInt64
+        let task: MQTTReconnectScheduledTask
+    }
+
+    private enum AttemptState {
+        case idle
+        case scheduled(ScheduledAttempt)
+        case connecting
+        case paused(PendingAttempt)
+    }
+
+    private enum DisconnectIntent {
+        case none
+        case expected(requestPending: Bool)
+        case unexpected
+    }
+
+    private enum ReconnectDelay: Equatable {
+        case normal
+        case immediate
+    }
+
+    private struct PendingReconnect {
+        var attemptCountBeforeDisconnect: UInt
+        var pendingAttempt: PendingAttempt
+        var delay: ReconnectDelay
+    }
+
+    private let lock = NSLock()
     private let eventLoopQueue: DispatchQueue
     private let scheduler: MQTTReconnectScheduling
-    private let reconnect: () -> Void
+
+    weak var delegate: MQTTAutoReconnectControllerDelegate?
 
     private var enabled = false
     private var initialInterval: UInt16 = 1
     private var maximumInterval: UInt16 = 128
     private var currentInterval: UInt16 = 0
     private var attemptCount: UInt = 0
-    private var paused = false
-    private var scheduledTask: MQTTReconnectScheduledTask?
-    private var isAttemptScheduled = false
-    private var hasPausedAttempt = false
-    private var hasPendingAttempt = false
     private var generation: UInt64 = 0
-    private var pendingSocketDisconnectAttemptCount: UInt?
-    private var shouldResumeAfterPendingDisconnect = false
-    private var expectedDisconnectPending = false
-    private var suppressReconnectForNextDisconnect = false
+    private var attemptState = AttemptState.idle
+    private var disconnectIntent = DisconnectIntent.none
+    private var pendingReconnect: PendingReconnect?
+    private var nextDisconnectToken: UInt64 = 0
+    // Tokens survive reconnect-cycle resets so an older callback cannot unblock
+    // or consume a newer lifecycle's pending reconnect.
+    private var inFlightDisconnectCallbacks = Set<UInt64>()
 
     init(
         eventLoopQueue: DispatchQueue,
-        scheduler: MQTTReconnectScheduling = CocoaMQTTReconnectScheduler(),
-        reconnect: @escaping () -> Void
+        scheduler: MQTTReconnectScheduling = CocoaMQTTReconnectScheduler()
     ) {
         self.eventLoopQueue = eventLoopQueue
         self.scheduler = scheduler
-        self.reconnect = reconnect
     }
 
     deinit {
-        scheduledTask?.cancel()
+        if case let .scheduled(attempt) = attemptState {
+            attempt.task.cancel()
+        }
     }
 
     var isEnabled: Bool {
@@ -73,7 +122,7 @@ final class MQTTAutoReconnectController {
             lock.lock()
             enabled = newValue
             if !newValue {
-                resetLocked()
+                resetReconnectCycleLocked()
             }
             lock.unlock()
         }
@@ -120,7 +169,10 @@ final class MQTTAutoReconnectController {
     var isPaused: Bool {
         lock.lock()
         defer { lock.unlock() }
-        return paused
+        if case .paused = attemptState {
+            return true
+        }
+        return false
     }
 
     /// Prevents duplicate expected disconnect requests until the socket either
@@ -128,42 +180,50 @@ final class MQTTAutoReconnectController {
     func beginExpectedDisconnect() -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        guard !expectedDisconnectPending else { return false }
-        expectedDisconnectPending = true
-        suppressReconnectForNextDisconnect = true
+        if case .expected(requestPending: true) = disconnectIntent {
+            return false
+        }
+        disconnectIntent = .expected(requestPending: true)
+        pendingReconnect = nil
         return true
     }
 
-    /// Records the reconnect generation before requesting an unexpected socket close.
+    /// Records the reconnect cycle before requesting an unexpected socket close.
     func beginUnexpectedDisconnect() {
         lock.lock()
-        pendingSocketDisconnectAttemptCount = attemptCount
-        suppressReconnectForNextDisconnect = false
+        disconnectIntent = .unexpected
+        registerPendingReconnectLocked(attemptCountBeforeDisconnect: attemptCount)
         lock.unlock()
     }
 
     func socketConnected() {
         lock.lock()
-        expectedDisconnectPending = false
+        if case .expected = disconnectIntent {
+            disconnectIntent = .expected(requestPending: false)
+        }
         lock.unlock()
     }
 
     func connectionSucceeded() {
         lock.lock()
-        suppressReconnectForNextDisconnect = false
-        resetLocked()
+        disconnectIntent = .none
+        resetReconnectCycleLocked()
         lock.unlock()
     }
 
     func pause() {
         lock.lock()
-        paused = true
-        if isAttemptScheduled {
-            hasPausedAttempt = true
-            isAttemptScheduled = false
+        let pendingAttempt: PendingAttempt
+        switch attemptState {
+        case let .scheduled(attempt):
+            attempt.task.cancel()
+            pendingAttempt = .prepared
+        case let .paused(existing):
+            pendingAttempt = existing
+        case .idle, .connecting:
+            pendingAttempt = .none
         }
-        shouldResumeAfterPendingDisconnect = false
-        cancelScheduledTaskLocked()
+        attemptState = .paused(pendingAttempt)
         generation &+= 1
         lock.unlock()
     }
@@ -171,28 +231,27 @@ final class MQTTAutoReconnectController {
     func resume(connectionIsDisconnected: Bool) -> CocoaMQTTAutoReconnectSchedule? {
         lock.lock()
         defer { lock.unlock() }
-        guard paused else { return nil }
+        guard case let .paused(pausedAttempt) = attemptState else { return nil }
 
-        paused = false
+        attemptState = .idle
         guard enabled, connectionIsDisconnected else {
-            hasPausedAttempt = false
-            hasPendingAttempt = false
-            shouldResumeAfterPendingDisconnect = false
+            pendingReconnect = nil
             return nil
         }
 
-        if pendingSocketDisconnectAttemptCount != nil {
-            // The old socket delegate must be cleared before a new connection starts.
-            shouldResumeAfterPendingDisconnect = true
+        if pendingReconnect != nil || !inFlightDisconnectCallbacks.isEmpty {
+            if var pendingReconnect = pendingReconnect {
+                pendingReconnect.pendingAttempt = pendingReconnect.pendingAttempt.merging(pausedAttempt)
+                pendingReconnect.delay = .immediate
+                self.pendingReconnect = pendingReconnect
+            }
             return nil
         }
 
-        guard hasPausedAttempt || hasPendingAttempt else { return nil }
-        if !hasPausedAttempt {
+        guard pausedAttempt != .none else { return nil }
+        if pausedAttempt == .unprepared {
             prepareAttemptLocked()
         }
-        hasPausedAttempt = false
-        hasPendingAttempt = false
         return scheduleLocked(after: 0)
     }
 
@@ -200,21 +259,36 @@ final class MQTTAutoReconnectController {
         lock.lock()
         defer { lock.unlock() }
 
-        expectedDisconnectPending = false
-        let suppressesReconnect = suppressReconnectForNextDisconnect
-        suppressReconnectForNextDisconnect = false
-        if suppressesReconnect || !enabled {
-            resetLocked()
+        let suppressesReconnect: Bool
+        switch disconnectIntent {
+        case .expected:
+            suppressesReconnect = true
+        case .none, .unexpected:
+            suppressesReconnect = false
         }
 
-        let countBeforeCallbacks = pendingSocketDisconnectAttemptCount ?? attemptCount
-        if !suppressesReconnect && enabled {
-            pendingSocketDisconnectAttemptCount = countBeforeCallbacks
+        let wasUnexpectedRequest: Bool
+        if case .unexpected = disconnectIntent {
+            wasUnexpectedRequest = true
+        } else {
+            wasUnexpectedRequest = false
         }
-        return MQTTAutoReconnectDisconnectContext(
-            attemptCountBeforeCallbacks: countBeforeCallbacks,
-            suppressesReconnect: suppressesReconnect
-        )
+        disconnectIntent = .none
+
+        if case .connecting = attemptState {
+            attemptState = .idle
+        }
+
+        if suppressesReconnect || !enabled {
+            resetReconnectCycleLocked()
+        } else if !wasUnexpectedRequest {
+            registerPendingReconnectLocked(attemptCountBeforeDisconnect: attemptCount)
+        }
+
+        nextDisconnectToken &+= 1
+        let token = nextDisconnectToken
+        inFlightDisconnectCallbacks.insert(token)
+        return MQTTAutoReconnectDisconnectContext(token: token, suppressesReconnect: suppressesReconnect)
     }
 
     /// Must be called after the public disconnect callbacks have completed.
@@ -224,39 +298,52 @@ final class MQTTAutoReconnectController {
         lock.lock()
         defer { lock.unlock() }
 
-        guard !context.suppressesReconnect else { return nil }
+        guard inFlightDisconnectCallbacks.remove(context.token) != nil else { return nil }
+        guard inFlightDisconnectCallbacks.isEmpty else { return nil }
         guard enabled else {
-            resetLocked()
+            resetReconnectCycleLocked()
             return nil
         }
+        guard let pendingReconnect = pendingReconnect else { return nil }
+        self.pendingReconnect = nil
+        guard attemptCount == pendingReconnect.attemptCountBeforeDisconnect else { return nil }
 
-        pendingSocketDisconnectAttemptCount = nil
-        guard !paused,
-              !isAttemptScheduled,
-              attemptCount == context.attemptCountBeforeCallbacks else {
-            if paused,
-               !isAttemptScheduled,
-               attemptCount == context.attemptCountBeforeCallbacks {
-                hasPendingAttempt = true
+        switch attemptState {
+        case let .paused(pausedAttempt):
+            attemptState = .paused(pausedAttempt.merging(pendingReconnect.pendingAttempt))
+            return nil
+        case .scheduled, .connecting:
+            return nil
+        case .idle:
+            if pendingReconnect.pendingAttempt != .prepared {
+                prepareAttemptLocked()
             }
-            shouldResumeAfterPendingDisconnect = false
-            return nil
+            let delay: UInt16? = pendingReconnect.delay == .immediate ? 0 : nil
+            return scheduleLocked(after: delay)
         }
-
-        let resumeImmediately = shouldResumeAfterPendingDisconnect
-        shouldResumeAfterPendingDisconnect = false
-        if !hasPausedAttempt {
-            prepareAttemptLocked()
-        }
-        hasPausedAttempt = false
-        hasPendingAttempt = false
-        return scheduleLocked(after: resumeImmediately ? 0 : nil)
     }
 
     func isCurrent(_ schedule: CocoaMQTTAutoReconnectSchedule) -> Bool {
         lock.lock()
         defer { lock.unlock() }
         return enabled && generation == schedule.generation
+    }
+
+    private func registerPendingReconnectLocked(attemptCountBeforeDisconnect: UInt) {
+        let statePendingAttempt: PendingAttempt
+        if case .paused(.prepared) = attemptState {
+            statePendingAttempt = .prepared
+        } else {
+            statePendingAttempt = .unprepared
+        }
+
+        let existingPendingAttempt = pendingReconnect?.pendingAttempt ?? .none
+        let existingDelay = pendingReconnect?.delay ?? .normal
+        pendingReconnect = PendingReconnect(
+            attemptCountBeforeDisconnect: attemptCountBeforeDisconnect,
+            pendingAttempt: existingPendingAttempt.merging(statePendingAttempt),
+            delay: existingDelay
+        )
     }
 
     private func prepareAttemptLocked() {
@@ -269,18 +356,17 @@ final class MQTTAutoReconnectController {
     private func scheduleLocked(after interval: UInt16?) -> CocoaMQTTAutoReconnectSchedule {
         let delay = interval ?? currentInterval
         printInfo("Try reconnect to server after \(delay)s")
-        isAttemptScheduled = true
         generation &+= 1
         let scheduledGeneration = generation
-        cancelScheduledTaskLocked()
-        scheduledTask = scheduler.schedule(after: Double(delay)) { [weak self] in
+        let task = scheduler.schedule(after: Double(delay)) { [weak self] in
             guard let self = self else { return }
             self.eventLoopQueue.async { [weak self] in
                 guard let self = self,
                       self.prepareScheduledAttempt(generation: scheduledGeneration) else { return }
-                self.reconnect()
+                self.delegate?.autoReconnectControllerRequestsReconnect(self)
             }
         }
+        attemptState = .scheduled(ScheduledAttempt(generation: scheduledGeneration, task: task))
         return CocoaMQTTAutoReconnectSchedule(
             attemptCount: attemptCount,
             interval: delay,
@@ -291,33 +377,27 @@ final class MQTTAutoReconnectController {
     private func prepareScheduledAttempt(generation scheduledGeneration: UInt64) -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        guard generation == scheduledGeneration else { return false }
-        guard enabled, !paused else {
-            isAttemptScheduled = false
-            return false
-        }
-        isAttemptScheduled = false
-        scheduledTask = nil
+        guard generation == scheduledGeneration,
+              case let .scheduled(attempt) = attemptState,
+              attempt.generation == scheduledGeneration,
+              enabled else { return false }
+        attemptState = .connecting
         let doubled = UInt32(currentInterval) * 2
         currentInterval = UInt16(min(doubled, UInt32(maximumInterval)))
         return true
     }
 
-    private func resetLocked() {
+    private func resetReconnectCycleLocked() {
+        if case let .scheduled(attempt) = attemptState {
+            attempt.task.cancel()
+        }
+        attemptState = .idle
         currentInterval = 0
         attemptCount = 0
-        paused = false
-        cancelScheduledTaskLocked()
-        isAttemptScheduled = false
-        hasPausedAttempt = false
-        hasPendingAttempt = false
-        pendingSocketDisconnectAttemptCount = nil
-        shouldResumeAfterPendingDisconnect = false
+        pendingReconnect = nil
+        if case .unexpected = disconnectIntent {
+            disconnectIntent = .none
+        }
         generation &+= 1
-    }
-
-    private func cancelScheduledTaskLocked() {
-        scheduledTask?.cancel()
-        scheduledTask = nil
     }
 }

--- a/Source/MQTTAutoReconnectController.swift
+++ b/Source/MQTTAutoReconnectController.swift
@@ -342,7 +342,11 @@ final class MQTTAutoReconnectController {
         case .connecting:
             attemptState = .idle
             prepareAttemptLocked()
-            return scheduleLocked(after: nil)
+            // A zero backoff is valid for the first reconnect, but repeatedly
+            // retrying a synchronously rejected connection without delay forms
+            // a hot loop. Keep the configured backoff unchanged and apply the
+            // floor only to this failed-start retry.
+            return scheduleLocked(after: max(currentInterval, 1))
         case .paused:
             attemptState = .paused(.unprepared)
             return nil

--- a/Source/MQTTAutoReconnectController.swift
+++ b/Source/MQTTAutoReconnectController.swift
@@ -238,6 +238,8 @@ final class MQTTAutoReconnectController {
             return nil
         }
 
+        // An unexpected disconnect owns this pending work until the socket
+        // callback confirms that transport cleanup has completed.
         if var pendingReconnect = pendingReconnect {
             pendingReconnect.pendingAttempt = pendingReconnect.pendingAttempt.merging(pausedAttempt)
             pendingReconnect.delay = .immediate

--- a/Source/MQTTAutoReconnectController.swift
+++ b/Source/MQTTAutoReconnectController.swift
@@ -32,6 +32,8 @@ struct MQTTAutoReconnectDisconnectContext {
 
 /// Owns protocol-neutral reconnect state for both MQTT 3.1.1 and MQTT 5 clients.
 final class MQTTAutoReconnectController {
+    private static let minimumFailedStartRetryInterval: UInt16 = 1
+
     private enum PendingAttempt: Equatable {
         case none
         case unprepared
@@ -346,7 +348,7 @@ final class MQTTAutoReconnectController {
             // retrying a synchronously rejected connection without delay forms
             // a hot loop. Keep the configured backoff unchanged and apply the
             // floor only to this failed-start retry.
-            return scheduleLocked(after: max(currentInterval, 1))
+            return scheduleLocked(after: max(currentInterval, Self.minimumFailedStartRetryInterval))
         case .paused:
             attemptState = .paused(.unprepared)
             return nil

--- a/Source/MQTTAutoReconnectController.swift
+++ b/Source/MQTTAutoReconnectController.swift
@@ -26,6 +26,7 @@ private struct CocoaMQTTReconnectScheduler: MQTTReconnectScheduling {
 }
 
 struct MQTTAutoReconnectDisconnectContext {
+    fileprivate let epoch: UInt64
     fileprivate let token: UInt64
     let suppressesReconnect: Bool
 }
@@ -93,9 +94,8 @@ final class MQTTAutoReconnectController {
     private var attemptState = AttemptState.idle
     private var disconnectIntent = DisconnectIntent.none
     private var pendingReconnect: PendingReconnect?
+    private var disconnectEpoch: UInt64 = 0
     private var nextDisconnectToken: UInt64 = 0
-    // Tokens survive reconnect-cycle resets so an older callback cannot unblock
-    // or consume a newer lifecycle's pending reconnect.
     private var inFlightDisconnectCallbacks = Set<UInt64>()
 
     init(
@@ -184,7 +184,7 @@ final class MQTTAutoReconnectController {
             return false
         }
         disconnectIntent = .expected(requestPending: true)
-        pendingReconnect = nil
+        resetReconnectCycleLocked()
         return true
     }
 
@@ -288,7 +288,11 @@ final class MQTTAutoReconnectController {
         nextDisconnectToken &+= 1
         let token = nextDisconnectToken
         inFlightDisconnectCallbacks.insert(token)
-        return MQTTAutoReconnectDisconnectContext(token: token, suppressesReconnect: suppressesReconnect)
+        return MQTTAutoReconnectDisconnectContext(
+            epoch: disconnectEpoch,
+            token: token,
+            suppressesReconnect: suppressesReconnect
+        )
     }
 
     /// Must be called after the public disconnect callbacks have completed.
@@ -298,7 +302,8 @@ final class MQTTAutoReconnectController {
         lock.lock()
         defer { lock.unlock() }
 
-        guard inFlightDisconnectCallbacks.remove(context.token) != nil else { return nil }
+        guard context.epoch == disconnectEpoch,
+              inFlightDisconnectCallbacks.remove(context.token) != nil else { return nil }
         guard inFlightDisconnectCallbacks.isEmpty else { return nil }
         guard enabled else {
             resetReconnectCycleLocked()
@@ -320,6 +325,25 @@ final class MQTTAutoReconnectController {
             }
             let delay: UInt16? = pendingReconnect.delay == .immediate ? 0 : nil
             return scheduleLocked(after: delay)
+        }
+    }
+
+    /// Restores backoff after the transport rejects a reconnect synchronously.
+    func reconnectAttemptFailedToStart() -> CocoaMQTTAutoReconnectSchedule? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard enabled else { return nil }
+        switch attemptState {
+        case .connecting:
+            attemptState = .idle
+            prepareAttemptLocked()
+            return scheduleLocked(after: nil)
+        case .paused:
+            attemptState = .paused(.unprepared)
+            return nil
+        case .idle, .scheduled:
+            return nil
         }
     }
 
@@ -398,6 +422,8 @@ final class MQTTAutoReconnectController {
         if case .unexpected = disconnectIntent {
             disconnectIntent = .none
         }
+        disconnectEpoch &+= 1
+        inFlightDisconnectCallbacks.removeAll(keepingCapacity: true)
         generation &+= 1
     }
 }

--- a/Source/MQTTAutoReconnectController.swift
+++ b/Source/MQTTAutoReconnectController.swift
@@ -28,7 +28,6 @@ private struct CocoaMQTTReconnectScheduler: MQTTReconnectScheduling {
 struct MQTTAutoReconnectDisconnectContext {
     fileprivate let epoch: UInt64
     fileprivate let token: UInt64
-    let suppressesReconnect: Bool
 }
 
 /// Owns protocol-neutral reconnect state for both MQTT 3.1.1 and MQTT 5 clients.
@@ -234,17 +233,21 @@ final class MQTTAutoReconnectController {
         guard case let .paused(pausedAttempt) = attemptState else { return nil }
 
         attemptState = .idle
-        guard enabled, connectionIsDisconnected else {
+        guard enabled else {
             pendingReconnect = nil
             return nil
         }
 
-        if pendingReconnect != nil || !inFlightDisconnectCallbacks.isEmpty {
-            if var pendingReconnect = pendingReconnect {
-                pendingReconnect.pendingAttempt = pendingReconnect.pendingAttempt.merging(pausedAttempt)
-                pendingReconnect.delay = .immediate
-                self.pendingReconnect = pendingReconnect
-            }
+        if var pendingReconnect = pendingReconnect {
+            pendingReconnect.pendingAttempt = pendingReconnect.pendingAttempt.merging(pausedAttempt)
+            pendingReconnect.delay = .immediate
+            self.pendingReconnect = pendingReconnect
+        }
+
+        guard connectionIsDisconnected else { return nil }
+        guard pendingReconnect == nil else { return nil }
+        guard inFlightDisconnectCallbacks.isEmpty else {
+            assert(pausedAttempt == .none, "An in-flight unexpected disconnect must retain its pending reconnect")
             return nil
         }
 
@@ -290,8 +293,7 @@ final class MQTTAutoReconnectController {
         inFlightDisconnectCallbacks.insert(token)
         return MQTTAutoReconnectDisconnectContext(
             epoch: disconnectEpoch,
-            token: token,
-            suppressesReconnect: suppressesReconnect
+            token: token
         )
     }
 

--- a/Source/MQTTAutoReconnectController.swift
+++ b/Source/MQTTAutoReconnectController.swift
@@ -1,0 +1,323 @@
+//
+//  MQTTAutoReconnectController.swift
+//  CocoaMQTT
+//
+
+import Foundation
+
+protocol MQTTReconnectScheduledTask: AnyObject {
+    func cancel()
+}
+
+protocol MQTTReconnectScheduling {
+    func schedule(after interval: TimeInterval, _ action: @escaping () -> Void) -> MQTTReconnectScheduledTask
+}
+
+extension CocoaMQTTTimer: MQTTReconnectScheduledTask {}
+
+private struct CocoaMQTTReconnectScheduler: MQTTReconnectScheduling {
+    func schedule(after interval: TimeInterval, _ action: @escaping () -> Void) -> MQTTReconnectScheduledTask {
+        CocoaMQTTTimer.after(interval, name: "autoReconnTimer", action)
+    }
+}
+
+struct MQTTAutoReconnectDisconnectContext {
+    let attemptCountBeforeCallbacks: UInt
+    let suppressesReconnect: Bool
+}
+
+/// Owns protocol-neutral reconnect state for both MQTT 3.1.1 and MQTT 5 clients.
+final class MQTTAutoReconnectController {
+    private let lock = NSRecursiveLock()
+    private let eventLoopQueue: DispatchQueue
+    private let scheduler: MQTTReconnectScheduling
+    private let reconnect: () -> Void
+
+    private var enabled = false
+    private var initialInterval: UInt16 = 1
+    private var maximumInterval: UInt16 = 128
+    private var currentInterval: UInt16 = 0
+    private var attemptCount: UInt = 0
+    private var paused = false
+    private var scheduledTask: MQTTReconnectScheduledTask?
+    private var isAttemptScheduled = false
+    private var hasPausedAttempt = false
+    private var hasPendingAttempt = false
+    private var generation: UInt64 = 0
+    private var pendingSocketDisconnectAttemptCount: UInt?
+    private var shouldResumeAfterPendingDisconnect = false
+    private var expectedDisconnectPending = false
+    private var suppressReconnectForNextDisconnect = false
+
+    init(
+        eventLoopQueue: DispatchQueue,
+        scheduler: MQTTReconnectScheduling = CocoaMQTTReconnectScheduler(),
+        reconnect: @escaping () -> Void
+    ) {
+        self.eventLoopQueue = eventLoopQueue
+        self.scheduler = scheduler
+        self.reconnect = reconnect
+    }
+
+    deinit {
+        scheduledTask?.cancel()
+    }
+
+    var isEnabled: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return enabled
+        }
+        set {
+            lock.lock()
+            enabled = newValue
+            if !newValue {
+                resetLocked()
+            }
+            lock.unlock()
+        }
+    }
+
+    var autoReconnectTimeInterval: UInt16 {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return initialInterval
+        }
+        set {
+            lock.lock()
+            initialInterval = newValue
+            lock.unlock()
+        }
+    }
+
+    var maxAutoReconnectTimeInterval: UInt16 {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return maximumInterval
+        }
+        set {
+            lock.lock()
+            maximumInterval = newValue
+            lock.unlock()
+        }
+    }
+
+    var reconnectTimeInterval: UInt16 {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentInterval
+    }
+
+    var reconnectAttemptCount: UInt {
+        lock.lock()
+        defer { lock.unlock() }
+        return attemptCount
+    }
+
+    var isPaused: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return paused
+    }
+
+    /// Prevents duplicate expected disconnect requests until the socket either
+    /// connects again or reports its disconnect.
+    func beginExpectedDisconnect() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !expectedDisconnectPending else { return false }
+        expectedDisconnectPending = true
+        suppressReconnectForNextDisconnect = true
+        return true
+    }
+
+    /// Records the reconnect generation before requesting an unexpected socket close.
+    func beginUnexpectedDisconnect() {
+        lock.lock()
+        pendingSocketDisconnectAttemptCount = attemptCount
+        suppressReconnectForNextDisconnect = false
+        lock.unlock()
+    }
+
+    func socketConnected() {
+        lock.lock()
+        expectedDisconnectPending = false
+        lock.unlock()
+    }
+
+    func connectionSucceeded() {
+        lock.lock()
+        suppressReconnectForNextDisconnect = false
+        resetLocked()
+        lock.unlock()
+    }
+
+    func pause() {
+        lock.lock()
+        paused = true
+        if isAttemptScheduled {
+            hasPausedAttempt = true
+            isAttemptScheduled = false
+        }
+        shouldResumeAfterPendingDisconnect = false
+        cancelScheduledTaskLocked()
+        generation &+= 1
+        lock.unlock()
+    }
+
+    func resume(connectionIsDisconnected: Bool) -> CocoaMQTTAutoReconnectSchedule? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard paused else { return nil }
+
+        paused = false
+        guard enabled, connectionIsDisconnected else {
+            hasPausedAttempt = false
+            hasPendingAttempt = false
+            shouldResumeAfterPendingDisconnect = false
+            return nil
+        }
+
+        if pendingSocketDisconnectAttemptCount != nil {
+            // The old socket delegate must be cleared before a new connection starts.
+            shouldResumeAfterPendingDisconnect = true
+            return nil
+        }
+
+        guard hasPausedAttempt || hasPendingAttempt else { return nil }
+        if !hasPausedAttempt {
+            prepareAttemptLocked()
+        }
+        hasPausedAttempt = false
+        hasPendingAttempt = false
+        return scheduleLocked(after: 0)
+    }
+
+    func socketDidDisconnect() -> MQTTAutoReconnectDisconnectContext {
+        lock.lock()
+        defer { lock.unlock() }
+
+        expectedDisconnectPending = false
+        let suppressesReconnect = suppressReconnectForNextDisconnect
+        suppressReconnectForNextDisconnect = false
+        if suppressesReconnect || !enabled {
+            resetLocked()
+        }
+
+        let countBeforeCallbacks = pendingSocketDisconnectAttemptCount ?? attemptCount
+        if !suppressesReconnect && enabled {
+            pendingSocketDisconnectAttemptCount = countBeforeCallbacks
+        }
+        return MQTTAutoReconnectDisconnectContext(
+            attemptCountBeforeCallbacks: countBeforeCallbacks,
+            suppressesReconnect: suppressesReconnect
+        )
+    }
+
+    /// Must be called after the public disconnect callbacks have completed.
+    func completeDisconnectCallbacks(
+        _ context: MQTTAutoReconnectDisconnectContext
+    ) -> CocoaMQTTAutoReconnectSchedule? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !context.suppressesReconnect else { return nil }
+        guard enabled else {
+            resetLocked()
+            return nil
+        }
+
+        pendingSocketDisconnectAttemptCount = nil
+        guard !paused,
+              !isAttemptScheduled,
+              attemptCount == context.attemptCountBeforeCallbacks else {
+            if paused,
+               !isAttemptScheduled,
+               attemptCount == context.attemptCountBeforeCallbacks {
+                hasPendingAttempt = true
+            }
+            shouldResumeAfterPendingDisconnect = false
+            return nil
+        }
+
+        let resumeImmediately = shouldResumeAfterPendingDisconnect
+        shouldResumeAfterPendingDisconnect = false
+        if !hasPausedAttempt {
+            prepareAttemptLocked()
+        }
+        hasPausedAttempt = false
+        hasPendingAttempt = false
+        return scheduleLocked(after: resumeImmediately ? 0 : nil)
+    }
+
+    func isCurrent(_ schedule: CocoaMQTTAutoReconnectSchedule) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return enabled && generation == schedule.generation
+    }
+
+    private func prepareAttemptLocked() {
+        if currentInterval == 0 {
+            currentInterval = min(initialInterval, maximumInterval)
+        }
+        attemptCount += 1
+    }
+
+    private func scheduleLocked(after interval: UInt16?) -> CocoaMQTTAutoReconnectSchedule {
+        let delay = interval ?? currentInterval
+        printInfo("Try reconnect to server after \(delay)s")
+        isAttemptScheduled = true
+        generation &+= 1
+        let scheduledGeneration = generation
+        cancelScheduledTaskLocked()
+        scheduledTask = scheduler.schedule(after: Double(delay)) { [weak self] in
+            guard let self = self else { return }
+            self.eventLoopQueue.async { [weak self] in
+                guard let self = self,
+                      self.prepareScheduledAttempt(generation: scheduledGeneration) else { return }
+                self.reconnect()
+            }
+        }
+        return CocoaMQTTAutoReconnectSchedule(
+            attemptCount: attemptCount,
+            interval: delay,
+            generation: scheduledGeneration
+        )
+    }
+
+    private func prepareScheduledAttempt(generation scheduledGeneration: UInt64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard generation == scheduledGeneration else { return false }
+        guard enabled, !paused else {
+            isAttemptScheduled = false
+            return false
+        }
+        isAttemptScheduled = false
+        scheduledTask = nil
+        let doubled = UInt32(currentInterval) * 2
+        currentInterval = UInt16(min(doubled, UInt32(maximumInterval)))
+        return true
+    }
+
+    private func resetLocked() {
+        currentInterval = 0
+        attemptCount = 0
+        paused = false
+        cancelScheduledTaskLocked()
+        isAttemptScheduled = false
+        hasPausedAttempt = false
+        hasPendingAttempt = false
+        pendingSocketDisconnectAttemptCount = nil
+        shouldResumeAfterPendingDisconnect = false
+        generation &+= 1
+    }
+
+    private func cancelScheduledTaskLocked() {
+        scheduledTask?.cancel()
+        scheduledTask = nil
+    }
+}


### PR DESCRIPTION
## What changed

- extract the duplicated MQTT 3.1.1 and MQTT 5 auto-reconnect lifecycle into one protocol-neutral controller
- model reconnect attempts, pause/resume, connection attempts, and disconnect intent as explicit internal states
- assign every disconnect callback a lifecycle token and wait for all in-flight callbacks, including concurrent and out-of-order completions
- inject reconnect scheduling so backoff, cancellation, pause/resume, and callback ordering can be tested without wall-clock waits
- initialize each facade's controller as a non-optional `let` and call back through a weak delegate
- cancel invalidated reconnect timers immediately instead of retaining them until their original deadlines
- keep the existing public facades, delegate queues, callback signatures, and Objective-C surface unchanged

## Why

This is the first incremental step toward the shared client core proposed in #699. It gives reconnect lifecycle behavior one implementation and one focused test suite without combining protocol-specific codecs or changing socket, delivery, or session ownership yet.

The lifecycle tokens also prevent a stale disconnect callback from consuming or scheduling a newer reconnect cycle after state reset, and the explicit `connecting` state prevents duplicate scheduling while an attempt is already in progress.

Progresses #699.

## Verification

- `swift test --skip CocoaMQTTTests.CocoaMQTTTests` (235 tests passed, 1 skipped)
- `swift test --filter 'AutoReconnectStateTests|MQTTAutoReconnectControllerTests'` (37 tests passed)
- `swift test --sanitize=thread --filter MQTTAutoReconnectControllerTests` (11 tests passed)
- `swift build`
- `xcodebuild -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath /tmp/CocoaMQTT-699-derived build CODE_SIGNING_ALLOWED=NO`
- `Tools/lint.sh`
- Swift API digester comparison: no public API changes
- generated Objective-C header comparison: no changes