### PR TITLE
Fix MQTT retransmission semantics

### DIFF
--- a/CocoaMQTTTests/CocoaMQTTDeliverTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTDeliverTests.swift
@@ -129,6 +129,8 @@ class CocoaMQTTDeliverTests: XCTestCase {
         for i in 0 ..< sents.count {
             assertEqual(caller.frames[i], sents[i])
         }
+        XCTAssertTrue((caller.frames[1] as? FramePublish)?.dup == true)
+        XCTAssertEqual(caller.frames[4].packetFixedHeaderType, 0x62)
     }
 
     func testRedeliverTimerDriftDoesNotSkipRetry() {
@@ -163,6 +165,54 @@ class CocoaMQTTDeliverTests: XCTestCase {
             assertEqual(publish, frame)
             XCTAssertTrue(publish.dup)
         }
+    }
+
+    func testMQTT5DoesNotRedeliverPublishWhileConnectionRemainsOpen() {
+        let caller = Caller()
+        let deliver = CocoaMQTTDeliver()
+        let frame = FramePublish(topic: "t/mqtt5", payload: [0x01], qos: .qos1, msgid: 43)
+
+        deliver.protocolVersion = .v5
+        deliver.retryTimeInterval = 1
+        deliver.delegate = caller
+        XCTAssertTrue(deliver.add(frame))
+        deliver.t_waitUntilIdle()
+        caller.delegateQueue.sync {}
+        caller.reset()
+
+        XCTAssertTrue(deliver.t_setInflightNextRetryTime(0, forMsgid: frame.msgid))
+        deliver.t_redeliver(atUptimeNanoseconds: UInt64.max)
+        deliver.t_waitUntilIdle()
+        caller.delegateQueue.sync {}
+
+        XCTAssertTrue(caller.frames.isEmpty)
+        XCTAssertEqual(deliver.t_inflightFrames().count, 1)
+    }
+
+    func testMQTT5DoesNotRedeliverPubrelWhileConnectionRemainsOpen() {
+        let caller = Caller()
+        let deliver = CocoaMQTTDeliver()
+        let publish = FramePublish(topic: "t/mqtt5-qos2", payload: [0x02], qos: .qos2, msgid: 44)
+
+        deliver.protocolVersion = .v5
+        deliver.retryTimeInterval = 1
+        deliver.delegate = caller
+        XCTAssertTrue(deliver.add(publish))
+        deliver.t_waitUntilIdle()
+        deliver.ack(by: FramePubRec(msgid: publish.msgid))
+        deliver.t_waitUntilIdle()
+        caller.delegateQueue.sync {}
+        caller.reset()
+
+        XCTAssertTrue(deliver.t_setInflightNextRetryTime(0, forMsgid: publish.msgid))
+        deliver.t_redeliver(atUptimeNanoseconds: UInt64.max)
+        deliver.t_waitUntilIdle()
+        caller.delegateQueue.sync {}
+
+        XCTAssertTrue(caller.frames.isEmpty)
+        let inflight = deliver.t_inflightFrames()
+        XCTAssertEqual(inflight.count, 1)
+        XCTAssertTrue(inflight.first is FramePubRel)
     }
 
     func testRetryIntervalNanosecondsClampsNonPositiveValues() {

--- a/CocoaMQTTTests/SendingMessageLifecycleTests.swift
+++ b/CocoaMQTTTests/SendingMessageLifecycleTests.swift
@@ -482,6 +482,134 @@ final class SendingMessageLifecycleTests: XCTestCase {
         XCTAssertEqual(recoveredProperties.contentType, "text/plain")
     }
 
+    func testMQTT5SessionResumeContinuesQoS2WithPubrel() {
+        let clientID = "mqtt5-qos2-resume-\(UUID().uuidString)"
+        defer { clearStorage(clientID) }
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT5(clientID: clientID, socket: socket)
+        establishSession(
+            mqtt,
+            socket: socket,
+            cleanStart: true,
+            requestedExpiry: UInt32.max
+        )
+
+        let packetIdentifier = mqtt.publish(
+            CocoaMQTT5Message(topic: "t/qos2", payload: [2], qos: .qos2),
+            properties: MqttPublishProperties()
+        )
+        mqtt.t_waitUntilDeliverIdle()
+        mqtt.didReceive(
+            CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5),
+            pubrec: FramePubRec(msgid: UInt16(packetIdentifier))
+        )
+        mqtt.t_waitUntilDeliverIdle()
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        socket.writes.removeAll()
+        establishSession(
+            mqtt,
+            socket: socket,
+            cleanStart: false,
+            requestedExpiry: UInt32.max,
+            sessionPresent: true
+        )
+        mqtt.t_waitUntilDeliverIdle()
+
+        XCTAssertFalse(socket.writes.contains { $0.first.map { $0 & 0xf0 } == FrameType.publish.rawValue })
+        let pubrel = socket.writes.first { $0.first == 0x62 }
+        XCTAssertEqual(pubrel.map { Array([UInt8]($0)[2...3]) }, UInt16(packetIdentifier).hlBytes)
+    }
+
+    func testMQTT5SessionPresentFalseDiscardsUnacknowledgedQoSState() {
+        let clientID = "mqtt5-session-missing-\(UUID().uuidString)"
+        defer { clearStorage(clientID) }
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT5(clientID: clientID, socket: socket)
+        establishSession(
+            mqtt,
+            socket: socket,
+            cleanStart: true,
+            requestedExpiry: UInt32.max
+        )
+        XCTAssertGreaterThan(
+            mqtt.publish(
+                CocoaMQTT5Message(topic: "t/discard", payload: [1], qos: .qos1),
+                properties: MqttPublishProperties()
+            ),
+            0
+        )
+        mqtt.t_waitUntilDeliverIdle()
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        socket.writes.removeAll()
+        establishSession(
+            mqtt,
+            socket: socket,
+            cleanStart: false,
+            requestedExpiry: UInt32.max,
+            sessionPresent: false
+        )
+        mqtt.t_waitUntilDeliverIdle()
+
+        XCTAssertFalse(socket.writes.contains { $0.first.map { $0 & 0xf0 } == FrameType.publish.rawValue })
+        XCTAssertFalse(socket.writes.contains { $0.first == 0x62 })
+        XCTAssertTrue(CocoaMQTTStorage(by: clientID, protocolVersion: .v5)?.readAll().isEmpty == true)
+        XCTAssertEqual(mqtt.t_sendingMessagesCount(), 0)
+        XCTAssertEqual(mqtt.t_reservedPacketIdentifierCount(), 0)
+    }
+
+    func testMQTT311SessionResumeContinuesQoS2WithPubrel() {
+        let clientID = "mqtt311-qos2-resume-\(UUID().uuidString)"
+        defer { clearStorage(clientID) }
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: clientID, socket: socket)
+        establishSession(mqtt, socket: socket, cleanSession: false, sessionPresent: false)
+
+        let packetIdentifier = mqtt.publish(
+            CocoaMQTTMessage(topic: "t/qos2", payload: [2], qos: .qos2)
+        )
+        mqtt.t_waitUntilDeliverIdle()
+        mqtt.didReceive(
+            CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v311),
+            pubrec: FramePubRec(msgid: UInt16(packetIdentifier))
+        )
+        mqtt.t_waitUntilDeliverIdle()
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        socket.writes.removeAll()
+        establishSession(mqtt, socket: socket, cleanSession: false, sessionPresent: true)
+        mqtt.t_waitUntilDeliverIdle()
+
+        XCTAssertFalse(socket.writes.contains { $0.first.map { $0 & 0xf0 } == FrameType.publish.rawValue })
+        let pubrel = socket.writes.first { $0.first == 0x62 }
+        XCTAssertEqual(pubrel.map { Array([UInt8]($0)[2...3]) }, UInt16(packetIdentifier).hlBytes)
+    }
+
+    func testMQTT311SessionPresentFalseDiscardsPreviousQoSState() {
+        let clientID = "mqtt311-session-missing-\(UUID().uuidString)"
+        defer { clearStorage(clientID) }
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: clientID, socket: socket)
+        establishSession(mqtt, socket: socket, cleanSession: false, sessionPresent: false)
+        XCTAssertGreaterThan(
+            mqtt.publish(CocoaMQTTMessage(topic: "t/discard", payload: [1], qos: .qos1)),
+            0
+        )
+        mqtt.t_waitUntilDeliverIdle()
+
+        mqtt.socketDidDisconnect(socket, withError: nil)
+        socket.writes.removeAll()
+        establishSession(mqtt, socket: socket, cleanSession: false, sessionPresent: false)
+        mqtt.t_waitUntilDeliverIdle()
+
+        XCTAssertFalse(socket.writes.contains { $0.first.map { $0 & 0xf0 } == FrameType.publish.rawValue })
+        XCTAssertFalse(socket.writes.contains { $0.first == 0x62 })
+        XCTAssertTrue(CocoaMQTTStorage(by: clientID, protocolVersion: .v311)?.readAll().isEmpty == true)
+        XCTAssertEqual(mqtt.t_sendingMessagesCount(), 0)
+        XCTAssertEqual(mqtt.t_reservedPacketIdentifierCount(), 0)
+    }
+
     func testDisconnectReleasesPendingSubscriptionPacketIdentifiers() {
         let mqtt311 = CocoaMQTT(clientID: "pending-requests-311", socket: SocketSpy())
         mqtt311.cleanSession = false
@@ -1159,6 +1287,30 @@ final class SendingMessageLifecycleTests: XCTestCase {
             defaults.removeObject(forKey: key)
         }
         defaults.synchronize()
+    }
+
+    private func establishSession(_ mqtt: CocoaMQTT,
+                                  socket: SocketSpy,
+                                  cleanSession: Bool,
+                                  sessionPresent: Bool) {
+        mqtt.cleanSession = cleanSession
+        XCTAssertTrue(mqtt.connect())
+        mqtt.socketConnected(socket)
+        let connack = FrameConnAck(
+            packetFixedHeaderType: FrameType.connack.rawValue,
+            bytes: [
+                sessionPresent ? UInt8(1) : UInt8(0),
+                CocoaMQTTCONNACKReasonCode.success.rawValue
+            ],
+            protocolVersion: .v311
+        )
+        XCTAssertNotNil(connack)
+        if let connack {
+            mqtt.didReceive(
+                CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v311),
+                connack: connack
+            )
+        }
     }
 
     private func establishSession(_ mqtt: CocoaMQTT5,

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -218,7 +218,9 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     // deliver
     private var deliver = CocoaMQTTDeliver()
 
-    /// Re-deliver the un-acked messages
+    /// Retained for source compatibility. MQTT 5 retransmits unacknowledged
+    /// messages only when a persistent session is resumed, so this value does
+    /// not schedule retries while a connection remains open.
     public var deliverTimeout: Double {
         get { return deliver.retryTimeInterval }
         set { deliver.retryTimeInterval = newValue }

--- a/Source/CocoaMQTTDeliver.swift
+++ b/Source/CocoaMQTTDeliver.swift
@@ -353,8 +353,11 @@ extension CocoaMQTTDeliver {
                 consumesSendQuota: frame is FramePublish
             ))
 
-            // Start a retry timer for resending it if it not receive PUBACK or PUBREC
-            if awaitingTimer == nil {
+            // MQTT 3.1.1 permits retrying an unacknowledged packet on the
+            // current connection. MQTT 5 only permits retransmission when a
+            // persistent session is resumed; that path is handled by session
+            // recovery after CONNACK.
+            if protocolVersion == .v311, awaitingTimer == nil {
                 awaitingTimer = CocoaMQTTTimer.every(retryTimeInterval / 1000.0, name: "awaitingTimer") { [weak self] in
                     guard let self = self else { return }
                     self.deliverQueue.async {
@@ -367,6 +370,10 @@ extension CocoaMQTTDeliver {
 
     /// Attempt to redeliver in-flight messages
     private func redeliver(nowUptimeNs: UInt64 = DispatchTime.now().uptimeNanoseconds) {
+        guard protocolVersion == .v311 else {
+            awaitingTimer = nil
+            return
+        }
         guard transportEnabled else { return }
         if isInflightEmpty {
             // Revoke the awaiting timer
@@ -375,7 +382,10 @@ extension CocoaMQTTDeliver {
         }
         for (idx, frame) in inflight.enumerated() where nowUptimeNs >= frame.nextRetryAtUptimeNs {
             var duplicatedFrame = frame
-            duplicatedFrame.frame.dup = true
+            if var publish = duplicatedFrame.frame as? FramePublish {
+                publish.dup = true
+                duplicatedFrame.frame = publish
+            }
             duplicatedFrame.nextRetryAtUptimeNs = nextRetryDeadline(after: frame.nextRetryAtUptimeNs, nowUptimeNs: nowUptimeNs)
 
             inflight[idx] = duplicatedFrame


### PR DESCRIPTION
## Summary

- keep connection-level QoS retry behavior for MQTT 3.1.1
- prevent MQTT 5 from retransmitting PUBLISH/PUBREL on a timer while the connection remains open
- preserve MQTT 5 retransmission through the existing persistent-session recovery path only
- set DUP only on retransmitted PUBLISH packets and keep PUBREL fixed-header flags at the required `0x62`
- document that `CocoaMQTT5.deliverTimeout` remains available for source compatibility but does not enable connection-level retries

## Protocol behavior covered

- MQTT 3.1.1 PUBLISH retry uses DUP = 1
- retransmitted PUBREL remains `0x62`
- MQTT 5 does not retry PUBLISH or PUBREL on the current connection
- MQTT 3.1.1 and MQTT 5 resume QoS 2 at PUBREL when Session Present = 1
- both clients discard previous QoS session state when Session Present = 0
- existing Clean Session / Clean Start and Session Expiry behavior remains covered

## Verification

- `swift test --filter "CocoaMQTTDeliverTests|SendingMessageLifecycleTests"` (57 tests passed)
- `swift build -c release`
- SwiftLint strict on all changed Swift files (0 violations)
- full `swift test` was attempted; broker-independent suites passed, while existing localhost broker integration tests timed out because no broker was running

Fixes #719