### PR TITLE
Make socket write timeout configurable

### DIFF
--- a/CocoaMQTTTests/GracefulDisconnectTests.swift
+++ b/CocoaMQTTTests/GracefulDisconnectTests.swift
@@ -14,6 +14,7 @@ final class GracefulDisconnectTests: XCTestCase {
         private(set) var disconnectCount = 0
         private(set) var writeAndDisconnectCount = 0
         private(set) var finalWrites = [Data]()
+        private(set) var finalWriteTimeouts = [TimeInterval]()
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
         func connect(toHost host: String, onPort port: UInt16) throws {}
@@ -26,6 +27,7 @@ final class GracefulDisconnectTests: XCTestCase {
         func writeAndDisconnect(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
             writeAndDisconnectCount += 1
             finalWrites.append(data)
+            finalWriteTimeouts.append(timeout)
         }
 
         func completeFinalWrite() {
@@ -36,12 +38,14 @@ final class GracefulDisconnectTests: XCTestCase {
     func testMQTT311WaitsForDisconnectWriteAndCoalescesRepeatedRequests() {
         let socket = DeferredDisconnectSocket()
         let mqtt = CocoaMQTT(clientID: "graceful-disconnect-311", socket: socket)
+        mqtt.socketWriteTimeout = 30
 
         mqtt.disconnect()
         mqtt.disconnect()
 
         XCTAssertEqual(socket.writeAndDisconnectCount, 1)
         XCTAssertEqual(socket.finalWrites, [Data([FrameType.disconnect.rawValue, 0])])
+        XCTAssertEqual(socket.finalWriteTimeouts, [30])
         XCTAssertEqual(socket.disconnectCount, 0)
 
         socket.completeFinalWrite()
@@ -51,6 +55,7 @@ final class GracefulDisconnectTests: XCTestCase {
     func testMQTT5WaitsForDisconnectWriteAndPreservesReasonProperties() throws {
         let socket = DeferredDisconnectSocket()
         let mqtt = CocoaMQTT5(clientID: "graceful-disconnect-5", socket: socket)
+        mqtt.socketWriteTimeout = 30
 
         mqtt.disconnect(
             reasonCode: .disconnectWithWillMessage,
@@ -59,6 +64,7 @@ final class GracefulDisconnectTests: XCTestCase {
         mqtt.disconnect()
 
         XCTAssertEqual(socket.writeAndDisconnectCount, 1)
+        XCTAssertEqual(socket.finalWriteTimeouts, [30])
         XCTAssertEqual(socket.disconnectCount, 0)
 
         let bytes = try XCTUnwrap(socket.finalWrites.first).map { $0 }

--- a/CocoaMQTTTests/SendingMessageLifecycleTests.swift
+++ b/CocoaMQTTTests/SendingMessageLifecycleTests.swift
@@ -20,6 +20,7 @@ final class SendingMessageLifecycleTests: XCTestCase {
         var enableSSL = false
         var writes = [Data]()
         var writeTags = [Int]()
+        var writeTimeouts = [TimeInterval]()
         var onWrite: ((Int) -> Void)?
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
@@ -30,8 +31,61 @@ final class SendingMessageLifecycleTests: XCTestCase {
         func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int) {
             writes.append(data)
             writeTags.append(tag)
+            writeTimeouts.append(timeout)
             onWrite?(tag)
         }
+    }
+
+    func testMQTT311PassesConfiguredTimeoutToPublishWrite() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT(clientID: "write-timeout-311", socket: socket)
+
+        XCTAssertEqual(mqtt.socketWriteTimeout, 5)
+        mqtt.socketWriteTimeout = 30
+        establishSession(mqtt, socket: socket, cleanSession: true, sessionPresent: false)
+        socket.writeTimeouts.removeAll()
+        XCTAssertEqual(
+            mqtt.publish(CocoaMQTTMessage(topic: "write/timeout", payload: [1], qos: .qos0)),
+            0
+        )
+        mqtt.t_waitUntilDeliverIdle()
+
+        XCTAssertEqual(socket.writeTimeouts, [30])
+    }
+
+    func testMQTT5PassesConfiguredTimeoutToPublishWrite() {
+        let socket = SocketSpy()
+        let mqtt = CocoaMQTT5(clientID: "write-timeout-5", socket: socket)
+
+        XCTAssertEqual(mqtt.socketWriteTimeout, 5)
+        mqtt.socketWriteTimeout = 60
+        establishSession(mqtt, socket: socket, cleanStart: true, requestedExpiry: 0)
+        socket.writeTimeouts.removeAll()
+        XCTAssertEqual(
+            mqtt.publish(
+                CocoaMQTT5Message(topic: "write/timeout", payload: [1], qos: .qos0),
+                properties: MqttPublishProperties()
+            ),
+            0
+        )
+        mqtt.t_waitUntilDeliverIdle()
+
+        XCTAssertEqual(socket.writeTimeouts, [60])
+    }
+
+    func testSocketWriteTimeoutNormalizesDisabledAndInvalidValues() {
+        let mqtt = CocoaMQTT(clientID: "write-timeout-normalization")
+        let mqtt5 = CocoaMQTT5(clientID: "write-timeout-normalization-5")
+
+        mqtt.socketWriteTimeout = 0
+        mqtt5.socketWriteTimeout = -10
+        XCTAssertEqual(mqtt.socketWriteTimeout, -1)
+        XCTAssertEqual(mqtt5.socketWriteTimeout, -1)
+
+        mqtt.socketWriteTimeout = .infinity
+        mqtt5.socketWriteTimeout = .nan
+        XCTAssertEqual(mqtt.socketWriteTimeout, 5)
+        XCTAssertEqual(mqtt5.socketWriteTimeout, 5)
     }
 
     func testMQTT311ReleasesQoS0MessageAfterSending() {

--- a/CocoaMQTTTests/SendingMessageLifecycleTests.swift
+++ b/CocoaMQTTTests/SendingMessageLifecycleTests.swift
@@ -82,6 +82,9 @@ final class SendingMessageLifecycleTests: XCTestCase {
         XCTAssertEqual(mqtt.socketWriteTimeout, -1)
         XCTAssertEqual(mqtt5.socketWriteTimeout, -1)
 
+        mqtt.socketWriteTimeout = -.infinity
+        XCTAssertEqual(mqtt.socketWriteTimeout, -1)
+
         mqtt.socketWriteTimeout = .infinity
         mqtt5.socketWriteTimeout = .nan
         XCTAssertEqual(mqtt.socketWriteTimeout, 5)

--- a/README.md
+++ b/README.md
@@ -343,8 +343,9 @@ mqtt.socketWriteTimeout = 30
 Set `socketWriteTimeout` to `0` or a negative value to disable the deadline.
 This setting applies to MQTT 3.1.1 and MQTT 5 over the built-in TCP and
 WebSocket transports. It does not override the broker's packet-size limit or
-the MQTT 5 Server Maximum Packet Size. Prefer binary payloads or application
-level chunking when messages are large; Base64 increases their encoded size.
+the MQTT 5 Server Maximum Packet Size. Prefer binary payloads or
+application-level chunking when messages are large; Base64 increases their
+encoded size.
 
 ## Example App
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,21 @@ extension WebSocketManager: CocoaMQTTDelegate {
 }
 ```
 
+### Large outgoing messages
+
+Socket writes have a five-second deadline by default. Increase it before
+publishing large messages on slower connections:
+
+```swift
+mqtt.socketWriteTimeout = 30
+```
+
+Set `socketWriteTimeout` to `0` or a negative value to disable the deadline.
+This setting applies to MQTT 3.1.1 and MQTT 5 over the built-in TCP and
+WebSocket transports. It does not override the broker's packet-size limit or
+the MQTT 5 Server Maximum Packet Size. Prefer binary payloads or application
+level chunking when messages are large; Base64 increases their encoded size.
+
 ## Example App
 
 You can follow the Example App to learn how to use it. But we need to make the Example App works first:

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -178,6 +178,23 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         set { (self.socket as? CocoaMQTTSocket)?.backgroundOnSocket = newValue }
     }
 
+    /// Maximum time allowed for a socket write. Default is 5 seconds.
+    ///
+    /// Set this to zero or a negative value to disable the write deadline.
+    /// This controls only the client transport deadline; broker packet-size
+    /// limits still apply.
+    @objc public var socketWriteTimeout: TimeInterval {
+        get { configuredSocketWriteTimeout }
+        set {
+            configuredSocketWriteTimeout = CocoaMQTTSocketWriteTimeout.normalize(newValue)
+        }
+    }
+    @ConcurrentAtomic(
+        wrappedValue: CocoaMQTTSocketWriteTimeout.defaultValue,
+        label: "CocoaMQTT.socketWriteTimeout"
+    )
+    private var configuredSocketWriteTimeout
+
     /// Delegate Executed queue. Default is `DispatchQueue.main`
     ///
     /// The delegate/closure callback function will be committed asynchronously to it.
@@ -432,10 +449,11 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         printDebug("SEND: \(frame)")
         let data = frame.bytes(version: version)
         let packet = Data(bytes: data, count: data.count)
+        let writeTimeout = socketWriteTimeout
         if disconnectAfterWriting {
-            socket.writeAndDisconnect(packet, withTimeout: 5, tag: tag)
+            socket.writeAndDisconnect(packet, withTimeout: writeTimeout, tag: tag)
         } else {
-            socket.write(packet, withTimeout: 5, tag: tag)
+            socket.write(packet, withTimeout: writeTimeout, tag: tag)
         }
     }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -187,6 +187,23 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         set { (self.socket as? CocoaMQTTSocket)?.backgroundOnSocket = newValue }
     }
 
+    /// Maximum time allowed for a socket write. Default is 5 seconds.
+    ///
+    /// Set this to zero or a negative value to disable the write deadline.
+    /// This controls only the client transport deadline; the server Maximum
+    /// Packet Size and other broker limits still apply.
+    @objc public var socketWriteTimeout: TimeInterval {
+        get { configuredSocketWriteTimeout }
+        set {
+            configuredSocketWriteTimeout = CocoaMQTTSocketWriteTimeout.normalize(newValue)
+        }
+    }
+    @ConcurrentAtomic(
+        wrappedValue: CocoaMQTTSocketWriteTimeout.defaultValue,
+        label: "CocoaMQTT5.socketWriteTimeout"
+    )
+    private var configuredSocketWriteTimeout
+
     /// Delegate Executed queue. Default is `DispatchQueue.main`
     ///
     /// The delegate/closure callback function will be committed asynchronously to it.
@@ -481,10 +498,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         }
 
         let packet = Data(bytes: data, count: data.count)
+        let writeTimeout = socketWriteTimeout
         if disconnectAfterWriting {
-            socket.writeAndDisconnect(packet, withTimeout: 5, tag: tag)
+            socket.writeAndDisconnect(packet, withTimeout: writeTimeout, tag: tag)
         } else {
-            socket.write(packet, withTimeout: 5, tag: tag)
+            socket.write(packet, withTimeout: writeTimeout, tag: tag)
         }
         return true
     }

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -100,6 +100,15 @@ public protocol CocoaMQTTSocketProtocol {
     func write(_ data: Data, withTimeout timeout: TimeInterval, tag: Int)
 }
 
+enum CocoaMQTTSocketWriteTimeout {
+    static let defaultValue: TimeInterval = 5
+
+    static func normalize(_ timeout: TimeInterval) -> TimeInterval {
+        guard timeout.isFinite else { return defaultValue }
+        return timeout > 0 ? timeout : -1
+    }
+}
+
 protocol MQTTClientTeardownSocket: AnyObject {
     func prepareClientTeardown() -> Bool
     func performClientTeardown()

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -104,8 +104,11 @@ enum CocoaMQTTSocketWriteTimeout {
     static let defaultValue: TimeInterval = 5
 
     static func normalize(_ timeout: TimeInterval) -> TimeInterval {
+        if timeout <= 0 {
+            return -1
+        }
         guard timeout.isFinite else { return defaultValue }
-        return timeout > 0 ? timeout : -1
+        return timeout
     }
 }
 


### PR DESCRIPTION
## Summary

- add a thread-safe `socketWriteTimeout` setting to CocoaMQTT and CocoaMQTT5
- preserve the existing five-second default and allow zero or negative values to disable the deadline
- apply the setting to publish, control, and graceful-disconnect writes without changing the socket protocol
- document large-message limits and add MQTT 3.1.1, MQTT 5, normalization, and disconnect regressions

Closes #572.

## Compatibility

This is an additive API. Existing clients retain the five-second write deadline. Broker packet-size limits and MQTT 5 Server Maximum Packet Size remain authoritative.

## Verification

- `swift test --filter SendingMessageLifecycleTests`
- `swift test --filter GracefulDisconnectTests`
- `swift test --skip CocoaMQTTTests.CocoaMQTTTests`
- `Tools/lint.sh`
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `xcodebuild -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath . build CODE_SIGNING_ALLOWED=NO`
- `pod lib lint CocoaMQTT.podspec --allow-warnings --skip-tests --platforms=ios,macos`
- `swift package diagnose-api-breaking-changes origin/master`