### PR TITLE
Fix MQTT keepalive timeout handling

### DIFF
--- a/CocoaMQTT.xcodeproj/project.pbxproj
+++ b/CocoaMQTT.xcodeproj/project.pbxproj
@@ -163,6 +163,10 @@
 		F0A300000000000000000003 /* MQTTAutoReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300000000000000000001 /* MQTTAutoReconnectController.swift */; };
 		F0A300000000000000000004 /* MQTTAutoReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300000000000000000001 /* MQTTAutoReconnectController.swift */; };
 		F0A300000000000000000006 /* MQTTAutoReconnectControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300000000000000000005 /* MQTTAutoReconnectControllerTests.swift */; };
+		F0A400000000000000000002 /* MQTTKeepAliveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A400000000000000000001 /* MQTTKeepAliveController.swift */; };
+		F0A400000000000000000003 /* MQTTKeepAliveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A400000000000000000001 /* MQTTKeepAliveController.swift */; };
+		F0A400000000000000000004 /* MQTTKeepAliveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A400000000000000000001 /* MQTTKeepAliveController.swift */; };
+		F0A400000000000000000006 /* KeepAliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A400000000000000000005 /* KeepAliveTests.swift */; };
 		A1B2C3D4E5F60718293A0001 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
 		A1B2C3D4E5F60718293A0002 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
 		A1B2C3D4E5F60718293A0003 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
@@ -254,6 +258,8 @@
 		F0A200000000000000000001 /* MQTT5SessionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MQTT5SessionState.swift; sourceTree = "<group>"; };
 		F0A300000000000000000001 /* MQTTAutoReconnectController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MQTTAutoReconnectController.swift; sourceTree = "<group>"; };
 		F0A300000000000000000005 /* MQTTAutoReconnectControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MQTTAutoReconnectControllerTests.swift; sourceTree = "<group>"; };
+		F0A400000000000000000001 /* MQTTKeepAliveController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MQTTKeepAliveController.swift; sourceTree = "<group>"; };
+		F0A400000000000000000005 /* KeepAliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepAliveTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = utilities/ConcurrentAtomic.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0012 /* ConcurrentAtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentAtomicTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0013 /* ThreadSafetyRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafetyRegressionTests.swift; sourceTree = "<group>"; };
@@ -325,6 +331,7 @@
 				8D7A262D23AF2FEA00CE7442 /* client-keycert.p12 */,
 				0409971E1C1B0B96006B5A6D /* CocoaMQTTTests.swift */,
 				F0A300000000000000000005 /* MQTTAutoReconnectControllerTests.swift */,
+				F0A400000000000000000005 /* KeepAliveTests.swift */,
 				A1B2C3D4E5F60718293A0012 /* ConcurrentAtomicTests.swift */,
 				A1B2C3D4E5F60718293A0014 /* PublicLoggerAPITests.swift */,
 				8D14C7622345CAB5002D959E /* CocoaMQTTDeliverTests.swift */,
@@ -403,6 +410,7 @@
 				F0A100000000000000000001 /* MQTTPacketIdentifierAllocator.swift */,
 				F0A200000000000000000001 /* MQTT5SessionState.swift */,
 				F0A300000000000000000001 /* MQTTAutoReconnectController.swift */,
+				F0A400000000000000000001 /* MQTTKeepAliveController.swift */,
 				A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */,
 				9228E8C827610A9100063DF2 /* CocoaMQTTReasonCode.swift */,
 				9228E8C427610A8500063DF2 /* CocoaMQTTProperty.swift */,
@@ -649,6 +657,7 @@
 				F0A100000000000000000003 /* MQTTPacketIdentifierAllocator.swift in Sources */,
 				F0A200000000000000000003 /* MQTT5SessionState.swift in Sources */,
 				F0A300000000000000000003 /* MQTTAutoReconnectController.swift in Sources */,
+				F0A400000000000000000003 /* MQTTKeepAliveController.swift in Sources */,
 				1111248E24BB515E00E2DFBC /* CocoaMQTT.swift in Sources */,
 				9228E8CF27610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
 				1111248F24BB515E00E2DFBC /* FrameConnAck.swift in Sources */,
@@ -703,6 +712,7 @@
 				F0A100000000000000000004 /* MQTTPacketIdentifierAllocator.swift in Sources */,
 				F0A200000000000000000004 /* MQTT5SessionState.swift in Sources */,
 				F0A300000000000000000004 /* MQTTAutoReconnectController.swift in Sources */,
+				F0A400000000000000000004 /* MQTTKeepAliveController.swift in Sources */,
 				111124B824BB516300E2DFBC /* CocoaMQTT.swift in Sources */,
 				9228E8D027610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
 				111124B924BB516300E2DFBC /* FrameConnAck.swift in Sources */,
@@ -757,6 +767,7 @@
 				F0A100000000000000000002 /* MQTTPacketIdentifierAllocator.swift in Sources */,
 				F0A200000000000000000002 /* MQTT5SessionState.swift in Sources */,
 				F0A300000000000000000002 /* MQTTAutoReconnectController.swift in Sources */,
+				F0A400000000000000000002 /* MQTTKeepAliveController.swift in Sources */,
 				8225B53A227C2FC600E4DB51 /* CocoaMQTT.swift in Sources */,
 				9228E8CE27610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
 				8D43DE4E22FAEC6700D9A06B /* FrameConnAck.swift in Sources */,
@@ -810,6 +821,7 @@
 			files = (
 				8D14C7632345CAB5002D959E /* CocoaMQTTDeliverTests.swift in Sources */,
 				F0A300000000000000000006 /* MQTTAutoReconnectControllerTests.swift in Sources */,
+				F0A400000000000000000006 /* KeepAliveTests.swift in Sources */,
 				8D14C7672349C2A3002D959E /* CocoaMQTTStorageTests.swift in Sources */,
 				8225B556227C334700E4DB51 /* CocoaMQTTTests.swift in Sources */,
 				A1B2C3D4E5F60718293A0004 /* ConcurrentAtomicTests.swift in Sources */,

--- a/CocoaMQTTTests/KeepAliveTests.swift
+++ b/CocoaMQTTTests/KeepAliveTests.swift
@@ -184,6 +184,21 @@ final class KeepAliveTests: XCTestCase {
         XCTAssertNil(controller.interval)
     }
 
+    func testDeinitializingControllerCancelsScheduledTask() {
+        let eventLoop = DispatchQueue(label: "tests.keepalive.deinit")
+        let scheduler = Scheduler()
+        var controller: MQTTKeepAliveController? = MQTTKeepAliveController(
+            eventLoopQueue: eventLoop,
+            scheduler: scheduler
+        )
+
+        controller?.start(interval: 5)
+        let scheduledTask = scheduler.tasks[0]
+        controller = nil
+
+        XCTAssertTrue(scheduledTask.isCancelled)
+    }
+
     private func establishSession(_ mqtt: CocoaMQTT, socket: SocketSpy) {
         XCTAssertTrue(mqtt.connect())
         mqtt.socketConnected(socket)

--- a/CocoaMQTTTests/KeepAliveTests.swift
+++ b/CocoaMQTTTests/KeepAliveTests.swift
@@ -1,0 +1,224 @@
+import Foundation
+import XCTest
+@testable import CocoaMQTT
+
+final class KeepAliveTests: XCTestCase {
+
+    private final class ScheduledTask: MQTTKeepAliveScheduledTask {
+        private let action: () -> Void
+        private(set) var isCancelled = false
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        func cancel() {
+            isCancelled = true
+        }
+
+        func fireIgnoringCancellation() {
+            action()
+        }
+    }
+
+    private final class Scheduler: MQTTKeepAliveScheduling {
+        private(set) var intervals = [TimeInterval]()
+        private(set) var tasks = [ScheduledTask]()
+
+        func schedule(after interval: TimeInterval, _ action: @escaping () -> Void) -> MQTTKeepAliveScheduledTask {
+            let task = ScheduledTask(action: action)
+            intervals.append(interval)
+            tasks.append(task)
+            return task
+        }
+    }
+
+    private final class KeepAliveDelegate: MQTTKeepAliveControllerDelegate {
+        private(set) var pingCount = 0
+        private(set) var timeoutCount = 0
+
+        func keepAliveControllerRequestsPing(_ controller: MQTTKeepAliveController) {
+            pingCount += 1
+        }
+
+        func keepAliveControllerDidTimeOut(_ controller: MQTTKeepAliveController) {
+            timeoutCount += 1
+        }
+    }
+
+    private final class SocketSpy: CocoaMQTTSocketProtocol {
+        var enableSSL = false
+
+        private let lock = NSLock()
+        private weak var delegate: CocoaMQTTSocketDelegate?
+        private var delegateQueue: DispatchQueue?
+
+        func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
+            lock.lock()
+            delegate = theDelegate
+            self.delegateQueue = delegateQueue
+            lock.unlock()
+        }
+        func connect(toHost host: String, onPort port: UInt16) throws {}
+        func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
+        func disconnect() {
+            lock.lock()
+            let delegate = delegate
+            let delegateQueue = delegateQueue
+            lock.unlock()
+            delegateQueue?.async {
+                delegate?.socketDidDisconnect(self, withError: nil)
+            }
+        }
+        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
+        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {}
+    }
+
+    func testMQTT311DisconnectsWhenPingResponseDoesNotArrive() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "keepalive-timeout-\(UUID().uuidString)", socket: socket)
+        mqtt.keepAlive = 1
+        mqtt.autoReconnect = true
+        let reconnectScheduled = expectation(description: "missing PINGRESP schedules reconnect")
+        mqtt.didScheduleReconnect = { _, _, _ in
+            reconnectScheduled.fulfill()
+        }
+
+        establishSession(mqtt, socket: socket)
+
+        wait(for: [reconnectScheduled], timeout: 2.5)
+    }
+
+    func testMQTT5DisconnectsWhenPingResponseDoesNotArrive() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT5(clientID: "keepalive-timeout-5-\(UUID().uuidString)", socket: socket)
+        mqtt.keepAlive = 1
+        mqtt.autoReconnect = true
+        let reconnectScheduled = expectation(description: "missing MQTT 5 PINGRESP schedules reconnect")
+        mqtt.didScheduleReconnect = { _, _, _ in
+            reconnectScheduled.fulfill()
+        }
+
+        establishSession(mqtt, socket: socket)
+
+        wait(for: [reconnectScheduled], timeout: 2.5)
+    }
+
+    func testMQTT311KeepAliveZeroDisablesAutomaticPing() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "keepalive-disabled-\(UUID().uuidString)", socket: socket)
+        mqtt.keepAlive = 0
+
+        establishSession(mqtt, socket: socket)
+
+        XCTAssertNil(mqtt.t_keepAliveInterval())
+    }
+
+    func testControllerTimesOutAfterOneUnansweredPing() {
+        let eventLoop = DispatchQueue(label: "tests.keepalive.timeout")
+        let scheduler = Scheduler()
+        let delegate = KeepAliveDelegate()
+        let controller = MQTTKeepAliveController(eventLoopQueue: eventLoop, scheduler: scheduler)
+        controller.delegate = delegate
+
+        controller.start(interval: 7)
+        XCTAssertEqual(scheduler.intervals, [7])
+
+        scheduler.tasks[0].fireIgnoringCancellation()
+        eventLoop.sync {}
+        XCTAssertEqual(delegate.pingCount, 1)
+        XCTAssertEqual(delegate.timeoutCount, 0)
+        XCTAssertEqual(scheduler.intervals, [7, 7])
+
+        scheduler.tasks[1].fireIgnoringCancellation()
+        eventLoop.sync {}
+        XCTAssertEqual(delegate.timeoutCount, 1)
+        XCTAssertNil(controller.interval)
+    }
+
+    func testPingResponseStartsANewIdlePeriodAndInvalidatesOldTimeout() {
+        let eventLoop = DispatchQueue(label: "tests.keepalive.response")
+        let scheduler = Scheduler()
+        let delegate = KeepAliveDelegate()
+        let controller = MQTTKeepAliveController(eventLoopQueue: eventLoop, scheduler: scheduler)
+        controller.delegate = delegate
+
+        controller.start(interval: 9)
+        scheduler.tasks[0].fireIgnoringCancellation()
+        eventLoop.sync {}
+        let staleTimeout = scheduler.tasks[1]
+
+        controller.pingResponseReceived()
+        XCTAssertTrue(staleTimeout.isCancelled)
+        staleTimeout.fireIgnoringCancellation()
+        eventLoop.sync {}
+        XCTAssertEqual(delegate.timeoutCount, 0)
+
+        scheduler.tasks[2].fireIgnoringCancellation()
+        eventLoop.sync {}
+        XCTAssertEqual(delegate.pingCount, 2)
+    }
+
+    func testRepeatedManualPingDoesNotExtendOutstandingResponseDeadline() {
+        let eventLoop = DispatchQueue(label: "tests.keepalive.manual-ping")
+        let scheduler = Scheduler()
+        let controller = MQTTKeepAliveController(eventLoopQueue: eventLoop, scheduler: scheduler)
+
+        controller.start(interval: 5)
+        controller.pingSent()
+        let responseDeadline = scheduler.tasks[1]
+        controller.pingSent()
+
+        XCTAssertEqual(scheduler.tasks.count, 2)
+        XCTAssertFalse(responseDeadline.isCancelled)
+    }
+
+    func testStartingWithZeroKeepAliveSchedulesNothing() {
+        let eventLoop = DispatchQueue(label: "tests.keepalive.disabled")
+        let scheduler = Scheduler()
+        let controller = MQTTKeepAliveController(eventLoopQueue: eventLoop, scheduler: scheduler)
+
+        controller.start(interval: 0)
+
+        XCTAssertTrue(scheduler.tasks.isEmpty)
+        XCTAssertNil(controller.interval)
+    }
+
+    private func establishSession(_ mqtt: CocoaMQTT, socket: SocketSpy) {
+        XCTAssertTrue(mqtt.connect())
+        mqtt.socketConnected(socket)
+        let connack = FrameConnAck(
+            packetFixedHeaderType: FrameType.connack.rawValue,
+            bytes: [0, CocoaMQTTConnAck.accept.rawValue],
+            protocolVersion: .v311
+        )
+        XCTAssertNotNil(connack)
+        if let connack {
+            mqtt.didReceive(
+                CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v311),
+                connack: connack
+            )
+        }
+    }
+
+    private func establishSession(_ mqtt: CocoaMQTT5, socket: SocketSpy) {
+        XCTAssertTrue(mqtt.connect())
+        mqtt.socketConnected(socket)
+        let connack = FrameConnAck(
+            packetFixedHeaderType: FrameType.connack.rawValue,
+            bytes: [
+                0,
+                CocoaMQTTCONNACKReasonCode.success.rawValue,
+                0
+            ],
+            protocolVersion: .v5
+        )
+        XCTAssertNotNil(connack)
+        if let connack {
+            mqtt.didReceive(
+                CocoaMQTTReader(socket: socket, delegate: nil, protocolVersion: .v5),
+                connack: connack
+            )
+        }
+    }
+}

--- a/CocoaMQTTTests/SendingMessageLifecycleTests.swift
+++ b/CocoaMQTTTests/SendingMessageLifecycleTests.swift
@@ -1111,6 +1111,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
     func testMQTT5UsesServerKeepAlive() {
         let socket = SocketSpy()
         let mqtt = CocoaMQTT5(clientID: "server-keepalive-\(UUID().uuidString)", socket: socket)
+        mqtt.keepAlive = 30
         establishSession(
             mqtt,
             socket: socket,
@@ -1119,6 +1120,20 @@ final class SendingMessageLifecycleTests: XCTestCase {
             serverKeepAlive: 7
         )
         XCTAssertEqual(mqtt.t_keepAliveInterval(), 7)
+    }
+
+    func testMQTT5ServerKeepAliveZeroDisablesAutomaticPing() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT5(clientID: "server-keepalive-zero-\(UUID().uuidString)", socket: socket)
+        mqtt.keepAlive = 30
+        establishSession(
+            mqtt,
+            socket: socket,
+            cleanStart: true,
+            requestedExpiry: 0,
+            serverKeepAlive: 0
+        )
+        XCTAssertNil(mqtt.t_keepAliveInterval())
     }
 
     func testMQTT5ReusesSessionControllerWhenClientIdentifierCycles() {

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -247,7 +247,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Keep alive time interval
     public var keepAlive: UInt16 = 60
-    private var aliveTimer: CocoaMQTTTimer?
+    private let keepAliveController: MQTTKeepAliveController
 
     /// Maximum duration in seconds for each Remaining Length byte and the complete payload read.
     /// Each deadline starts with its read and is not reset by partial data. Header reads remain unlimited.
@@ -414,15 +414,17 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         let eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT.event-loop.\(UUID().uuidString)")
         self.eventLoopQueue = eventLoopQueue
         self.autoReconnectController = MQTTAutoReconnectController(eventLoopQueue: eventLoopQueue)
+        self.keepAliveController = MQTTKeepAliveController(eventLoopQueue: eventLoopQueue)
         super.init()
         autoReconnectController.delegate = self
+        keepAliveController.delegate = self
         socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
         socketDelegateProxy.delegate = self
         deliver.delegate = self
     }
 
     deinit {
-        aliveTimer?.suspend()
+        keepAliveController.stop()
 
         socket.setDelegate(nil, delegateQueue: nil)
         socket.disconnect()
@@ -608,6 +610,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Disconnect unexpectedly.
     /// This keeps auto-reconnect behavior enabled.
     func internal_disconnect() {
+        keepAliveController.stop()
         autoReconnectController.beginUnexpectedDisconnect()
         socket.disconnect()
     }
@@ -633,11 +636,17 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     private func expected_disconnect() {
         guard autoReconnectController.beginExpectedDisconnect() else { return }
+        keepAliveController.stop()
         send(FrameDisconnect(), tag: -0xE0, disconnectAfterWriting: true)
     }
 
     /// Send a PING request to broker
     public func ping() {
+        keepAliveController.pingSent()
+        sendPing()
+    }
+
+    private func sendPing() {
         printDebug("ping")
         send(FramePingReq(), tag: -0xC0)
 
@@ -944,6 +953,7 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
 
     public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
         // Clean up
+        keepAliveController.stop()
         socket.setDelegate(nil, delegateQueue: nil)
         clientStateLock.lock()
         // Publish uses the same lock, so queue admission cannot race with the
@@ -990,20 +1000,9 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
             autoReconnectController.connectionSucceeded()
 
-            // Start keepalive timer
+            // Start keepalive liveness tracking. A zero value disables it.
 
-            let interval = Double(keepAlive <= 0 ? 60: keepAlive)
-
-            aliveTimer = CocoaMQTTTimer.every(interval, name: "aliveTimer") { [weak self] in
-                guard let self = self else { return }
-                self.eventLoopQueue.async {
-                    guard self.connState == .connected else {
-                        self.aliveTimer = nil
-                        return
-                    }
-                    self.ping()
-                }
-            }
+            keepAliveController.start(interval: keepAlive)
 
             // recover session if enable
 
@@ -1188,6 +1187,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
     func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
+        keepAliveController.pingResponseReceived()
 
         __delegate_queue { mqtt in
             mqtt.delegate?.mqttDidReceivePong(mqtt)
@@ -1206,6 +1206,22 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
     }
 }
 
+extension CocoaMQTT: MQTTKeepAliveControllerDelegate {
+    func keepAliveControllerRequestsPing(_ controller: MQTTKeepAliveController) {
+        guard connState == .connected else {
+            controller.stop()
+            return
+        }
+        sendPing()
+    }
+
+    func keepAliveControllerDidTimeOut(_ controller: MQTTKeepAliveController) {
+        guard connState == .connected else { return }
+        printWarning("PINGRESP timed out, closing socket")
+        internal_disconnect()
+    }
+}
+
 // For tests
 extension CocoaMQTT {
     func t_sendingMessagesCount() -> Int {
@@ -1214,6 +1230,10 @@ extension CocoaMQTT {
 
     func t_reservedPacketIdentifierCount() -> Int {
         packetIdentifiers.reservedCount
+    }
+
+    func t_keepAliveInterval() -> TimeInterval? {
+        keepAliveController.interval
     }
 
     func t_waitUntilDeliverIdle() {

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -1000,10 +1000,6 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
             autoReconnectController.connectionSucceeded()
 
-            // Start keepalive liveness tracking. A zero value disables it.
-
-            keepAliveController.start(interval: keepAlive)
-
             // recover session if enable
 
             if cleanSession || !connack.sessPresent {
@@ -1034,6 +1030,8 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
             deliver.completeConnection()
             connState = .connected
+            // Start only after session recovery has completed and the client can send PINGREQ.
+            keepAliveController.start(interval: keepAlive)
 
         } else {
             connState = .disconnected

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -1376,9 +1376,7 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
             autoReconnectController.connectionSucceeded()
 
-            // Start keepalive liveness tracking.
             let negotiatedKeepAlive = properties?.serverKeepAlive ?? keepAlive
-            keepAliveController.start(interval: negotiatedKeepAlive)
 
             // recover session if enable
 
@@ -1418,6 +1416,8 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
             deliver.completeConnection()
             connState = .connected
+            // Start only after session recovery has completed and the client can send PINGREQ.
+            keepAliveController.start(interval: negotiatedKeepAlive)
 
         } else {
             connState = .disconnected

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -242,7 +242,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Keep alive time interval
     public var keepAlive: UInt16 = 60
-    private var aliveTimer: CocoaMQTTTimer?
+    private let keepAliveController: MQTTKeepAliveController
 
     /// Maximum duration in seconds for each Remaining Length byte and the complete payload read.
     /// Each deadline starts with its read and is not reset by partial data. Header reads remain unlimited.
@@ -443,8 +443,10 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         let eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT5.event-loop.\(UUID().uuidString)")
         self.eventLoopQueue = eventLoopQueue
         self.autoReconnectController = MQTTAutoReconnectController(eventLoopQueue: eventLoopQueue)
+        self.keepAliveController = MQTTKeepAliveController(eventLoopQueue: eventLoopQueue)
         super.init()
         autoReconnectController.delegate = self
+        keepAliveController.delegate = self
         socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
         socketDelegateProxy.delegate = self
         $connState.setMutationObserver { [weak self] state in
@@ -460,7 +462,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
 
     deinit {
-        aliveTimer?.suspend()
+        keepAliveController.stop()
         sessionExpiryController?.handleDisconnect()
         socket.setDelegate(nil, delegateQueue: nil)
         socket.disconnect()
@@ -730,6 +732,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Disconnect unexpectedly.
     /// This keeps auto-reconnect behavior enabled.
     func internal_disconnect() {
+        keepAliveController.stop()
         autoReconnectController.beginUnexpectedDisconnect()
         socket.disconnect()
     }
@@ -761,6 +764,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
                                      userProperties: [String: String]? = nil,
                                      recordsLocalReason: Bool = false) {
         guard autoReconnectController.beginExpectedDisconnect() else { return }
+        keepAliveController.stop()
         if recordsLocalReason {
             markPendingLocalDisconnect(reasonCode: reasonCode)
         }
@@ -773,6 +777,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
     /// Send a PING request to broker
     public func ping() {
+        keepAliveController.pingSent()
+        sendPing()
+    }
+
+    private func sendPing() {
         printDebug("ping")
         guard send(FramePingReq(), tag: -0xC0) else {
             internal_disconnect()
@@ -1246,6 +1255,7 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
 
     public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
         // Clean up
+        keepAliveController.stop()
         socket.setDelegate(nil, delegateQueue: nil)
         clientStateLock.lock()
         // Publish uses the same lock, so no frame can enter the new connection
@@ -1366,22 +1376,9 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
             autoReconnectController.connectionSucceeded()
 
-            // Start keepalive timer
-
+            // Start keepalive liveness tracking.
             let negotiatedKeepAlive = properties?.serverKeepAlive ?? keepAlive
-            aliveTimer = nil
-            if negotiatedKeepAlive > 0 {
-                aliveTimer = CocoaMQTTTimer.every(Double(negotiatedKeepAlive), name: "aliveTimer") { [weak self] in
-                    guard let self = self else { return }
-                    self.eventLoopQueue.async {
-                        guard self.connState == .connected else {
-                            self.aliveTimer = nil
-                            return
-                        }
-                        self.ping()
-                    }
-                }
-            }
+            keepAliveController.start(interval: negotiatedKeepAlive)
 
             // recover session if enable
 
@@ -1624,11 +1621,28 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
     func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
+        keepAliveController.pingResponseReceived()
 
         __delegate_queue { mqtt5 in
             mqtt5.delegate?.mqtt5DidReceivePong(mqtt5)
             mqtt5.didReceivePong(mqtt5)
         }
+    }
+}
+
+extension CocoaMQTT5: MQTTKeepAliveControllerDelegate {
+    func keepAliveControllerRequestsPing(_ controller: MQTTKeepAliveController) {
+        guard connState == .connected else {
+            controller.stop()
+            return
+        }
+        sendPing()
+    }
+
+    func keepAliveControllerDidTimeOut(_ controller: MQTTKeepAliveController) {
+        guard connState == .connected else { return }
+        printWarning("PINGRESP timed out, closing socket")
+        internal_disconnect()
     }
 }
 
@@ -1643,7 +1657,7 @@ extension CocoaMQTT5 {
     }
 
     func t_keepAliveInterval() -> TimeInterval? {
-        aliveTimer?.timeInterval
+        keepAliveController.interval
     }
 
     func t_sessionExpiryControllerCount() -> Int {

--- a/Source/MQTTKeepAliveController.swift
+++ b/Source/MQTTKeepAliveController.swift
@@ -1,0 +1,154 @@
+//
+//  MQTTKeepAliveController.swift
+//  CocoaMQTT
+//
+
+import Foundation
+
+protocol MQTTKeepAliveScheduledTask: AnyObject {
+    func cancel()
+}
+
+protocol MQTTKeepAliveScheduling {
+    func schedule(after interval: TimeInterval, _ action: @escaping () -> Void) -> MQTTKeepAliveScheduledTask
+}
+
+protocol MQTTKeepAliveControllerDelegate: AnyObject {
+    func keepAliveControllerRequestsPing(_ controller: MQTTKeepAliveController)
+    func keepAliveControllerDidTimeOut(_ controller: MQTTKeepAliveController)
+}
+
+extension CocoaMQTTTimer: MQTTKeepAliveScheduledTask {}
+
+private struct CocoaMQTTKeepAliveScheduler: MQTTKeepAliveScheduling {
+    func schedule(after interval: TimeInterval, _ action: @escaping () -> Void) -> MQTTKeepAliveScheduledTask {
+        CocoaMQTTTimer.after(interval, name: "keepAliveTimer", action)
+    }
+}
+
+/// Owns protocol-neutral PINGREQ/PINGRESP liveness state.
+final class MQTTKeepAliveController: @unchecked Sendable {
+    private enum Phase {
+        case stopped
+        case idle
+        case awaitingResponse
+    }
+
+    private let eventLoopQueue: DispatchQueue
+    private let scheduler: MQTTKeepAliveScheduling
+    private let lock = NSLock()
+
+    weak var delegate: MQTTKeepAliveControllerDelegate?
+
+    private var phase = Phase.stopped
+    private var scheduledTask: MQTTKeepAliveScheduledTask?
+    private var generation: UInt64 = 0
+    private var configuredInterval: TimeInterval?
+
+    init(
+        eventLoopQueue: DispatchQueue,
+        scheduler: MQTTKeepAliveScheduling = CocoaMQTTKeepAliveScheduler()
+    ) {
+        self.eventLoopQueue = eventLoopQueue
+        self.scheduler = scheduler
+    }
+
+    deinit {
+        scheduledTask?.cancel()
+    }
+
+    var interval: TimeInterval? {
+        lock.lock()
+        defer { lock.unlock() }
+        return configuredInterval
+    }
+
+    func start(interval: UInt16) {
+        lock.lock()
+        stopLocked()
+        guard interval > 0 else {
+            lock.unlock()
+            return
+        }
+        configuredInterval = TimeInterval(interval)
+        phase = .idle
+        scheduleNextEventLocked()
+        lock.unlock()
+    }
+
+    func stop() {
+        lock.lock()
+        stopLocked()
+        lock.unlock()
+    }
+
+    private func stopLocked() {
+        generation &+= 1
+        scheduledTask?.cancel()
+        scheduledTask = nil
+        configuredInterval = nil
+        phase = .stopped
+    }
+
+    func pingSent() {
+        lock.lock()
+        guard phase == .idle else {
+            lock.unlock()
+            return
+        }
+        phase = .awaitingResponse
+        scheduleNextEventLocked()
+        lock.unlock()
+    }
+
+    func pingResponseReceived() {
+        lock.lock()
+        guard phase == .awaitingResponse else {
+            lock.unlock()
+            return
+        }
+        phase = .idle
+        scheduleNextEventLocked()
+        lock.unlock()
+    }
+
+    private func scheduleNextEventLocked() {
+        guard let interval = configuredInterval else { return }
+        generation &+= 1
+        let scheduledGeneration = generation
+        scheduledTask?.cancel()
+        scheduledTask = scheduler.schedule(after: interval) { [weak self] in
+            guard let self = self else { return }
+            self.eventLoopQueue.async {
+                self.handleScheduledEvent(generation: scheduledGeneration)
+            }
+        }
+    }
+
+    private func handleScheduledEvent(generation scheduledGeneration: UInt64) {
+        lock.lock()
+        guard scheduledGeneration == generation else {
+            lock.unlock()
+            return
+        }
+        scheduledTask = nil
+
+        switch phase {
+        case .stopped:
+            lock.unlock()
+            return
+        case .idle:
+            phase = .awaitingResponse
+            scheduleNextEventLocked()
+            let delegate = delegate
+            lock.unlock()
+            delegate?.keepAliveControllerRequestsPing(self)
+        case .awaitingResponse:
+            phase = .stopped
+            configuredInterval = nil
+            let delegate = delegate
+            lock.unlock()
+            delegate?.keepAliveControllerDidTimeOut(self)
+        }
+    }
+}

--- a/Source/MQTTKeepAliveController.swift
+++ b/Source/MQTTKeepAliveController.swift
@@ -54,7 +54,7 @@ final class MQTTKeepAliveController: @unchecked Sendable {
     }
 
     deinit {
-        scheduledTask?.cancel()
+        stop()
     }
 
     var interval: TimeInterval? {


### PR DESCRIPTION
## What changed
- add a shared, thread-safe keepalive controller for MQTT 3.1.1 and MQTT 5
- track the PINGREQ/PINGRESP lifecycle explicitly and close a half-open socket after one unanswered response deadline
- hand keepalive timeouts to the existing unexpected-disconnect and auto-reconnect lifecycle
- honor MQTT 3.1.1 `keepAlive == 0` by disabling automatic keepalive traffic
- continue using MQTT 5 Server Keep Alive when negotiated
- invalidate stale timers on PONG, reconnect, expected disconnect, unexpected disconnect, and deinitialization

## Why
The clients periodically sent PINGREQ packets but never tracked whether a PINGRESP arrived. A half-open connection could therefore remain `connected` indefinitely and never enter the auto-reconnect path.

Before the production change, the new MQTT 3.1.1 facade regression failed after 2.5 seconds because no socket disconnect or reconnect schedule occurred. The same path is now covered for MQTT 5.

Fixes #319
Related to #504

## Verification
- `swift test --filter KeepAliveTests`
- `swift test --sanitize=thread --filter KeepAliveTests`
- `swift test --filter 'AutoReconnectStateTests|MQTTAutoReconnectControllerTests|ClientEventLoopTests|SendingMessageLifecycleTests'`
- `swift test --skip '^CocoaMQTTTests\\.CocoaMQTTTests/'`
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `swift build -c release`
- `Tools/lint.sh --strict Source/MQTTKeepAliveController.swift Source/CocoaMQTT.swift Source/CocoaMQTT5.swift CocoaMQTTTests/KeepAliveTests.swift`
- `xcodebuild -project CocoaMQTT.xcodeproj -scheme 'Mac Framework' -derivedDataPath /tmp/CocoaMQTT-keepalive-derived build CODE_SIGNING_ALLOWED=NO`

The skipped `CocoaMQTTTests.CocoaMQTTTests` class requires a local MQTT broker. AWS integration remains environment-gated and skipped without credentials.
