### PR TITLE
Add visionOS support through SwiftPM

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,6 +49,13 @@ jobs:
           SCRATCH_PATH="${RUNNER_TEMP}/CocoaMQTT-visionOS"
 
           swift build \
+            --target CocoaMQTT \
+            --triple arm64-apple-xros1.0 \
+            --sdk "${SDK_PATH}" \
+            --scratch-path "${SCRATCH_PATH}"
+
+          swift build \
+            --target CocoaMQTTWebSocket \
             --triple arm64-apple-xros1.0 \
             --sdk "${SDK_PATH}" \
             --scratch-path "${SCRATCH_PATH}"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,29 @@ jobs:
       - name: Build core target with Swift 6 language mode
         run: swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6
 
+  visionos-compile-check:
+    name: visionOS Compile Check (SPM)
+    runs-on: macos-15
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show visionOS SDK
+        run: xcodebuild -version -sdk xros
+
+      - name: Build SwiftPM products for visionOS
+        run: |
+          set -euo pipefail
+          SDK_PATH="$(xcrun --sdk xros --show-sdk-path)"
+          SCRATCH_PATH="${RUNNER_TEMP}/CocoaMQTT-visionOS"
+
+          swift build \
+            --triple arm64-apple-xros1.0 \
+            --sdk "${SDK_PATH}" \
+            --scratch-path "${SCRATCH_PATH}"
+
   build-and-test:
     name: Swift Build & Test
     runs-on: macos-15

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
         .macOS(.v10_13),
         .iOS(.v12),
         .tvOS(.v12)
+        // visionOS is supported through SwiftPM and compiled in CI. An explicit
+        // declaration requires PackageDescription 5.9, while this manifest
+        // intentionally remains compatible with Swift tools 5.7.
     ],
     products: [
         .library(name: "CocoaMQTT", targets: ["CocoaMQTT"]),

--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,13 @@ import PackageDescription
 
 let package = Package(
     name: "CocoaMQTT",
+    // visionOS is supported through SwiftPM and compiled in CI. An explicit
+    // declaration requires PackageDescription 5.9, while this manifest
+    // intentionally remains compatible with Swift tools 5.7.
     platforms: [
         .macOS(.v10_13),
         .iOS(.v12),
         .tvOS(.v12)
-        // visionOS is supported through SwiftPM and compiled in CI. An explicit
-        // declaration requires PackageDescription 5.9, while this manifest
-        // intentionally remains compatible with Swift tools 5.7.
     ],
     products: [
         .library(name: "CocoaMQTT", targets: ["CocoaMQTT"]),

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ![License](https://img.shields.io/cocoapods/l/BadgeSwift.svg?style=flat)
 ![Swift version](https://img.shields.io/badge/swift-5-orange.svg)
 
-MQTT v3.1.1 and v5.0 client library for iOS/macOS/tvOS/visionOS written with Swift 5
+MQTT v3.1.1 and v5.0 client library for iOS/macOS/tvOS/visionOS written with Swift 5.
+visionOS is supported through Swift Package Manager.
 
 
 ## Build
@@ -14,8 +15,9 @@ Build with Xcode 11.1 / Swift 5.1
 
 IOS Target: 12.0 or above
 OSX Target: 10.13 or above
-TVOS Target: 10.0 or above
-visionOS Target: 1.0 or above (Swift Package Manager only)
+TVOS Target: 12.0 or above with Swift Package Manager or CocoaPods WebSockets;
+10.0 or above with CocoaPods Core
+visionOS Target: 1.0 or above (Swift Package Manager only, compile-verified in CI)
 
 ##  xcode 14.3 issue:
 ```ruby
@@ -37,7 +39,8 @@ To integrate CocoaMQTT into your Xcode project using [Swift Package Manager](htt
 5. Add the package to your target.
 
 Swift Package Manager supports iOS, macOS, tvOS, and visionOS. Both the
-`CocoaMQTT` and `CocoaMQTTWebSocket` products are compiled for visionOS in CI.
+`CocoaMQTT` and `CocoaMQTTWebSocket` products are compile-verified against the
+visionOS SDK in CI.
 
 At last, import "CocoaMQTT" to your project:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![License](https://img.shields.io/cocoapods/l/BadgeSwift.svg?style=flat)
 ![Swift version](https://img.shields.io/badge/swift-5-orange.svg)
 
-MQTT v3.1.1 and v5.0 client library for iOS/macOS/tvOS written with Swift 5
+MQTT v3.1.1 and v5.0 client library for iOS/macOS/tvOS/visionOS written with Swift 5
 
 
 ## Build
@@ -15,6 +15,7 @@ Build with Xcode 11.1 / Swift 5.1
 IOS Target: 12.0 or above
 OSX Target: 10.13 or above
 TVOS Target: 10.0 or above
+visionOS Target: 1.0 or above (Swift Package Manager only)
 
 ##  xcode 14.3 issue:
 ```ruby
@@ -35,6 +36,9 @@ To integrate CocoaMQTT into your Xcode project using [Swift Package Manager](htt
 4. Choose the latest version or specify a version range.
 5. Add the package to your target.
 
+Swift Package Manager supports iOS, macOS, tvOS, and visionOS. Both the
+`CocoaMQTT` and `CocoaMQTTWebSocket` products are compiled for visionOS in CI.
+
 At last, import "CocoaMQTT" to your project:
 
 ```swift
@@ -44,6 +48,10 @@ import CocoaMQTT
 ### CocoaPods
 
 To integrate CocoaMQTT into your Xcode project using [CocoaPods](http://cocoapods.org), you need to modify you `Podfile` like the followings:
+
+> **visionOS:** CocoaPods installation is not currently supported because the
+> transitive CocoaPods dependencies do not declare visionOS compatibility. Use
+> Swift Package Manager for visionOS applications.
 
 ```ruby
 use_frameworks!


### PR DESCRIPTION
## What changed

- document visionOS 1.0+ support through Swift Package Manager
- explicitly document that CocoaPods does not currently support visionOS because transitive podspecs do not declare it
- add a CI job that cross-compiles all SwiftPM products and transport dependencies with the visionOS SDK
- retain swift-tools-version 5.7 instead of requiring PackageDescription 5.9 only for an explicit platform declaration

## Verification

- swift package dump-package
- swift build --triple arm64-apple-xros1.0 --sdk <visionOS SDK path>
- swift test --skip CocoaMQTTTests.CocoaMQTTTests (275 passed, 1 skipped)
- workflow YAML parse and git diff --check

The full local test command additionally requires the repository standard local EMQX broker; CI starts it before running the complete suite.

Closes #590