### PR TITLE
Add regression coverage for concurrent publish messages

### DIFF
--- a/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
+++ b/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
@@ -11,6 +11,13 @@ import XCTest
 
 final class ThreadSafetyRegressionTests: XCTestCase {
 
+    private struct PublishCallbackSnapshot: Equatable {
+        let messageID: UInt16
+        let payload: [UInt8]
+        let qos: CocoaMQTTQoS
+        let retained: Bool
+    }
+
     private final class SocketDelegateStub: CocoaMQTTSocketDelegate {
         func socketConnected(_ socket: CocoaMQTTSocketProtocol) {}
         func socket(_ socket: CocoaMQTTSocketProtocol, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void) {
@@ -297,36 +304,126 @@ final class ThreadSafetyRegressionTests: XCTestCase {
 
     func testConcurrentQoS0PublishesPreserveCallbackMessages() {
         let messageCount = 400
+        let socket = SocketStub()
         let mqtt = CocoaMQTT(
             clientID: "thread-safe-qos0-publish-\(UUID().uuidString)",
-            socket: SocketStub()
+            socket: socket
         )
-        let callbackQueue = DispatchQueue(label: "tests.threadsafe.qos0-publish.callback")
+        let callbackQueue = DispatchQueue(
+            label: "tests.threadsafe.qos0-publish.callback",
+            attributes: .concurrent
+        )
         mqtt.delegateQueue = callbackQueue
 
         let callbacks = expectation(description: "All QoS 0 publish callbacks")
         callbacks.expectedFulfillmentCount = messageCount
-        var callbackTopics = [String]()
+        let callbackMessages = ThreadSafeDictionary<String, PublishCallbackSnapshot>(
+            label: "tests.threadsafe.qos0-publish.callbacks"
+        )
         mqtt.didPublishMessage = { _, message, messageID in
-            XCTAssertEqual(messageID, 0)
-            callbackTopics.append(message.topic)
+            callbackMessages[message.topic] = PublishCallbackSnapshot(
+                messageID: messageID,
+                payload: message.payload,
+                qos: message.qos,
+                retained: message.retained
+            )
             callbacks.fulfill()
         }
 
         let resultCodes = ThreadSafeDictionary<Int, Int>(label: "tests.threadsafe.qos0-publish.results")
         DispatchQueue.concurrentPerform(iterations: messageCount) { index in
             resultCodes[index] = mqtt.publish(
-                CocoaMQTTMessage(topic: "t/qos0/\(index)", payload: [UInt8(index % 255)], qos: .qos0)
+                CocoaMQTTMessage(
+                    topic: "t/qos0/\(index)",
+                    payload: [UInt8(index % 255)],
+                    qos: .qos0,
+                    retained: index.isMultiple(of: 2)
+                )
             )
         }
 
         wait(for: [callbacks], timeout: 5)
-        callbackQueue.sync {}
+        mqtt.eventLoopQueue.sync {}
+
+        let expectedMessages = Dictionary(uniqueKeysWithValues: (0..<messageCount).map { index in
+            (
+                "t/qos0/\(index)",
+                PublishCallbackSnapshot(
+                    messageID: 0,
+                    payload: [UInt8(index % 255)],
+                    qos: .qos0,
+                    retained: index.isMultiple(of: 2)
+                )
+            )
+        })
 
         XCTAssertEqual(resultCodes.snapshot().count, messageCount)
         XCTAssertTrue(resultCodes.snapshot().values.allSatisfy { $0 == 0 })
-        XCTAssertEqual(Set(callbackTopics), Set((0..<messageCount).map { "t/qos0/\($0)" }))
+        XCTAssertEqual(callbackMessages.snapshot(), expectedMessages)
         XCTAssertEqual(mqtt.t_sendingMessagesCount(), 0)
+        mqtt.socketDidDisconnect(socket, withError: nil)
+    }
+
+    func testCocoaMQTT5ConcurrentQoS0PublishesPreserveCallbackMessages() {
+        let messageCount = 400
+        let socket = SocketStub()
+        let mqtt5 = CocoaMQTT5(
+            clientID: "thread-safe-qos0-publish-5-\(UUID().uuidString)",
+            socket: socket
+        )
+        mqtt5.delegateQueue = DispatchQueue(
+            label: "tests.threadsafe.qos0-publish-5.callback",
+            attributes: .concurrent
+        )
+
+        let callbacks = expectation(description: "All MQTT 5 QoS 0 publish callbacks")
+        callbacks.expectedFulfillmentCount = messageCount
+        let callbackMessages = ThreadSafeDictionary<String, PublishCallbackSnapshot>(
+            label: "tests.threadsafe.qos0-publish-5.callbacks"
+        )
+        mqtt5.didPublishMessage = { _, message, messageID in
+            callbackMessages[message.topic] = PublishCallbackSnapshot(
+                messageID: messageID,
+                payload: message.payload,
+                qos: message.qos,
+                retained: message.retained
+            )
+            callbacks.fulfill()
+        }
+
+        let resultCodes = ThreadSafeDictionary<Int, Int>(label: "tests.threadsafe.qos0-publish-5.results")
+        DispatchQueue.concurrentPerform(iterations: messageCount) { index in
+            resultCodes[index] = mqtt5.publish(
+                CocoaMQTT5Message(
+                    topic: "t/qos0/\(index)",
+                    payload: [UInt8(index % 255)],
+                    qos: .qos0,
+                    retained: index.isMultiple(of: 2)
+                ),
+                properties: MqttPublishProperties()
+            )
+        }
+
+        wait(for: [callbacks], timeout: 5)
+        mqtt5.eventLoopQueue.sync {}
+
+        let expectedMessages = Dictionary(uniqueKeysWithValues: (0..<messageCount).map { index in
+            (
+                "t/qos0/\(index)",
+                PublishCallbackSnapshot(
+                    messageID: 0,
+                    payload: [UInt8(index % 255)],
+                    qos: .qos0,
+                    retained: index.isMultiple(of: 2)
+                )
+            )
+        })
+
+        XCTAssertEqual(resultCodes.snapshot().count, messageCount)
+        XCTAssertTrue(resultCodes.snapshot().values.allSatisfy { $0 == 0 })
+        XCTAssertEqual(callbackMessages.snapshot(), expectedMessages)
+        XCTAssertEqual(mqtt5.t_sendingMessagesCount(), 0)
+        mqtt5.socketDidDisconnect(socket, withError: nil)
     }
 
     func testPacketIdentifierAllocatorExhaustionAndReuse() {

--- a/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
+++ b/CocoaMQTTTests/ThreadSafetyRegressionTests.swift
@@ -295,6 +295,40 @@ final class ThreadSafetyRegressionTests: XCTestCase {
         mqtt.socketDidDisconnect(SocketStub(), withError: nil)
     }
 
+    func testConcurrentQoS0PublishesPreserveCallbackMessages() {
+        let messageCount = 400
+        let mqtt = CocoaMQTT(
+            clientID: "thread-safe-qos0-publish-\(UUID().uuidString)",
+            socket: SocketStub()
+        )
+        let callbackQueue = DispatchQueue(label: "tests.threadsafe.qos0-publish.callback")
+        mqtt.delegateQueue = callbackQueue
+
+        let callbacks = expectation(description: "All QoS 0 publish callbacks")
+        callbacks.expectedFulfillmentCount = messageCount
+        var callbackTopics = [String]()
+        mqtt.didPublishMessage = { _, message, messageID in
+            XCTAssertEqual(messageID, 0)
+            callbackTopics.append(message.topic)
+            callbacks.fulfill()
+        }
+
+        let resultCodes = ThreadSafeDictionary<Int, Int>(label: "tests.threadsafe.qos0-publish.results")
+        DispatchQueue.concurrentPerform(iterations: messageCount) { index in
+            resultCodes[index] = mqtt.publish(
+                CocoaMQTTMessage(topic: "t/qos0/\(index)", payload: [UInt8(index % 255)], qos: .qos0)
+            )
+        }
+
+        wait(for: [callbacks], timeout: 5)
+        callbackQueue.sync {}
+
+        XCTAssertEqual(resultCodes.snapshot().count, messageCount)
+        XCTAssertTrue(resultCodes.snapshot().values.allSatisfy { $0 == 0 })
+        XCTAssertEqual(Set(callbackTopics), Set((0..<messageCount).map { "t/qos0/\($0)" }))
+        XCTAssertEqual(mqtt.t_sendingMessagesCount(), 0)
+    }
+
     func testPacketIdentifierAllocatorExhaustionAndReuse() {
         let allocator = MQTTPacketIdentifierAllocator()
         var identifiers = Set<UInt16>()


### PR DESCRIPTION
## Summary

- add concurrent QoS 0 publish regressions for MQTT 3.1.1 and MQTT 5
- verify every callback retains the original message id, payload, QoS, and retained flag
- drain the internal event loop before asserting the sending-message cache is empty
- exercise the public callback path with a concurrent `delegateQueue`

## Fix provenance

This PR adds regression coverage for #369; it does not change the production implementation.

The underlying message-cache and delivery-lifecycle fix landed in #706, which fixed #587, #432, and #585. PR #709 (fixes #700) made `ThreadSafeDictionary` mutations synchronous and visible before returning. PR #711 (closes #710) separated internal delivery processing from the public callback queue. Together, those changes remove the old `sendingMessages` concurrent read/write window reported in #369.

#369 was not explicitly linked by the earlier implementation PRs, so this PR intentionally references it rather than claiming a new production fix.

## Verification

- `swift test --filter ThreadSafetyRegressionTests`
- `swift test --sanitize=thread --filter "ThreadSafetyRegressionTests/testConcurrentQoS0PublishesPreserveCallbackMessages|ThreadSafetyRegressionTests/testCocoaMQTT5ConcurrentQoS0PublishesPreserveCallbackMessages"`
- `swiftlint lint --strict CocoaMQTTTests/ThreadSafetyRegressionTests.swift`

## CI note

The repository CI runs the functional XCTest coverage, but does not currently run Thread Sanitizer. The TSan command above was run locally; adding a dedicated CI TSan job is intentionally outside this test-only PR.

Refs #369, #706, #709, #711