### PR TITLE
Allow configuring WebSocket message size

### DIFF
--- a/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CryptoKit
+import Network
 import Security
 import XCTest
 @testable import CocoaMQTT
@@ -7,6 +9,100 @@ import XCTest
 #endif
 
 final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+    private final class LoopbackWebSocketServer {
+        private let listener: NWListener
+        private let queue = DispatchQueue(label: "tests.websocket-message-size.server")
+        private let ready = DispatchSemaphore(value: 0)
+        private var connection: NWConnection?
+        private var requestData = Data()
+        private let payload: Data
+
+        var port: UInt16 {
+            listener.port?.rawValue ?? 0
+        }
+
+        init(payload: Data) throws {
+            self.payload = payload
+            listener = try NWListener(using: .tcp, on: .any)
+            listener.stateUpdateHandler = { [ready] state in
+                if case .ready = state {
+                    ready.signal()
+                }
+            }
+            listener.newConnectionHandler = { [weak self] connection in
+                self?.accept(connection)
+            }
+            listener.start(queue: queue)
+            guard ready.wait(timeout: .now() + 3) == .success else {
+                listener.cancel()
+                throw CocoaMQTTError.invalidURL
+            }
+        }
+
+        deinit {
+            stop()
+        }
+
+        func stop() {
+            connection?.cancel()
+            listener.cancel()
+        }
+
+        private func accept(_ connection: NWConnection) {
+            self.connection = connection
+            connection.start(queue: queue)
+            receiveRequest(on: connection)
+        }
+
+        private func receiveRequest(on connection: NWConnection) {
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 8_192) { [weak self] data, _, _, error in
+                guard let self = self, error == nil else { return }
+                if let data = data {
+                    self.requestData.append(data)
+                }
+                guard self.requestData.range(of: Data("\r\n\r\n".utf8)) != nil else {
+                    self.receiveRequest(on: connection)
+                    return
+                }
+                self.sendHandshakeAndPayload(on: connection)
+            }
+        }
+
+        private func sendHandshakeAndPayload(on connection: NWConnection) {
+            guard let request = String(data: requestData, encoding: .utf8),
+                  let keyLine = request.split(separator: "\r\n").first(where: {
+                      $0.lowercased().hasPrefix("sec-websocket-key:")
+                  }),
+                  let key = keyLine.split(separator: ":", maxSplits: 1).last?
+                    .trimmingCharacters(in: .whitespaces) else {
+                connection.cancel()
+                return
+            }
+            let source = Data((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").utf8)
+            let accept = Data(Insecure.SHA1.hash(data: source)).base64EncodedString()
+            let response = [
+                "HTTP/1.1 101 Switching Protocols",
+                "Upgrade: websocket",
+                "Connection: Upgrade",
+                "Sec-WebSocket-Accept: \(accept)",
+                "Sec-WebSocket-Protocol: mqtt"
+            ].joined(separator: "\r\n") + "\r\n\r\n"
+            connection.send(content: Data(response.utf8), completion: .contentProcessed { [weak self] error in
+                guard let self = self, error == nil else { return }
+                connection.send(content: self.binaryFrame(), completion: .idempotent)
+            })
+        }
+
+        private func binaryFrame() -> Data {
+            var frame = Data([0x82, 0x7F])
+            var length = UInt64(payload.count).bigEndian
+            withUnsafeBytes(of: &length) { frame.append(contentsOf: $0) }
+            frame.append(payload)
+            return frame
+        }
+    }
+
     private final class ChallengeSenderStub: NSObject, URLAuthenticationChallengeSender {
         func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
         func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
@@ -17,12 +113,21 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
 
     private final class SocketDelegateSpy: CocoaMQTTSocketDelegate {
         private(set) var urlSessionTrustCallCount = 0
+        var connected: (() -> Void)?
+        var receivedData: ((Data) -> Void)?
+        var disconnected: ((Error?) -> Void)?
 
-        func socketConnected(_ socket: CocoaMQTTSocketProtocol) {}
+        func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+            connected?()
+        }
         func socket(_ socket: CocoaMQTTSocketProtocol, didReceive trust: SecTrust, completionHandler: @escaping (Bool) -> Void) {}
         func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {}
-        func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {}
-        func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {}
+        func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {
+            receivedData?(data)
+        }
+        func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
+            disconnected?(err)
+        }
 
         func socketUrlSession(
             _ socket: CocoaMQTTSocketProtocol,
@@ -106,6 +211,38 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
 
         wait(for: [completed], timeout: 1)
         XCTAssertEqual(delegate.urlSessionTrustCallCount, 1)
+    }
+
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+    func testFoundationConnectionReceivesMessageLargerThanDefaultLimitWhenConfigured() throws {
+        let payload = Data(repeating: 0xA5, count: 1_048_577)
+        let server = try LoopbackWebSocketServer(payload: payload)
+        defer { server.stop() }
+        let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
+        let delegate = SocketDelegateSpy()
+        let callbackQueue = DispatchQueue(label: "tests.websocket-message-size.delegate")
+        let opened = expectation(description: "opened WebSocket")
+        let received = expectation(description: "received WebSocket message larger than 1 MiB")
+        delegate.connected = {
+            opened.fulfill()
+        }
+        delegate.disconnected = { error in
+            XCTFail("WebSocket closed before receiving the message: \(String(describing: error))")
+        }
+        delegate.receivedData = { data in
+            XCTAssertEqual(data.count, payload.count)
+            XCTAssertEqual(data.first, payload.first)
+            XCTAssertEqual(data.last, payload.last)
+            received.fulfill()
+        }
+        websocket.maximumMessageSize = payload.count + 1
+        websocket.setDelegate(delegate, delegateQueue: callbackQueue)
+        try websocket.connect(toHost: "127.0.0.1", onPort: server.port)
+        websocket.readData(toLength: UInt(payload.count), withTimeout: 5, tag: 1)
+
+        wait(for: [opened, received], timeout: 5)
+        delegate.disconnected = nil
+        websocket.disconnect()
     }
 
     private func makeTrust() throws -> SecTrust {

--- a/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
@@ -71,7 +71,7 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
 
         private func sendHandshakeAndPayload(on connection: NWConnection) {
             guard let request = String(data: requestData, encoding: .utf8),
-                  let keyLine = request.split(separator: "\r\n").first(where: {
+                  let keyLine = request.components(separatedBy: "\r\n").first(where: {
                       $0.lowercased().hasPrefix("sec-websocket-key:")
                   }),
                   let key = keyLine.split(separator: ":", maxSplits: 1).last?
@@ -216,6 +216,53 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testFoundationConnectionReceivesMessageLargerThanDefaultLimitWhenConfigured() throws {
         let payload = Data(repeating: 0xA5, count: 1_048_577)
+        try assertReceives(payload, maximumMessageSize: payload.count + 1)
+    }
+
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+    func testFoundationConnectionTreatsZeroMaximumMessageSizeAsUnlimited() throws {
+        let payload = Data(repeating: 0x5A, count: 1_048_577)
+        try assertReceives(payload, maximumMessageSize: 0)
+    }
+
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+    func testFoundationConnectionRejectsMessageLargerThanDefaultLimit() throws {
+        let payload = Data(repeating: 0xA5, count: 1_048_577)
+        let server = try LoopbackWebSocketServer(payload: payload)
+        defer { server.stop() }
+        let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
+        let delegate = SocketDelegateSpy()
+        let callbackQueue = DispatchQueue(label: "tests.websocket-default-message-size.delegate")
+        let opened = expectation(description: "opened WebSocket")
+        let rejected = expectation(description: "rejected message larger than default limit")
+        delegate.connected = {
+            opened.fulfill()
+        }
+        delegate.receivedData = { _ in
+            XCTFail("Received a WebSocket message larger than the default limit")
+        }
+        delegate.disconnected = { error in
+            XCTAssertNotNil(error)
+            rejected.fulfill()
+        }
+        websocket.setDelegate(delegate, delegateQueue: callbackQueue)
+        try websocket.connect(toHost: "127.0.0.1", onPort: server.port)
+
+        wait(for: [opened, rejected], timeout: 5)
+        delegate.disconnected = nil
+        websocket.disconnect()
+    }
+
+    func testNegativeMaximumMessageSizeResetsToFoundationDefault() {
+        let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
+
+        websocket.maximumMessageSize = -1
+
+        XCTAssertEqual(websocket.maximumMessageSize, 1_048_576)
+    }
+
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+    private func assertReceives(_ payload: Data, maximumMessageSize: Int) throws {
         let server = try LoopbackWebSocketServer(payload: payload)
         defer { server.stop() }
         let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
@@ -230,12 +277,10 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
             XCTFail("WebSocket closed before receiving the message: \(String(describing: error))")
         }
         delegate.receivedData = { data in
-            XCTAssertEqual(data.count, payload.count)
-            XCTAssertEqual(data.first, payload.first)
-            XCTAssertEqual(data.last, payload.last)
+            XCTAssertEqual(data, payload)
             received.fulfill()
         }
-        websocket.maximumMessageSize = payload.count + 1
+        websocket.maximumMessageSize = maximumMessageSize
         websocket.setDelegate(delegate, delegateQueue: callbackQueue)
         try websocket.connect(toHost: "127.0.0.1", onPort: server.port)
         websocket.readData(toLength: UInt(payload.count), withTimeout: 5, tag: 1)

--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ let mqtt = CocoaMQTT(clientID: clientID, host: host, port: 8083, socket: websock
 _ = mqtt.connect()
 ```
 
+The Foundation WebSocket transport accepts incoming messages up to 1 MiB by
+default. Set a larger limit before connecting if the broker may send larger
+MQTT packets:
+
+```swift
+let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
+websocket.maximumMessageSize = 10 * 1024 * 1024
+```
+
 If you want to add additional custom header to the connection, you can use the following:
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -224,14 +224,19 @@ let mqtt = CocoaMQTT(clientID: clientID, host: host, port: 8083, socket: websock
 _ = mqtt.connect()
 ```
 
-The Foundation WebSocket transport accepts incoming messages up to 1 MiB by
-default. Set a larger limit before connecting if the broker may send larger
-MQTT packets:
+The built-in Foundation WebSocket transport fails a receive when one WebSocket
+message reaches its 1 MiB buffering limit. Set a value greater than the largest
+expected WebSocket message before connecting, or use `0` to remove the limit:
 
 ```swift
 let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
-websocket.maximumMessageSize = 10 * 1024 * 1024
+websocket.maximumMessageSize = 10 * 1024 * 1024 + 1 // Accept up to 10 MiB.
 ```
+
+This setting is independent of MQTT 5 Maximum Packet Size. It is not used by
+the older Starscream transport, and custom connection builders must configure
+their own transport. Use `0` only when message sizes are otherwise controlled,
+because it permits unbounded buffering.
 
 If you want to add additional custom header to the connection, you can use the following:
 

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -47,15 +47,26 @@ public protocol CocoaMQTTWebSocketConnectionBuilder {
 
 }
 
+private protocol CocoaMQTTWebSocketMessageSizeConfiguring: AnyObject {
+    var maximumMessageSize: Int { get set }
+}
+
 // MARK: - CocoaMQTTWebSocket
 
 public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
+
+    private static let foundationDefaultMaximumMessageSize = 1_048_576
 
     public var enableSSL = false
 
     public var shouldConnectWithURIOnly = false
 
     public var headers: [String: String] = [:]
+
+    /// Maximum incoming WebSocket message size for the built-in Foundation
+    /// transport. The default remains 1 MiB to preserve its bounded buffering.
+    /// Values below one byte are clamped to one.
+    public var maximumMessageSize = CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize
 
     public typealias ConnectionBuilder = CocoaMQTTWebSocketConnectionBuilder
 
@@ -108,6 +119,9 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
             reset()
             disconnectAfterWrites = false
             let newConnection = try builder.buildConnection(forURL: url, withHeaders: self.headers)
+            if let configurableConnection = newConnection as? CocoaMQTTWebSocketMessageSizeConfiguring {
+                configurableConnection.maximumMessageSize = max(1, maximumMessageSize)
+            }
             connection = newConnection
             newConnection.delegate = self
             newConnection.queue = internalQueue
@@ -348,6 +362,14 @@ public extension CocoaMQTTWebSocket {
 
         public weak var delegate: CocoaMQTTWebSocketConnectionDelegate?
         public lazy var queue = DispatchQueue(label: "CocoaMQTTFoundationWebSocketConnection-\(self.hashValue)")
+        var maximumMessageSize: Int {
+            get {
+                task?.maximumMessageSize ?? CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize
+            }
+            set {
+                task?.maximumMessageSize = max(1, newValue)
+            }
+        }
 
         var session: URLSession?
         var task: URLSessionWebSocketTask?
@@ -404,6 +426,9 @@ public extension CocoaMQTTWebSocket {
         }
     }
 }
+
+@available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension CocoaMQTTWebSocket.FoundationConnection: CocoaMQTTWebSocketMessageSizeConfiguring {}
 
 @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension CocoaMQTTWebSocket.FoundationConnection: URLSessionWebSocketDelegate {

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -63,10 +63,20 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
 
     public var headers: [String: String] = [:]
 
-    /// Maximum incoming WebSocket message size for the built-in Foundation
-    /// transport. The default remains 1 MiB to preserve its bounded buffering.
-    /// Values below one byte are clamped to one.
-    public var maximumMessageSize = CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize
+    /// Incoming WebSocket message buffering limit for the built-in Foundation
+    /// transport. A message must be smaller than this value. The default is
+    /// 1 MiB, zero removes the limit, and negative values reset to the default.
+    /// Set this before connecting; custom builders must configure their own
+    /// transports. The older Starscream transport does not use this setting.
+    /// Use zero only when the peer and message sizes are otherwise controlled,
+    /// because it permits unbounded message buffering.
+    public var maximumMessageSize = CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize {
+        didSet {
+            if maximumMessageSize < 0 {
+                maximumMessageSize = CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize
+            }
+        }
+    }
 
     public typealias ConnectionBuilder = CocoaMQTTWebSocketConnectionBuilder
 
@@ -120,7 +130,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
             disconnectAfterWrites = false
             let newConnection = try builder.buildConnection(forURL: url, withHeaders: self.headers)
             if let configurableConnection = newConnection as? CocoaMQTTWebSocketMessageSizeConfiguring {
-                configurableConnection.maximumMessageSize = max(1, maximumMessageSize)
+                configurableConnection.maximumMessageSize = maximumMessageSize
             }
             connection = newConnection
             newConnection.delegate = self
@@ -367,7 +377,9 @@ public extension CocoaMQTTWebSocket {
                 task?.maximumMessageSize ?? CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize
             }
             set {
-                task?.maximumMessageSize = max(1, newValue)
+                task?.maximumMessageSize = newValue < 0
+                    ? CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize
+                    : newValue
             }
         }
 


### PR DESCRIPTION
## Summary
- expose `CocoaMQTTWebSocket.maximumMessageSize` for the built-in Foundation transport
- preserve Foundation’s 1 MiB default and its `0`-means-unlimited behavior; normalize negative values back to the safe default
- document the strict buffering-threshold semantics, connection timing, transport scope, memory risk of unlimited buffering, and independence from MQTT 5 Maximum Packet Size
- add loopback WebSocket coverage for configured, default-rejection, and unlimited receive behavior above 1 MiB

Fixes #536

## Verification
- `swift test --filter CocoaMQTTWebSocketAuthenticationTests`
- `swift test --sanitize=thread --filter CocoaMQTTWebSocketAuthenticationTests`
- `swift test --skip 'CocoaMQTTTests\\.CocoaMQTTTests'` (272 tests, 1 skipped)\n- `Tools/lint.sh --strict Source CocoaMQTTTests`\n- `xcodebuild -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath /tmp/cocoamqtt-536-derived build CODE_SIGNING_ALLOWED=NO`