### PR TITLE
Avoid blocking client teardown on socket cleanup

### DIFF
--- a/CocoaMQTTTests/ClientEventLoopTests.swift
+++ b/CocoaMQTTTests/ClientEventLoopTests.swift
@@ -20,17 +20,19 @@ final class ClientEventLoopTests: XCTestCase {
         }
     }
 
-    private final class BlockingNativeTeardownSocket: CocoaMQTTSocketProtocol, MQTTClientTeardownSocket, @unchecked Sendable {
+    private final class BlockingTeardownSocket: CocoaMQTTSocketProtocol, MQTTClientTeardownSocket, @unchecked Sendable {
         var enableSSL = false
 
         let disconnectStarted = DispatchSemaphore(value: 0)
         let allowDisconnect = DispatchSemaphore(value: 0)
 
-        func scheduleClientTeardown() {
+        func prepareClientTeardown() -> Bool {
             setDelegate(nil, delegateQueue: nil)
-            DispatchQueue.global(qos: .utility).async {
-                self.disconnect()
-            }
+            return true
+        }
+
+        func performClientTeardown() {
+            disconnect()
         }
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
@@ -330,7 +332,7 @@ final class ClientEventLoopTests: XCTestCase {
     private func assertDeinitDoesNotWaitForNativeTransportDisconnect(
         makeClient: (CocoaMQTTSocketProtocol) -> AnyObject
     ) {
-        let socket = BlockingNativeTeardownSocket()
+        let socket = BlockingTeardownSocket()
         let holder = ClientHolder(makeClient(socket))
         let releaseReturned = DispatchSemaphore(value: 0)
 

--- a/CocoaMQTTTests/ClientEventLoopTests.swift
+++ b/CocoaMQTTTests/ClientEventLoopTests.swift
@@ -12,18 +12,57 @@ final class ClientEventLoopTests: XCTestCase {
         }
     }
 
+    private final class ClientHolder: @unchecked Sendable {
+        var client: AnyObject?
+
+        init(_ client: AnyObject) {
+            self.client = client
+        }
+    }
+
+    private final class BlockingNativeTeardownSocket: CocoaMQTTSocketProtocol, MQTTClientTeardownSocket, @unchecked Sendable {
+        var enableSSL = false
+
+        let disconnectStarted = DispatchSemaphore(value: 0)
+        let allowDisconnect = DispatchSemaphore(value: 0)
+
+        func scheduleClientTeardown() {
+            setDelegate(nil, delegateQueue: nil)
+            DispatchQueue.global(qos: .utility).async {
+                self.disconnect()
+            }
+        }
+
+        func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
+        func connect(toHost host: String, onPort port: UInt16) throws {}
+        func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
+        func disconnect() {
+            disconnectStarted.signal()
+            allowDisconnect.wait()
+        }
+        func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
+        func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {}
+    }
+
     private final class SocketSpy: CocoaMQTTSocketProtocol {
         var enableSSL = false
 
         private let lock = NSLock()
         private weak var delegate: CocoaMQTTSocketDelegate?
         private var _delegateQueue: DispatchQueue?
+        private var _disconnectCallCount = 0
         var writeHandler: (() -> Void)?
 
         var capturedDelegateQueue: DispatchQueue? {
             lock.lock()
             defer { lock.unlock() }
             return _delegateQueue
+        }
+
+        var disconnectCallCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _disconnectCallCount
         }
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
@@ -42,7 +81,11 @@ final class ClientEventLoopTests: XCTestCase {
 
         func connect(toHost host: String, onPort port: UInt16) throws {}
         func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {}
-        func disconnect() {}
+        func disconnect() {
+            lock.lock()
+            _disconnectCallCount += 1
+            lock.unlock()
+        }
         func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {}
         func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
             writeHandler?()
@@ -179,6 +222,31 @@ final class ClientEventLoopTests: XCTestCase {
         callbackQueue.sync {}
     }
 
+    func testMQTT311DeinitDoesNotWaitForNativeTransportDisconnect() {
+        assertDeinitDoesNotWaitForNativeTransportDisconnect {
+            CocoaMQTT(clientID: "nonblocking-deinit-311", socket: $0)
+        }
+    }
+
+    func testMQTT5DeinitDoesNotWaitForNativeTransportDisconnect() {
+        assertDeinitDoesNotWaitForNativeTransportDisconnect {
+            CocoaMQTT5(clientID: "nonblocking-deinit-5", socket: $0)
+        }
+    }
+
+    func testCustomSocketRetainsSynchronousDeinitCleanupByDefault() {
+        let socket = SocketSpy()
+        var mqtt311: CocoaMQTT? = CocoaMQTT(clientID: "custom-deinit-311", socket: socket)
+        var mqtt5: CocoaMQTT5? = CocoaMQTT5(clientID: "custom-deinit-5", socket: socket)
+
+        XCTAssertNotNil(mqtt311)
+        XCTAssertNotNil(mqtt5)
+        mqtt311 = nil
+        XCTAssertEqual(socket.disconnectCallCount, 1)
+        mqtt5 = nil
+        XCTAssertEqual(socket.disconnectCallCount, 2)
+    }
+
     func testCallbackQueueChangeDoesNotMoveAlreadySubmittedCallbacks() {
         let mqtt = CocoaMQTT(clientID: "callback-queue-snapshot")
         let firstQueue = DispatchQueue(label: "tests.event-loop.first-callback")
@@ -257,5 +325,27 @@ final class ClientEventLoopTests: XCTestCase {
         )
 
         wait(for: [write], timeout: 1)
+    }
+
+    private func assertDeinitDoesNotWaitForNativeTransportDisconnect(
+        makeClient: (CocoaMQTTSocketProtocol) -> AnyObject
+    ) {
+        let socket = BlockingNativeTeardownSocket()
+        let holder = ClientHolder(makeClient(socket))
+        let releaseReturned = DispatchSemaphore(value: 0)
+
+        DispatchQueue(label: "tests.client-release").async {
+            holder.client = nil
+            releaseReturned.signal()
+        }
+
+        XCTAssertEqual(socket.disconnectStarted.wait(timeout: .now() + 1), .success)
+        let result = releaseReturned.wait(timeout: .now() + 1)
+        socket.allowDisconnect.signal()
+
+        XCTAssertEqual(result, .success)
+        if result != .success {
+            XCTAssertEqual(releaseReturned.wait(timeout: .now() + 1), .success)
+        }
     }
 }

--- a/CocoaMQTTTests/ClientEventLoopTests.swift
+++ b/CocoaMQTTTests/ClientEventLoopTests.swift
@@ -341,13 +341,13 @@ final class ClientEventLoopTests: XCTestCase {
             releaseReturned.signal()
         }
 
-        XCTAssertEqual(socket.disconnectStarted.wait(timeout: .now() + 1), .success)
-        let result = releaseReturned.wait(timeout: .now() + 1)
+        XCTAssertEqual(socket.disconnectStarted.wait(timeout: .now() + 3), .success)
+        let result = releaseReturned.wait(timeout: .now() + 3)
         socket.allowDisconnect.signal()
 
         XCTAssertEqual(result, .success)
         if result != .success {
-            XCTAssertEqual(releaseReturned.wait(timeout: .now() + 1), .success)
+            XCTAssertEqual(releaseReturned.wait(timeout: .now() + 3), .success)
         }
     }
 }

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -425,9 +425,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     deinit {
         keepAliveController.stop()
-
-        socket.setDelegate(nil, delegateQueue: nil)
-        socket.disconnect()
+        socket.disconnectForClientDeinit()
     }
 
     fileprivate func send(_ frame: Frame, tag: Int = 0, disconnectAfterWriting: Bool = false) {

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -464,8 +464,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     deinit {
         keepAliveController.stop()
         sessionExpiryController?.handleDisconnect()
-        socket.setDelegate(nil, delegateQueue: nil)
-        socket.disconnect()
+        socket.disconnectForClientDeinit()
     }
 
     @discardableResult

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -100,6 +100,23 @@ public protocol CocoaMQTTSocketProtocol {
     func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int)
 }
 
+protocol MQTTClientTeardownSocket: AnyObject {
+    func scheduleClientTeardown()
+}
+
+extension CocoaMQTTSocketProtocol {
+    /// Native TCP teardown can block while removing streams from its run loop.
+    /// Other transports retain their established synchronous cleanup contract.
+    func disconnectForClientDeinit() {
+        if let socket = self as? MQTTClientTeardownSocket {
+            socket.scheduleClientTeardown()
+            return
+        }
+        setDelegate(nil, delegateQueue: nil)
+        disconnect()
+    }
+}
+
 /// Normalizes callbacks from built-in and custom transports onto the client's
 /// private event loop. Custom transports are not required to honor the queue
 /// passed to `setDelegate`; correctness is enforced at this boundary instead.
@@ -197,9 +214,22 @@ public extension CocoaMQTTSocketProtocol {
 
 public class CocoaMQTTSocket: NSObject {
 
+    private final class TeardownReference: @unchecked Sendable {
+        let socket: CocoaMQTTSocket
+
+        init(_ socket: CocoaMQTTSocket) {
+            self.socket = socket
+        }
+    }
+
     private static let trustEvaluationQueue = DispatchQueue(
         label: "trust.cocoamqtt.emqx",
         qos: .userInitiated
+    )
+    private static let teardownQueue = DispatchQueue(
+        label: "io.emqx.CocoaMQTT.transport-teardown",
+        qos: .utility,
+        attributes: .concurrent
     )
 
     public var backgroundOnSocket = true
@@ -235,7 +265,9 @@ public class CocoaMQTTSocket: NSObject {
     fileprivate let reference = MGCDAsyncSocket()
     fileprivate weak var delegate: CocoaMQTTSocketDelegate?
     private let connectionStateLock = NSLock()
+    private let teardownCondition = NSCondition()
     private var connectedHost: String?
+    private var teardownPending = false
 
     public override init() { super.init() }
 
@@ -262,6 +294,9 @@ public class CocoaMQTTSocket: NSObject {
 
 extension CocoaMQTTSocket: CocoaMQTTDisconnectAfterWritingSocket {
     public func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
+        if theDelegate != nil {
+            waitForPendingClientTeardown()
+        }
         delegate = theDelegate
         reference.setDelegate((delegate != nil ? self : nil), delegateQueue: delegateQueue)
     }
@@ -271,6 +306,7 @@ extension CocoaMQTTSocket: CocoaMQTTDisconnectAfterWritingSocket {
     }
 
     public func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {
+        waitForPendingClientTeardown()
         connectionStateLock.lock()
         connectedHost = host
         connectionStateLock.unlock()
@@ -278,6 +314,7 @@ extension CocoaMQTTSocket: CocoaMQTTDisconnectAfterWritingSocket {
     }
 
     public func disconnect() {
+        waitForPendingClientTeardown()
         reference.disconnect()
     }
 
@@ -292,6 +329,43 @@ extension CocoaMQTTSocket: CocoaMQTTDisconnectAfterWritingSocket {
     public func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
         reference.write(data, withTimeout: timeout, tag: tag)
         reference.disconnectAfterWriting()
+    }
+}
+
+extension CocoaMQTTSocket: MQTTClientTeardownSocket {
+    func scheduleClientTeardown() {
+        teardownCondition.lock()
+        guard !teardownPending else {
+            teardownCondition.unlock()
+            return
+        }
+        teardownPending = true
+        teardownCondition.unlock()
+
+        delegate = nil
+        reference.setDelegate(nil, delegateQueue: nil)
+
+        let socketReference = TeardownReference(self)
+        Self.teardownQueue.async {
+            socketReference.socket.finishClientTeardown()
+        }
+    }
+
+    private func finishClientTeardown() {
+        reference.disconnect()
+
+        teardownCondition.lock()
+        teardownPending = false
+        teardownCondition.broadcast()
+        teardownCondition.unlock()
+    }
+
+    private func waitForPendingClientTeardown() {
+        teardownCondition.lock()
+        while teardownPending {
+            teardownCondition.wait()
+        }
+        teardownCondition.unlock()
     }
 }
 

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -101,7 +101,34 @@ public protocol CocoaMQTTSocketProtocol {
 }
 
 protocol MQTTClientTeardownSocket: AnyObject {
-    func scheduleClientTeardown()
+    func prepareClientTeardown() -> Bool
+    func performClientTeardown()
+}
+
+private final class MQTTClientTeardownReference: @unchecked Sendable {
+    let socket: MQTTClientTeardownSocket
+
+    init(_ socket: MQTTClientTeardownSocket) {
+        self.socket = socket
+    }
+}
+
+private enum MQTTClientTeardownScheduler {
+    static let queue = DispatchQueue(
+        label: "io.emqx.CocoaMQTT.transport-teardown",
+        qos: .utility,
+        attributes: .concurrent
+    )
+}
+
+extension MQTTClientTeardownSocket {
+    func scheduleClientTeardown() {
+        guard prepareClientTeardown() else { return }
+        let reference = MQTTClientTeardownReference(self)
+        MQTTClientTeardownScheduler.queue.async {
+            reference.socket.performClientTeardown()
+        }
+    }
 }
 
 extension CocoaMQTTSocketProtocol {
@@ -214,22 +241,9 @@ public extension CocoaMQTTSocketProtocol {
 
 public class CocoaMQTTSocket: NSObject {
 
-    private final class TeardownReference: @unchecked Sendable {
-        let socket: CocoaMQTTSocket
-
-        init(_ socket: CocoaMQTTSocket) {
-            self.socket = socket
-        }
-    }
-
     private static let trustEvaluationQueue = DispatchQueue(
         label: "trust.cocoamqtt.emqx",
         qos: .userInitiated
-    )
-    private static let teardownQueue = DispatchQueue(
-        label: "io.emqx.CocoaMQTT.transport-teardown",
-        qos: .utility,
-        attributes: .concurrent
     )
 
     public var backgroundOnSocket = true
@@ -294,11 +308,10 @@ public class CocoaMQTTSocket: NSObject {
 
 extension CocoaMQTTSocket: CocoaMQTTDisconnectAfterWritingSocket {
     public func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
-        if theDelegate != nil {
-            waitForPendingClientTeardown()
+        withClientTeardownExcluded {
+            delegate = theDelegate
+            reference.setDelegate((delegate != nil ? self : nil), delegateQueue: delegateQueue)
         }
-        delegate = theDelegate
-        reference.setDelegate((delegate != nil ? self : nil), delegateQueue: delegateQueue)
     }
 
     public func connect(toHost host: String, onPort port: UInt16) throws {
@@ -306,52 +319,54 @@ extension CocoaMQTTSocket: CocoaMQTTDisconnectAfterWritingSocket {
     }
 
     public func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {
-        waitForPendingClientTeardown()
-        connectionStateLock.lock()
-        connectedHost = host
-        connectionStateLock.unlock()
-        try reference.connect(toHost: host, onPort: port, withTimeout: timeout)
+        try withClientTeardownExcluded {
+            connectionStateLock.lock()
+            connectedHost = host
+            connectionStateLock.unlock()
+            try reference.connect(toHost: host, onPort: port, withTimeout: timeout)
+        }
     }
 
     public func disconnect() {
-        waitForPendingClientTeardown()
-        reference.disconnect()
+        withClientTeardownExcluded {
+            reference.disconnect()
+        }
     }
 
     public func readData(toLength length: UInt, withTimeout timeout: TimeInterval, tag: Int) {
-        reference.readData(toLength: length, withTimeout: timeout, tag: tag)
+        withClientTeardownExcluded {
+            reference.readData(toLength: length, withTimeout: timeout, tag: tag)
+        }
     }
 
     public func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
-        reference.write(data, withTimeout: timeout, tag: tag)
+        withClientTeardownExcluded {
+            reference.write(data, withTimeout: timeout, tag: tag)
+        }
     }
 
     public func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
-        reference.write(data, withTimeout: timeout, tag: tag)
-        reference.disconnectAfterWriting()
+        withClientTeardownExcluded {
+            reference.write(data, withTimeout: timeout, tag: tag)
+            reference.disconnectAfterWriting()
+        }
     }
 }
 
 extension CocoaMQTTSocket: MQTTClientTeardownSocket {
-    func scheduleClientTeardown() {
+    func prepareClientTeardown() -> Bool {
         teardownCondition.lock()
+        defer { teardownCondition.unlock() }
         guard !teardownPending else {
-            teardownCondition.unlock()
-            return
+            return false
         }
         teardownPending = true
-        teardownCondition.unlock()
-
         delegate = nil
         reference.setDelegate(nil, delegateQueue: nil)
-
-        let socketReference = TeardownReference(self)
-        Self.teardownQueue.async {
-            socketReference.socket.finishClientTeardown()
-        }
+        return true
     }
 
-    private func finishClientTeardown() {
+    func performClientTeardown() {
         reference.disconnect()
 
         teardownCondition.lock()
@@ -360,12 +375,15 @@ extension CocoaMQTTSocket: MQTTClientTeardownSocket {
         teardownCondition.unlock()
     }
 
-    private func waitForPendingClientTeardown() {
+    private func withClientTeardownExcluded<Result>(
+        _ operation: () throws -> Result
+    ) rethrows -> Result {
         teardownCondition.lock()
         while teardownPending {
             teardownCondition.wait()
         }
-        teardownCondition.unlock()
+        defer { teardownCondition.unlock() }
+        return try operation()
     }
 }
 


### PR DESCRIPTION
## What changed
- move native TCP socket cleanup off the thread that releases `CocoaMQTT` or `CocoaMQTT5`
- detach the native socket delegate before scheduling teardown so callbacks cannot outlive the client
- serialize immediate native-socket reuse behind pending teardown, preserving the previous disconnect-before-reconnect ordering
- retain the existing synchronous deinit cleanup contract for custom transports
- add MQTT 3.1.1, MQTT 5, and custom-transport regressions

## Why
`MGCDAsyncSocket.disconnect()` is synchronous and may wait for its CFStream run-loop cleanup. Calling it directly from client `deinit` can block a main or user-interactive thread and trigger the priority inversion reported in #580.

Fixes #580

## Verification
- `swift test --filter ClientEventLoopTests`
- `swift test --sanitize=thread --filter ClientEventLoopTests`
- `swift test --skip '^CocoaMQTTTests\\.CocoaMQTTTests/'`
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `Tools/lint.sh --strict Source/CocoaMQTTSocket.swift Source/CocoaMQTT.swift Source/CocoaMQTT5.swift CocoaMQTTTests/ClientEventLoopTests.swift`
- `xcodebuild -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath /tmp/cocoamqtt-580-derived-final build`
- `git diff --check`