### PR TITLE
Add WebSocket client certificate support

### DIFF
--- a/CocoaMQTTTests/ClientIdentityTests.swift
+++ b/CocoaMQTTTests/ClientIdentityTests.swift
@@ -263,7 +263,7 @@ final class ClientIdentityTests: XCTestCase {
     }
 
 #if IS_SWIFT_PACKAGE
-    func testMQTTClientsDoNotApplyIdentityToWebSocketTransport() throws {
+    func testMQTTClientsProxyIdentityToWebSocketTransport() throws {
         let fixture = try Self.fixture.get()
         let identity = try CocoaMQTTClientIdentity(
             certificateData: fixture.clientCertificatePEM,
@@ -281,8 +281,8 @@ final class ClientIdentityTests: XCTestCase {
         mqtt.clientIdentity = identity
         mqtt5.clientIdentity = identity
 
-        XCTAssertNil(mqtt.clientIdentity)
-        XCTAssertNil(mqtt5.clientIdentity)
+        XCTAssertTrue(mqtt.clientIdentity === identity)
+        XCTAssertTrue(mqtt5.clientIdentity === identity)
     }
 #endif
 

--- a/CocoaMQTTTests/TLSChallengeResolutionTests.swift
+++ b/CocoaMQTTTests/TLSChallengeResolutionTests.swift
@@ -4,8 +4,12 @@ import XCTest
 @testable import CocoaMQTT
 
 final class TLSChallengeResolutionTests: XCTestCase {
-    private final class SocketStub: CocoaMQTTSocketProtocol {
+    private final class SocketStub: CocoaMQTTSocketProtocol, CocoaMQTTServerTrustConfiguring {
         var enableSSL = false
+        var tlsServerName: String?
+        var trustedServerCertificates = [SecCertificate]()
+        var usesSystemTrustStore = true
+        var manuallyEvaluateTrust = false
 
         func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {}
         func connect(toHost host: String, onPort port: UInt16) throws {}
@@ -260,6 +264,26 @@ final class TLSChallengeResolutionTests: XCTestCase {
         wait(for: [completed], timeout: 2)
     }
 
+    func testMQTTClientsUseCustomTransportTrustCapability() throws {
+        let socket311 = try configuredSocketStub()
+        let socket5 = try configuredSocketStub()
+        let mqtt = CocoaMQTT(clientID: "custom-transport-ca-311", socket: socket311)
+        let mqtt5 = CocoaMQTT5(clientID: "custom-transport-ca-5", socket: socket5)
+        let mqttCompleted = expectation(description: "MQTT 3.1.1 custom transport trust accepted")
+        let mqtt5Completed = expectation(description: "MQTT 5 custom transport trust accepted")
+
+        mqtt.socket(socket311, didReceive: try leafTrust()) { trusted in
+            XCTAssertTrue(trusted)
+            mqttCompleted.fulfill()
+        }
+        mqtt5.socket(socket5, didReceive: try leafTrust()) { trusted in
+            XCTAssertTrue(trusted)
+            mqtt5Completed.fulfill()
+        }
+
+        wait(for: [mqttCompleted, mqtt5Completed], timeout: 2)
+    }
+
     func testURLSessionChallengeDefaultsToSystemValidation() throws {
         var dispositions = [URLSession.AuthChallengeDisposition]()
 
@@ -352,6 +376,25 @@ final class TLSChallengeResolutionTests: XCTestCase {
         let mqtt = CocoaMQTT5(clientID: "tls-default-5", socket: socket)
 
         try assertSystemDefaultChallengeHandling(client: mqtt, socket: socket)
+    }
+
+    func testURLSessionManualTrustWithoutHandlerOrCertificatesRejects() throws {
+        let socket = SocketStub()
+        socket.manuallyEvaluateTrust = true
+        let mqtt = CocoaMQTT(clientID: "tls-manual-empty", socket: socket)
+        let completed = expectation(description: "empty manual trust rejected")
+
+        mqtt.socketUrlSession(
+            socket,
+            didReceiveTrust: try makeTrust(),
+            didReceiveChallenge: makeChallenge()
+        ) { disposition, credential in
+            XCTAssertEqual(disposition, .rejectProtectionSpace)
+            XCTAssertNil(credential)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
     }
 
     func testMQTT311URLSessionChallengeCancelsIfClientIsReleasedBeforeCallback() throws {
@@ -561,6 +604,14 @@ final class TLSChallengeResolutionTests: XCTestCase {
         }
 
         wait(for: [completed], timeout: 1)
+    }
+
+    private func configuredSocketStub() throws -> SocketStub {
+        let socket = SocketStub()
+        socket.tlsServerName = "broker.example.com"
+        socket.trustedServerCertificates = [try certificate(base64: testRootCertificate)]
+        socket.usesSystemTrustStore = false
+        return socket
     }
 
     private func makeTrust() throws -> SecTrust {

--- a/CocoaMQTTTests/TLSLoopbackTestSupport.swift
+++ b/CocoaMQTTTests/TLSLoopbackTestSupport.swift
@@ -146,6 +146,157 @@ final class TLSMQTTLoopbackBroker {
     }
 }
 
+/// Minimal mutual-TLS WebSocket broker that records CONNECT protocol levels
+/// and returns CONNACK.
+@available(macOS 10.15, *)
+final class TLSWebSocketMQTTLoopbackBroker {
+
+    private let queue = DispatchQueue(label: "tests.cocoamqtt.wss-loopback-broker")
+    private let listener: NWListener
+    private let lock = NSLock()
+    private var connections = [NWConnection]()
+    private var protocolLevels = [UInt8]()
+
+    var port: UInt16? {
+        listener.port?.rawValue
+    }
+
+    var receivedProtocolLevels: [UInt8] {
+        lock.lock()
+        defer { lock.unlock() }
+        return protocolLevels
+    }
+
+    init(identity: SecIdentity, trustedClientRootCertificate: SecCertificate) throws {
+        let tlsOptions = NWProtocolTLS.Options()
+        guard let protocolIdentity = sec_identity_create(identity) else {
+            throw TLSLoopbackError.invalidIdentity
+        }
+        sec_protocol_options_set_local_identity(
+            tlsOptions.securityProtocolOptions,
+            protocolIdentity
+        )
+        sec_protocol_options_set_peer_authentication_required(
+            tlsOptions.securityProtocolOptions,
+            true
+        )
+        sec_protocol_options_set_verify_block(
+            tlsOptions.securityProtocolOptions,
+            { _, trust, complete in
+                let secTrust = sec_trust_copy_ref(trust).takeRetainedValue()
+                guard SecTrustSetPolicies(
+                    secTrust,
+                    SecPolicyCreateBasicX509()
+                ) == errSecSuccess,
+                SecTrustSetAnchorCertificates(
+                    secTrust,
+                    [trustedClientRootCertificate] as CFArray
+                ) == errSecSuccess,
+                SecTrustSetAnchorCertificatesOnly(secTrust, true) == errSecSuccess else {
+                    complete(false)
+                    return
+                }
+                var error: CFError?
+                complete(SecTrustEvaluateWithError(secTrust, &error))
+            },
+            queue
+        )
+        let webSocketOptions = NWProtocolWebSocket.Options()
+        webSocketOptions.autoReplyPing = true
+        webSocketOptions.setClientRequestHandler(queue) { subprotocols, _ in
+            NWProtocolWebSocket.Response(
+                status: .accept,
+                subprotocol: subprotocols.contains("mqtt") ? "mqtt" : nil
+            )
+        }
+        let parameters = NWParameters(tls: tlsOptions, tcp: NWProtocolTCP.Options())
+        parameters.defaultProtocolStack.applicationProtocols.insert(webSocketOptions, at: 0)
+        listener = try NWListener(using: parameters, on: .any)
+    }
+
+    func start(onReady: @escaping () -> Void) {
+        listener.stateUpdateHandler = { state in
+            if case .ready = state {
+                onReady()
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else { return }
+            self.lock.lock()
+            self.connections.append(connection)
+            self.lock.unlock()
+            connection.stateUpdateHandler = { [weak self, weak connection] state in
+                guard let self, let connection, case .ready = state else { return }
+                self.receiveConnect(from: connection, buffer: Data())
+            }
+            connection.start(queue: self.queue)
+        }
+        listener.start(queue: queue)
+    }
+
+    func stop() {
+        listener.cancel()
+        lock.lock()
+        let activeConnections = connections
+        connections.removeAll()
+        lock.unlock()
+        activeConnections.forEach { $0.cancel() }
+    }
+
+    private func receiveConnect(from connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { [weak self, weak connection] data, _, isComplete, error in
+            guard let self, let connection else { return }
+            var nextBuffer = buffer
+            if let data {
+                nextBuffer.append(data)
+            }
+            if let protocolLevel = Self.connectProtocolLevel(in: nextBuffer) {
+                self.lock.lock()
+                self.protocolLevels.append(protocolLevel)
+                self.lock.unlock()
+                let connAck = protocolLevel == 5
+                    ? Data([0x20, 0x03, 0x00, 0x00, 0x00])
+                    : Data([0x20, 0x02, 0x00, 0x00])
+                let metadata = NWProtocolWebSocket.Metadata(opcode: .binary)
+                let context = NWConnection.ContentContext(
+                    identifier: "MQTT CONNACK",
+                    metadata: [metadata]
+                )
+                connection.send(
+                    content: connAck,
+                    contentContext: context,
+                    isComplete: true,
+                    completion: .contentProcessed { _ in }
+                )
+                return
+            }
+            if !isComplete && error == nil {
+                self.receiveConnect(from: connection, buffer: nextBuffer)
+            }
+        }
+    }
+
+    private static func connectProtocolLevel(in data: Data) -> UInt8? {
+        guard data.count >= 2, data[0] >> 4 == 1 else { return nil }
+        var remainingLength = 0
+        var multiplier = 1
+        var index = 1
+        for _ in 0..<4 {
+            guard index < data.count else { return nil }
+            let byte = data[index]
+            remainingLength += Int(byte & 0x7f) * multiplier
+            index += 1
+            if byte & 0x80 == 0 {
+                guard remainingLength >= 7,
+                      data.count >= index + remainingLength else { return nil }
+                return data[index + 6]
+            }
+            multiplier *= 128
+        }
+        return nil
+    }
+}
+
 /// Generates fresh certificates so Apple's leaf-validity limit cannot expire the tests.
 final class TLSLoopbackCertificateFixture {
 

--- a/CocoaMQTTTests/WebSocketMTLSIntegrationTests.swift
+++ b/CocoaMQTTTests/WebSocketMTLSIntegrationTests.swift
@@ -9,6 +9,14 @@ final class WebSocketMTLSIntegrationTests: XCTestCase {
 
     private static let fixture = Result { try TLSLoopbackCertificateFixture() }
 
+    private final class ChallengeSenderStub: NSObject, URLAuthenticationChallengeSender {
+        func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+        func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+        func cancel(_ challenge: URLAuthenticationChallenge) {}
+        func performDefaultHandling(for challenge: URLAuthenticationChallenge) {}
+        func rejectProtectionSpaceAndContinue(with challenge: URLAuthenticationChallenge) {}
+    }
+
     override static func tearDown() {
         try? fixture.get().removeTemporaryFiles()
         super.tearDown()
@@ -126,6 +134,51 @@ final class WebSocketMTLSIntegrationTests: XCTestCase {
         XCTAssertTrue(broker.receivedProtocolLevels.isEmpty)
     }
 
+    func testFoundationConnectionUsesIdentityForMatchingEndpoint() throws {
+        let fixture = try Self.fixture.get()
+        let identity = try makeClientIdentity(fixture)
+        let connection = try makeFoundationConnection()
+        connection.clientIdentity = identity
+        addTeardownBlock { connection.disconnect() }
+
+        let completed = expectation(description: "client identity supplied")
+        performClientCertificateChallenge(on: connection, host: "broker.example.com") { disposition, credential in
+            XCTAssertEqual(disposition, .useCredential)
+            XCTAssertTrue(credential?.identity === identity.identity)
+            XCTAssertEqual(credential?.certificates.count, 1)
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 1)
+    }
+
+    func testFoundationConnectionCancelsChallengeWithoutConfiguredIdentity() throws {
+        let connection = try makeFoundationConnection()
+        addTeardownBlock { connection.disconnect() }
+
+        let completed = expectation(description: "missing identity rejected")
+        performClientCertificateChallenge(on: connection, host: "broker.example.com") { disposition, credential in
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            XCTAssertNil(credential)
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 1)
+    }
+
+    func testFoundationConnectionDoesNotSendIdentityToAnotherHost() throws {
+        let fixture = try Self.fixture.get()
+        let connection = try makeFoundationConnection()
+        connection.clientIdentity = try makeClientIdentity(fixture)
+        addTeardownBlock { connection.disconnect() }
+
+        let completed = expectation(description: "cross-host identity rejected")
+        performClientCertificateChallenge(on: connection, host: "redirect.example.com") { disposition, credential in
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            XCTAssertNil(credential)
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 1)
+    }
+
     private func start(_ broker: TLSWebSocketMQTTLoopbackBroker) throws -> UInt16 {
         let ready = expectation(description: "mTLS WebSocket broker ready")
         broker.start { ready.fulfill() }
@@ -141,6 +194,41 @@ final class WebSocketMTLSIntegrationTests: XCTestCase {
             certificateData: fixture.clientCertificatePEM,
             privateKeyData: fixture.clientPrivateKeyPKCS1PEM,
             intermediateCertificateData: [fixture.intermediateCertificatePEM]
+        )
+    }
+
+    private func makeFoundationConnection() throws -> CocoaMQTTWebSocket.FoundationConnection {
+        CocoaMQTTWebSocket.FoundationConnection(
+            url: try XCTUnwrap(URL(string: "wss://broker.example.com:443/mqtt")),
+            config: .ephemeral
+        )
+    }
+
+    private func performClientCertificateChallenge(
+        on connection: CocoaMQTTWebSocket.FoundationConnection,
+        host: String,
+        completion: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        let protectionSpace = URLProtectionSpace(
+            host: host,
+            port: 443,
+            protocol: "https",
+            realm: nil,
+            authenticationMethod: NSURLAuthenticationMethodClientCertificate
+        )
+        let challenge = URLAuthenticationChallenge(
+            protectionSpace: protectionSpace,
+            proposedCredential: nil,
+            previousFailureCount: 0,
+            failureResponse: nil,
+            error: nil,
+            sender: ChallengeSenderStub()
+        )
+        connection.urlSession(
+            connection.session!,
+            task: connection.task!,
+            didReceive: challenge,
+            completionHandler: completion
         )
     }
 

--- a/CocoaMQTTTests/WebSocketMTLSIntegrationTests.swift
+++ b/CocoaMQTTTests/WebSocketMTLSIntegrationTests.swift
@@ -1,0 +1,167 @@
+#if os(macOS) && IS_SWIFT_PACKAGE
+import Security
+import XCTest
+@testable import CocoaMQTT
+@testable import CocoaMQTTWebSocket
+
+@available(macOS 10.15, *)
+final class WebSocketMTLSIntegrationTests: XCTestCase {
+
+    private static let fixture = Result { try TLSLoopbackCertificateFixture() }
+
+    override static func tearDown() {
+        try? fixture.get().removeTemporaryFiles()
+        super.tearDown()
+    }
+
+    func testMQTT311ConnectsOverWebSocketWithClientIdentity() throws {
+        let fixture = try Self.fixture.get()
+        let broker = try TLSWebSocketMQTTLoopbackBroker(
+            identity: fixture.serverIdentity,
+            trustedClientRootCertificate: fixture.rootCertificate
+        )
+        let port = try start(broker)
+        let connected = expectation(description: "MQTT 3.1.1 connected over mTLS WebSocket")
+        let socket = CocoaMQTTWebSocket(uri: "/mqtt")
+        let mqtt = CocoaMQTT(
+            clientID: "wss-mtls-311",
+            host: "127.0.0.1",
+            port: port,
+            socket: socket
+        )
+        configure(
+            mqtt,
+            identity: try makeClientIdentity(fixture),
+            trustedRoot: fixture.rootCertificate
+        )
+        mqtt.didConnectAck = { client, ack in
+            XCTAssertEqual(ack, .accept)
+            connected.fulfill()
+            client.disconnect()
+        }
+
+        XCTAssertTrue(mqtt.connect(timeout: 2))
+        wait(for: [connected], timeout: 5)
+        XCTAssertEqual(broker.receivedProtocolLevels, [4])
+    }
+
+    func testMQTT5ConnectsOverWebSocketWithClientIdentity() throws {
+        let fixture = try Self.fixture.get()
+        let broker = try TLSWebSocketMQTTLoopbackBroker(
+            identity: fixture.serverIdentity,
+            trustedClientRootCertificate: fixture.rootCertificate
+        )
+        let port = try start(broker)
+        let connected = expectation(description: "MQTT 5 connected over mTLS WebSocket")
+        let socket = CocoaMQTTWebSocket(uri: "/mqtt")
+        let mqtt = CocoaMQTT5(
+            clientID: "wss-mtls-5",
+            host: "127.0.0.1",
+            port: port,
+            socket: socket
+        )
+        configure(
+            mqtt,
+            identity: try makeClientIdentity(fixture),
+            trustedRoot: fixture.rootCertificate
+        )
+        mqtt.didConnectAck = { client, reasonCode, _ in
+            XCTAssertEqual(reasonCode, .success)
+            connected.fulfill()
+            client.disconnect()
+        }
+
+        XCTAssertTrue(mqtt.connect(timeout: 2))
+        wait(for: [connected], timeout: 5)
+        XCTAssertEqual(broker.receivedProtocolLevels, [5])
+    }
+
+    func testWebSocketBrokerRequiringClientCertificateRejectsMissingIdentity() throws {
+        let fixture = try Self.fixture.get()
+        let broker = try TLSWebSocketMQTTLoopbackBroker(
+            identity: fixture.serverIdentity,
+            trustedClientRootCertificate: fixture.rootCertificate
+        )
+        let port = try start(broker)
+        let disconnected = expectation(description: "WebSocket mTLS connection rejected")
+        let socket = CocoaMQTTWebSocket(uri: "/mqtt")
+        let mqtt = CocoaMQTT(
+            clientID: "wss-mtls-missing",
+            host: "127.0.0.1",
+            port: port,
+            socket: socket
+        )
+        configure(mqtt, identity: nil, trustedRoot: fixture.rootCertificate)
+        mqtt.didDisconnect = { _, _ in disconnected.fulfill() }
+
+        XCTAssertTrue(mqtt.connect(timeout: 2))
+        wait(for: [disconnected], timeout: 5)
+        XCTAssertTrue(broker.receivedProtocolLevels.isEmpty)
+    }
+
+    private func start(_ broker: TLSWebSocketMQTTLoopbackBroker) throws -> UInt16 {
+        let ready = expectation(description: "mTLS WebSocket broker ready")
+        broker.start { ready.fulfill() }
+        addTeardownBlock { broker.stop() }
+        wait(for: [ready], timeout: 2)
+        return try XCTUnwrap(broker.port)
+    }
+
+    private func makeClientIdentity(
+        _ fixture: TLSLoopbackCertificateFixture
+    ) throws -> CocoaMQTTClientIdentity {
+        try CocoaMQTTClientIdentity(
+            certificateData: fixture.clientCertificatePEM,
+            privateKeyData: fixture.clientPrivateKeyPKCS1PEM,
+            intermediateCertificateData: [fixture.intermediateCertificatePEM]
+        )
+    }
+
+    private func configure(
+        _ mqtt: CocoaMQTT,
+        identity: CocoaMQTTClientIdentity?,
+        trustedRoot: SecCertificate
+    ) {
+        mqtt.enableSSL = true
+        mqtt.autoReconnect = false
+        mqtt.logLevel = .off
+        mqtt.clientIdentity = identity
+        mqtt.didReceiveTrust = { _, trust, completion in
+            completion(Self.evaluate(trust, trustedRoot: trustedRoot))
+        }
+    }
+
+    private func configure(
+        _ mqtt: CocoaMQTT5,
+        identity: CocoaMQTTClientIdentity,
+        trustedRoot: SecCertificate
+    ) {
+        mqtt.enableSSL = true
+        mqtt.autoReconnect = false
+        mqtt.logLevel = .off
+        mqtt.clientIdentity = identity
+        mqtt.didReceiveTrust = { _, trust, completion in
+            completion(Self.evaluate(trust, trustedRoot: trustedRoot))
+        }
+    }
+
+    private static func evaluate(
+        _ trust: SecTrust,
+        trustedRoot: SecCertificate
+    ) -> Bool {
+        guard SecTrustSetPolicies(
+            trust,
+            SecPolicyCreateSSL(true, "127.0.0.1" as CFString)
+        ) == errSecSuccess,
+        SecTrustSetAnchorCertificates(
+            trust,
+            [trustedRoot] as CFArray
+        ) == errSecSuccess,
+        SecTrustSetAnchorCertificatesOnly(trust, true) == errSecSuccess else {
+            return false
+        }
+        var error: CFError?
+        return SecTrustEvaluateWithError(trust, &error)
+    }
+}
+#endif

--- a/CocoaMQTTTests/WebSocketMTLSIntegrationTests.swift
+++ b/CocoaMQTTTests/WebSocketMTLSIntegrationTests.swift
@@ -99,6 +99,33 @@ final class WebSocketMTLSIntegrationTests: XCTestCase {
         XCTAssertTrue(broker.receivedProtocolLevels.isEmpty)
     }
 
+    func testWebSocketRejectsServerSignedByUntrustedCA() throws {
+        let fixture = try Self.fixture.get()
+        let broker = try TLSWebSocketMQTTLoopbackBroker(
+            identity: fixture.serverIdentity,
+            trustedClientRootCertificate: fixture.rootCertificate
+        )
+        let port = try start(broker)
+        let disconnected = expectation(description: "untrusted WSS server rejected")
+        let socket = CocoaMQTTWebSocket(uri: "/mqtt")
+        let mqtt = CocoaMQTT(
+            clientID: "wss-untrusted-server",
+            host: "127.0.0.1",
+            port: port,
+            socket: socket
+        )
+        configure(
+            mqtt,
+            identity: try makeClientIdentity(fixture),
+            trustedRoot: fixture.untrustedRootCertificate
+        )
+        mqtt.didDisconnect = { _, _ in disconnected.fulfill() }
+
+        XCTAssertTrue(mqtt.connect(timeout: 2))
+        wait(for: [disconnected], timeout: 5)
+        XCTAssertTrue(broker.receivedProtocolLevels.isEmpty)
+    }
+
     private func start(_ broker: TLSWebSocketMQTTLoopbackBroker) throws -> UInt16 {
         let ready = expectation(description: "mTLS WebSocket broker ready")
         broker.start { ready.fulfill() }
@@ -126,9 +153,9 @@ final class WebSocketMTLSIntegrationTests: XCTestCase {
         mqtt.autoReconnect = false
         mqtt.logLevel = .off
         mqtt.clientIdentity = identity
-        mqtt.didReceiveTrust = { _, trust, completion in
-            completion(Self.evaluate(trust, trustedRoot: trustedRoot))
-        }
+        mqtt.tlsServerName = "broker.example.com"
+        mqtt.trustedServerCertificates = [trustedRoot]
+        mqtt.usesSystemTrustStore = false
     }
 
     private func configure(
@@ -140,28 +167,9 @@ final class WebSocketMTLSIntegrationTests: XCTestCase {
         mqtt.autoReconnect = false
         mqtt.logLevel = .off
         mqtt.clientIdentity = identity
-        mqtt.didReceiveTrust = { _, trust, completion in
-            completion(Self.evaluate(trust, trustedRoot: trustedRoot))
-        }
-    }
-
-    private static func evaluate(
-        _ trust: SecTrust,
-        trustedRoot: SecCertificate
-    ) -> Bool {
-        guard SecTrustSetPolicies(
-            trust,
-            SecPolicyCreateSSL(true, "127.0.0.1" as CFString)
-        ) == errSecSuccess,
-        SecTrustSetAnchorCertificates(
-            trust,
-            [trustedRoot] as CFArray
-        ) == errSecSuccess,
-        SecTrustSetAnchorCertificatesOnly(trust, true) == errSecSuccess else {
-            return false
-        }
-        var error: CFError?
-        return SecTrustEvaluateWithError(trust, &error)
+        mqtt.tlsServerName = "broker.example.com"
+        mqtt.trustedServerCertificates = [trustedRoot]
+        mqtt.usesSystemTrustStore = false
     }
 }
 #endif

--- a/Example/Example/MutualTLSConfiguration.swift
+++ b/Example/Example/MutualTLSConfiguration.swift
@@ -29,8 +29,8 @@ enum MutualTLSExampleError: Error {
 
 enum MutualTLSConfiguration {
 
-    /// Creates an MQTT 3.1.1 client using the built-in Foundation WebSocket
-    /// transport on supported OS versions.
+    /// Creates an MQTT 3.1.1 client using the built-in Apple
+    /// `URLSessionWebSocketTask` transport.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
     static func makeMQTT311WebSocketClient(
         clientID: String,
@@ -46,8 +46,8 @@ enum MutualTLSConfiguration {
         )
     }
 
-    /// Creates an MQTT 5 client using the built-in Foundation WebSocket
-    /// transport on supported OS versions.
+    /// Creates an MQTT 5 client using the built-in Apple
+    /// `URLSessionWebSocketTask` transport.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
     static func makeMQTT5WebSocketClient(
         clientID: String,

--- a/Example/Example/MutualTLSConfiguration.swift
+++ b/Example/Example/MutualTLSConfiguration.swift
@@ -4,6 +4,7 @@
 //
 
 import CocoaMQTT
+import CocoaMQTTWebSocket
 import Foundation
 import Security
 
@@ -11,6 +12,7 @@ protocol CocoaMQTTMutualTLSConfiguring: AnyObject {
     var clientIdentity: CocoaMQTTClientIdentity? { get set }
     var trustedServerCertificates: [SecCertificate] { get set }
     var usesSystemTrustStore: Bool { get set }
+    var tlsServerName: String? { get set }
     var enableSSL: Bool { get set }
 }
 
@@ -27,6 +29,40 @@ enum MutualTLSExampleError: Error {
 
 enum MutualTLSConfiguration {
 
+    /// Creates an MQTT 3.1.1 client using the built-in Foundation WebSocket
+    /// transport on supported OS versions.
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+    static func makeMQTT311WebSocketClient(
+        clientID: String,
+        host: String,
+        port: UInt16 = 443,
+        uri: String = "/mqtt"
+    ) -> CocoaMQTT {
+        CocoaMQTT(
+            clientID: clientID,
+            host: host,
+            port: port,
+            socket: CocoaMQTTWebSocket(uri: uri)
+        )
+    }
+
+    /// Creates an MQTT 5 client using the built-in Foundation WebSocket
+    /// transport on supported OS versions.
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+    static func makeMQTT5WebSocketClient(
+        clientID: String,
+        host: String,
+        port: UInt16 = 443,
+        uri: String = "/mqtt"
+    ) -> CocoaMQTT5 {
+        CocoaMQTT5(
+            clientID: clientID,
+            host: host,
+            port: port,
+            socket: CocoaMQTTWebSocket(uri: uri)
+        )
+    }
+
     /// Configures either MQTT client with an in-memory PEM/DER client identity.
     ///
     /// Obtain private-key data through secure provisioning. Do not embed a
@@ -37,7 +73,8 @@ enum MutualTLSConfiguration {
         privateKeyURL: URL,
         intermediateCertificateURLs: [URL] = [],
         brokerCAURLs: [URL] = [],
-        usesSystemTrustStore: Bool = true
+        usesSystemTrustStore: Bool = true,
+        tlsServerName: String? = nil
     ) throws {
         let identity = try CocoaMQTTClientIdentity(
             certificateData: try Data(contentsOf: clientCertificateURL),
@@ -50,7 +87,8 @@ enum MutualTLSConfiguration {
             client: client,
             identity: identity,
             brokerCAURLs: brokerCAURLs,
-            usesSystemTrustStore: usesSystemTrustStore
+            usesSystemTrustStore: usesSystemTrustStore,
+            tlsServerName: tlsServerName
         )
     }
 
@@ -63,7 +101,8 @@ enum MutualTLSConfiguration {
         pkcs12URL: URL,
         password: String,
         brokerCAURLs: [URL] = [],
-        usesSystemTrustStore: Bool = true
+        usesSystemTrustStore: Bool = true,
+        tlsServerName: String? = nil
     ) throws {
         let identity = try clientIdentity(
             fromPKCS12: Data(contentsOf: pkcs12URL),
@@ -73,7 +112,8 @@ enum MutualTLSConfiguration {
             client: client,
             identity: identity,
             brokerCAURLs: brokerCAURLs,
-            usesSystemTrustStore: usesSystemTrustStore
+            usesSystemTrustStore: usesSystemTrustStore,
+            tlsServerName: tlsServerName
         )
     }
 
@@ -143,7 +183,8 @@ enum MutualTLSConfiguration {
         client: Client,
         identity: CocoaMQTTClientIdentity,
         brokerCAURLs: [URL],
-        usesSystemTrustStore: Bool
+        usesSystemTrustStore: Bool,
+        tlsServerName: String?
     ) throws {
         let brokerCertificates = try brokerCAURLs.map { url in
             let data = try Data(contentsOf: url)
@@ -156,6 +197,9 @@ enum MutualTLSConfiguration {
         client.clientIdentity = identity
         client.trustedServerCertificates = brokerCertificates
         client.usesSystemTrustStore = usesSystemTrustStore
+        if let tlsServerName {
+            client.tlsServerName = tlsServerName
+        }
         client.enableSSL = true
     }
 }

--- a/README.md
+++ b/README.md
@@ -177,8 +177,15 @@ the leaf bundle; duplicates and a repeated leaf are ignored. Pass the leaf
 issuer first and normally exclude the root. It is independent from
 `trustedServerCertificates`, which validates the broker. The PEM/DER importer
 requires macOS 10.14, iOS 12, tvOS 12, or visionOS 1. This API applies to the
-built-in TCP transport, not MQTT over WebSocket; assigning it to a client using
-another socket transport has no effect.
+built-in TCP transport and the Foundation WebSocket transport available on
+macOS 10.15, iOS 13, tvOS 13, watchOS 6, and later. The older Starscream
+WebSocket transport does not support client identities. Custom transports can
+opt in by conforming to `CocoaMQTTClientIdentityConfiguring`.
+
+For WSS brokers that use a private server CA, the TCP-only
+`trustedServerCertificates` setting does not apply. Validate that server trust
+through `mqttUrlSession(_:didReceiveTrust:didReceiveChallenge:completionHandler:)`
+or its MQTT 5 equivalent. Client identity and server trust remain independent.
 
 PKCS#12 is a password-protected identity container supported by Apple's
 [`SecPKCS12Import`](https://developer.apple.com/documentation/security/secpkcs12import%28_%3A_%3A_%3A%29).

--- a/README.md
+++ b/README.md
@@ -164,10 +164,16 @@ a trust callback or custom CA certificates rejects the connection.
 
 ### Mutual TLS
 
-For a complete setup that works with either `CocoaMQTT` or `CocoaMQTT5`, see
-the [PEM/DER example](Example/Example/MutualTLSConfiguration.swift#L34-L55) or
-the [PKCS#12 example](Example/Example/MutualTLSConfiguration.swift#L61-L78).
-Both examples configure the client identity and broker trust separately.
+For TCP, create `CocoaMQTT` or `CocoaMQTT5` normally. For Foundation WSS, use
+the [MQTT 3.1.1 WebSocket client](Example/Example/MutualTLSConfiguration.swift#L35-L47)
+or [MQTT 5 WebSocket client](Example/Example/MutualTLSConfiguration.swift#L52-L64)
+example. Before calling `connect()`, apply either the
+[PEM/DER configuration](Example/Example/MutualTLSConfiguration.swift#L70-L93)
+or [PKCS#12 configuration](Example/Example/MutualTLSConfiguration.swift#L99-L118).
+Both configuration functions work with MQTT 3.1.1 and MQTT 5 over TCP or
+Foundation WSS, and configure the client identity and broker trust separately.
+Use their `tlsServerName` parameter when the connection host differs from the
+DNS name in the broker certificate.
 
 `certificateData` accepts a DER certificate, a single PEM certificate, or a PEM
 bundle with the leaf first followed by its intermediates. `privateKeyData`

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ For advanced pinning or enterprise policies, set `manuallyEvaluateTrust = true`
 and implement the trust delegate method or `didReceiveTrust` closure. Never
 accept every certificate in production. The legacy
 `allowUntrustCACertificate` property only enables this manual evaluation; it
-does not safely trust a private CA by itself.
+does not safely trust a private CA by itself. Enabling manual evaluation without
+a trust callback or custom CA certificates rejects the connection.
 
 ### Mutual TLS
 
@@ -182,9 +183,14 @@ macOS 10.15, iOS 13, tvOS 13, watchOS 6, and later. The older Starscream
 WebSocket transport does not support client identities. Custom transports can
 opt in by conforming to `CocoaMQTTClientIdentityConfiguring`.
 
-The high-level TLS settings—`tlsServerName`, `trustedServerCertificates`,
-`usesSystemTrustStore`, `manuallyEvaluateTrust`, and `clientIdentity`—work the
-same way with the built-in TCP and Foundation WebSocket transports.
+Foundation WebSocket client identities are scoped to the original WebSocket
+host and port. A client-certificate challenge is cancelled when no
+`clientIdentity` is configured or after a cross-host redirect.
+
+The same high-level TLS settings—`tlsServerName`,
+`trustedServerCertificates`, `usesSystemTrustStore`, `manuallyEvaluateTrust`,
+and `clientIdentity`—are available to the built-in TCP and Foundation
+WebSocket transports while preserving each transport's existing callback flow.
 `sslSettings` remains a TCP-only low-level escape hatch. Client identity and
 server trust remain independent. For WebSocket connections, `tlsServerName`
 overrides certificate identity verification; the WebSocket URL host still

--- a/README.md
+++ b/README.md
@@ -164,14 +164,19 @@ a trust callback or custom CA certificates rejects the connection.
 
 ### Mutual TLS
 
-For TCP, create `CocoaMQTT` or `CocoaMQTT5` normally. For Foundation WSS, use
-the [MQTT 3.1.1 WebSocket client](Example/Example/MutualTLSConfiguration.swift#L35-L47)
+For TCP, create `CocoaMQTT` or `CocoaMQTT5` normally. For WSS, use the
+[MQTT 3.1.1 WebSocket client](Example/Example/MutualTLSConfiguration.swift#L35-L47)
 or [MQTT 5 WebSocket client](Example/Example/MutualTLSConfiguration.swift#L52-L64)
-example. Before calling `connect()`, apply either the
+example. `CocoaMQTTWebSocket` automatically uses Apple's
+`URLSessionWebSocketTask` on macOS 10.15, iOS 13, tvOS 13, visionOS 1, and
+later; no transport selection is required. Older supported OS versions
+automatically fall back to Starscream, where `clientIdentity` does not
+participate in the TLS handshake. Before calling `connect()`, apply either the
 [PEM/DER configuration](Example/Example/MutualTLSConfiguration.swift#L70-L93)
 or [PKCS#12 configuration](Example/Example/MutualTLSConfiguration.swift#L99-L118).
 Both configuration functions work with MQTT 3.1.1 and MQTT 5 over TCP or
-Foundation WSS, and configure the client identity and broker trust separately.
+WSS using `URLSessionWebSocketTask`, and configure the client identity and
+broker trust separately.
 Use their `tlsServerName` parameter when the connection host differs from the
 DNS name in the broker certificate.
 
@@ -184,23 +189,23 @@ the leaf bundle; duplicates and a repeated leaf are ignored. Pass the leaf
 issuer first and normally exclude the root. It is independent from
 `trustedServerCertificates`, which validates the broker. The PEM/DER importer
 requires macOS 10.14, iOS 12, tvOS 12, or visionOS 1. This API applies to the
-built-in TCP transport and the Foundation WebSocket transport available on
-macOS 10.15, iOS 13, tvOS 13, watchOS 6, and later. The older Starscream
-WebSocket transport does not support client identities. Custom transports can
-opt in by conforming to `CocoaMQTTClientIdentityConfiguring`.
+built-in TCP transport and the Apple `URLSessionWebSocketTask` transport. The
+older Starscream WebSocket fallback does not support client identities. Custom
+transports can opt in by conforming to
+`CocoaMQTTClientIdentityConfiguring`.
 
-Foundation WebSocket client identities are scoped to the original WebSocket
-host and port. A client-certificate challenge is cancelled when no
+`URLSessionWebSocketTask` client identities are scoped to the original
+WebSocket host and port. A client-certificate challenge is cancelled when no
 `clientIdentity` is configured or after a cross-host redirect.
 
 The same high-level TLS settings—`tlsServerName`,
 `trustedServerCertificates`, `usesSystemTrustStore`, `manuallyEvaluateTrust`,
-and `clientIdentity`—are available to the built-in TCP and Foundation
-WebSocket transports while preserving each transport's existing callback flow.
-`sslSettings` remains a TCP-only low-level escape hatch. Client identity and
-server trust remain independent. For WebSocket connections, `tlsServerName`
-overrides certificate identity verification; the WebSocket URL host still
-controls routing and TLS SNI.
+and `clientIdentity`—are available to the built-in TCP and
+`URLSessionWebSocketTask` transports while preserving each transport's existing
+callback flow. `sslSettings` remains a TCP-only low-level escape hatch. Client
+identity and server trust remain independent. For WebSocket connections,
+`tlsServerName` overrides certificate identity verification; the WebSocket URL
+host still controls routing and TLS SNI.
 
 PKCS#12 is a password-protected identity container supported by Apple's
 [`SecPKCS12Import`](https://developer.apple.com/documentation/security/secpkcs12import%28_%3A_%3A_%3A%29).
@@ -213,9 +218,9 @@ through secure provisioning or user input, and keep long-lived secrets in
 Keychain-backed storage. The file format itself does not determine App Store
 eligibility; use supported Security framework APIs and protect the private key.
 
-## MQTT over Websocket
+## MQTT over WebSocket
 
-In the 1.3.0, The CocoaMQTT has supported to connect to MQTT Broker by Websocket.
+CocoaMQTT supports connecting to MQTT brokers over WebSocket.
 
 If you integrated by **Swift Package Manager**, follow these steps:
 
@@ -223,17 +228,17 @@ If you integrated by **Swift Package Manager**, follow these steps:
 2. Go to `File` > `Swift Packages` > `Add Package Dependency`.
 3. Enter the repository URL: `https://github.com/emqx/CocoaMQTT.git`.
 4. Choose the latest version or specify a version range.
-5. Add the package to your target.
+5. Add the `CocoaMQTT` and `CocoaMQTTWebSocket` products to your target.
 
-At last, import "CocoaMQTT" and "Starscream" to your project:
+Import the CocoaMQTT products into your project:
 
 ```swift
 import CocoaMQTT
 import CocoaMQTTWebSocket
-import Starscream
 ```
 
-If you integrated by **CocoaPods**, you need to modify you `Podfile` like the followings and execute `pod install` again:
+If you integrated by **CocoaPods**, update your `Podfile` as follows and run
+`pod install` again:
 
 ```ruby
 use_frameworks!
@@ -248,11 +253,11 @@ If you're using CocoaMQTT in a project with only a `.podspec` and no `Podfile`, 
 ```ruby
 Pod::Spec.new do |s|
   ...
-  s.dependency "Starscream"
+  s.dependency "CocoaMQTT/WebSockets"
 end
 ```
 
-Then, Create a MQTT instance over Websocket:
+Then, create an MQTT instance over WebSocket:
 
 ```swift
 ///MQTT 5.0
@@ -275,9 +280,10 @@ let mqtt = CocoaMQTT(clientID: clientID, host: host, port: 8083, socket: websock
 _ = mqtt.connect()
 ```
 
-The built-in Foundation WebSocket transport fails a receive when one WebSocket
-message reaches its 1 MiB buffering limit. Set a value greater than the largest
-expected WebSocket message before connecting, or use `0` to remove the limit:
+The built-in Apple `URLSessionWebSocketTask` transport fails a receive when one
+WebSocket message reaches its 1 MiB buffering limit. Set a value greater than
+the largest expected WebSocket message before connecting, or use `0` to remove
+the limit:
 
 ```swift
 let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
@@ -285,7 +291,7 @@ websocket.maximumMessageSize = 10 * 1024 * 1024 + 1 // Accept up to 10 MiB.
 ```
 
 This setting is independent of MQTT 5 Maximum Packet Size. It is not used by
-the older Starscream transport, and custom connection builders must configure
+the older Starscream fallback, and custom connection builders must configure
 their own transport. Use `0` only when message sizes are otherwise controlled,
 because it permits unbounded buffering.
 
@@ -310,7 +316,6 @@ If you want to connect using WebSocket Secure (wss), you can use the following e
 ```swift
 import CocoaMQTT
 import CocoaMQTTWebSocket
-import Starscream
 
 class WebSocketManager {
     
@@ -415,7 +420,8 @@ These third-party functions are used:
 
 ~~[GCDAsyncSocket](https://github.com/robbiehanson/CocoaAsyncSocket)~~
 * [MqttCocoaAsyncSocket](https://github.com/leeway1208/MqttCocoaAsyncSocket)
-* [Starscream](https://github.com/daltoniam/Starscream)
+* [Starscream](https://github.com/daltoniam/Starscream) (legacy WebSocket
+  fallback for older Apple OS versions)
 
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -182,10 +182,13 @@ macOS 10.15, iOS 13, tvOS 13, watchOS 6, and later. The older Starscream
 WebSocket transport does not support client identities. Custom transports can
 opt in by conforming to `CocoaMQTTClientIdentityConfiguring`.
 
-For WSS brokers that use a private server CA, the TCP-only
-`trustedServerCertificates` setting does not apply. Validate that server trust
-through `mqttUrlSession(_:didReceiveTrust:didReceiveChallenge:completionHandler:)`
-or its MQTT 5 equivalent. Client identity and server trust remain independent.
+The high-level TLS settings—`tlsServerName`, `trustedServerCertificates`,
+`usesSystemTrustStore`, `manuallyEvaluateTrust`, and `clientIdentity`—work the
+same way with the built-in TCP and Foundation WebSocket transports.
+`sslSettings` remains a TCP-only low-level escape hatch. Client identity and
+server trust remain independent. For WebSocket connections, `tlsServerName`
+overrides certificate identity verification; the WebSocket URL host still
+controls routing and TLS SNI.
 
 PKCS#12 is a password-protected identity container supported by Apple's
 [`SecPKCS12Import`](https://developer.apple.com/documentation/security/secpkcs12import%28_%3A_%3A_%3A%29).

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -350,9 +350,11 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Client identity sent by transports that support mutual TLS.
     ///
-    /// The built-in TCP socket and the Foundation WebSocket transport support
-    /// this capability. Custom transports may opt in by conforming to
-    /// `CocoaMQTTClientIdentityConfiguring`.
+    /// The built-in TCP socket supports this capability. On modern Apple OS
+    /// versions, the default WebSocket transport uses `URLSessionWebSocketTask`
+    /// and also supports it. The Starscream fallback used on older OS versions
+    /// does not apply this identity. Custom transports may opt in by conforming
+    /// to `CocoaMQTTClientIdentityConfiguring`.
     public var clientIdentity: CocoaMQTTClientIdentity? {
         get { return (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity }
         set { (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity = newValue }

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -338,14 +338,14 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Server name used for TLS identity verification. Defaults to `host`.
     @objc public var tlsServerName: String? {
-        get { return (self.socket as? CocoaMQTTSocket)?.tlsServerName }
-        set { (self.socket as? CocoaMQTTSocket)?.tlsServerName = newValue }
+        get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.tlsServerName }
+        set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.tlsServerName = newValue }
     }
 
-    /// Additional CA certificates trusted by the built-in TCP socket.
+    /// Additional CA certificates trusted by supported TLS transports.
     public var trustedServerCertificates: [SecCertificate] {
-        get { return (self.socket as? CocoaMQTTSocket)?.trustedServerCertificates ?? [] }
-        set { (self.socket as? CocoaMQTTSocket)?.trustedServerCertificates = newValue }
+        get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.trustedServerCertificates ?? [] }
+        set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.trustedServerCertificates = newValue }
     }
 
     /// Client identity sent by transports that support mutual TLS.
@@ -360,22 +360,19 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Whether custom CA validation also accepts the system trust store.
     @objc public var usesSystemTrustStore: Bool {
-        get { return (self.socket as? CocoaMQTTSocket)?.usesSystemTrustStore ?? true }
-        set { (self.socket as? CocoaMQTTSocket)?.usesSystemTrustStore = newValue }
+        get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.usesSystemTrustStore ?? true }
+        set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.usesSystemTrustStore = newValue }
     }
 
-    /// Enables manual server trust evaluation on the built-in TCP socket.
-    /// Implement the trust delegate method or `didReceiveTrust` closure before
-    /// enabling this property.
+    /// Gives the trust delegate or `didReceiveTrust` closure first chance to
+    /// decide. Configured custom CA certificates remain the fallback.
     @objc public var manuallyEvaluateTrust: Bool {
-        get { return (self.socket as? CocoaMQTTSocket)?.manuallyEvaluateTrust ?? false }
-        set { (self.socket as? CocoaMQTTSocket)?.manuallyEvaluateTrust = newValue }
+        get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.manuallyEvaluateTrust ?? false }
+        set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.manuallyEvaluateTrust = newValue }
     }
 
     /// Legacy name for enabling manual trust evaluation.
     ///
-    /// This setting does not apply to `CocoaMQTTWebSocket`. Handle a WebSocket
-    /// trust challenge with `mqttUrlSession` or `didReceiveTrust` instead.
     /// Default is false. Setting this does not accept a certificate by itself.
     @available(*, deprecated, renamed: "manuallyEvaluateTrust")
     public var allowUntrustCACertificate: Bool {
@@ -947,6 +944,18 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
                     guard let handler = mqtt.customDidReceiveTrust else { return false }
                     handler(mqtt, trust, completion)
                     return true
+                },
+                fallback: { completion in
+                    guard let configuration = socket as? CocoaMQTTServerTrustConfiguring else {
+                        return false
+                    }
+                    return CocoaMQTTServerTrustEvaluator.evaluate(
+                        trust,
+                        configuration: configuration,
+                        serverName: configuration.tlsServerName
+                            ?? challenge.protectionSpace.host,
+                        completionHandler: completion
+                    )
                 },
                 legacyCredential: URLCredential(trust: trust),
                 completionHandler: completionHandler

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -365,7 +365,8 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     }
 
     /// Gives the trust delegate or `didReceiveTrust` closure first chance to
-    /// decide. Configured custom CA certificates remain the fallback.
+    /// decide. Configured custom CA certificates remain the fallback; without
+    /// either, enabling this setting rejects the connection.
     @objc public var manuallyEvaluateTrust: Bool {
         get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.manuallyEvaluateTrust ?? false }
         set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.manuallyEvaluateTrust = newValue }
@@ -916,10 +917,12 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
                 handler(mqtt, trust, completion)
                 return true
             }, fallback: { completion in
-                (socket as? CocoaMQTTSocket)?.evaluateServerTrust(
+                CocoaMQTTServerTrustEvaluator.evaluate(
                     trust,
+                    socket: socket,
+                    defaultServerName: mqtt.host,
                     completionHandler: completion
-                ) ?? false
+                )
             }, completionHandler: completionHandler)
         }, onDeallocated: { completionHandler(false) })
     }
@@ -946,14 +949,10 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
                     return true
                 },
                 fallback: { completion in
-                    guard let configuration = socket as? CocoaMQTTServerTrustConfiguring else {
-                        return false
-                    }
                     return CocoaMQTTServerTrustEvaluator.evaluate(
                         trust,
-                        configuration: configuration,
-                        serverName: configuration.tlsServerName
-                            ?? challenge.protectionSpace.host,
+                        socket: socket,
+                        defaultServerName: challenge.protectionSpace.host,
                         completionHandler: completion
                     )
                 },

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -348,12 +348,14 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         set { (self.socket as? CocoaMQTTSocket)?.trustedServerCertificates = newValue }
     }
 
-    /// Client identity sent by the built-in TCP socket during mutual TLS.
+    /// Client identity sent by transports that support mutual TLS.
     ///
-    /// This does not configure WebSocket client authentication.
+    /// The built-in TCP socket and the Foundation WebSocket transport support
+    /// this capability. Custom transports may opt in by conforming to
+    /// `CocoaMQTTClientIdentityConfiguring`.
     public var clientIdentity: CocoaMQTTClientIdentity? {
-        get { return (self.socket as? CocoaMQTTSocket)?.clientIdentity }
-        set { (self.socket as? CocoaMQTTSocket)?.clientIdentity = newValue }
+        get { return (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity }
+        set { (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity = newValue }
     }
 
     /// Whether custom CA validation also accepts the system trust store.

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -399,7 +399,8 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
 
     /// Gives the trust delegate or `didReceiveTrust` closure first chance to
-    /// decide. Configured custom CA certificates remain the fallback.
+    /// decide. Configured custom CA certificates remain the fallback; without
+    /// either, enabling this setting rejects the connection.
     @objc public var manuallyEvaluateTrust: Bool {
         get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.manuallyEvaluateTrust ?? false }
         set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.manuallyEvaluateTrust = newValue }
@@ -1219,10 +1220,12 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
                 handler(mqtt5, trust, completion)
                 return true
             }, fallback: { completion in
-                (socket as? CocoaMQTTSocket)?.evaluateServerTrust(
+                CocoaMQTTServerTrustEvaluator.evaluate(
                     trust,
+                    socket: socket,
+                    defaultServerName: mqtt5.host,
                     completionHandler: completion
-                ) ?? false
+                )
             }, completionHandler: completionHandler)
         }, onDeallocated: { completionHandler(false) })
     }
@@ -1249,14 +1252,10 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
                     return true
                 },
                 fallback: { completion in
-                    guard let configuration = socket as? CocoaMQTTServerTrustConfiguring else {
-                        return false
-                    }
                     return CocoaMQTTServerTrustEvaluator.evaluate(
                         trust,
-                        configuration: configuration,
-                        serverName: configuration.tlsServerName
-                            ?? challenge.protectionSpace.host,
+                        socket: socket,
+                        defaultServerName: challenge.protectionSpace.host,
                         completionHandler: completion
                     )
                 },

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -384,9 +384,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Client identity sent by transports that support mutual TLS.
     ///
-    /// The built-in TCP socket and the Foundation WebSocket transport support
-    /// this capability. Custom transports may opt in by conforming to
-    /// `CocoaMQTTClientIdentityConfiguring`.
+    /// The built-in TCP socket supports this capability. On modern Apple OS
+    /// versions, the default WebSocket transport uses `URLSessionWebSocketTask`
+    /// and also supports it. The Starscream fallback used on older OS versions
+    /// does not apply this identity. Custom transports may opt in by conforming
+    /// to `CocoaMQTTClientIdentityConfiguring`.
     public var clientIdentity: CocoaMQTTClientIdentity? {
         get { return (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity }
         set { (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity = newValue }

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -372,14 +372,14 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Server name used for TLS identity verification. Defaults to `host`.
     @objc public var tlsServerName: String? {
-        get { return (self.socket as? CocoaMQTTSocket)?.tlsServerName }
-        set { (self.socket as? CocoaMQTTSocket)?.tlsServerName = newValue }
+        get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.tlsServerName }
+        set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.tlsServerName = newValue }
     }
 
-    /// Additional CA certificates trusted by the built-in TCP socket.
+    /// Additional CA certificates trusted by supported TLS transports.
     public var trustedServerCertificates: [SecCertificate] {
-        get { return (self.socket as? CocoaMQTTSocket)?.trustedServerCertificates ?? [] }
-        set { (self.socket as? CocoaMQTTSocket)?.trustedServerCertificates = newValue }
+        get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.trustedServerCertificates ?? [] }
+        set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.trustedServerCertificates = newValue }
     }
 
     /// Client identity sent by transports that support mutual TLS.
@@ -394,22 +394,19 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Whether custom CA validation also accepts the system trust store.
     @objc public var usesSystemTrustStore: Bool {
-        get { return (self.socket as? CocoaMQTTSocket)?.usesSystemTrustStore ?? true }
-        set { (self.socket as? CocoaMQTTSocket)?.usesSystemTrustStore = newValue }
+        get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.usesSystemTrustStore ?? true }
+        set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.usesSystemTrustStore = newValue }
     }
 
-    /// Enables manual server trust evaluation on the built-in TCP socket.
-    /// Implement the trust delegate method or `didReceiveTrust` closure before
-    /// enabling this property.
+    /// Gives the trust delegate or `didReceiveTrust` closure first chance to
+    /// decide. Configured custom CA certificates remain the fallback.
     @objc public var manuallyEvaluateTrust: Bool {
-        get { return (self.socket as? CocoaMQTTSocket)?.manuallyEvaluateTrust ?? false }
-        set { (self.socket as? CocoaMQTTSocket)?.manuallyEvaluateTrust = newValue }
+        get { return (self.socket as? CocoaMQTTServerTrustConfiguring)?.manuallyEvaluateTrust ?? false }
+        set { (self.socket as? CocoaMQTTServerTrustConfiguring)?.manuallyEvaluateTrust = newValue }
     }
 
     /// Legacy name for enabling manual trust evaluation.
     ///
-    /// This setting does not apply to `CocoaMQTTWebSocket`. Handle a WebSocket
-    /// trust challenge with `mqtt5UrlSession` or `didReceiveTrust` instead.
     /// Default is false. Setting this does not accept a certificate by itself.
     @available(*, deprecated, renamed: "manuallyEvaluateTrust")
     public var allowUntrustCACertificate: Bool {
@@ -1250,6 +1247,18 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
                     guard let handler = mqtt5.customDidReceiveTrust else { return false }
                     handler(mqtt5, trust, completion)
                     return true
+                },
+                fallback: { completion in
+                    guard let configuration = socket as? CocoaMQTTServerTrustConfiguring else {
+                        return false
+                    }
+                    return CocoaMQTTServerTrustEvaluator.evaluate(
+                        trust,
+                        configuration: configuration,
+                        serverName: configuration.tlsServerName
+                            ?? challenge.protectionSpace.host,
+                        completionHandler: completion
+                    )
                 },
                 legacyCredential: URLCredential(trust: trust),
                 completionHandler: completionHandler

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -382,12 +382,14 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         set { (self.socket as? CocoaMQTTSocket)?.trustedServerCertificates = newValue }
     }
 
-    /// Client identity sent by the built-in TCP socket during mutual TLS.
+    /// Client identity sent by transports that support mutual TLS.
     ///
-    /// This does not configure WebSocket client authentication.
+    /// The built-in TCP socket and the Foundation WebSocket transport support
+    /// this capability. Custom transports may opt in by conforming to
+    /// `CocoaMQTTClientIdentityConfiguring`.
     public var clientIdentity: CocoaMQTTClientIdentity? {
-        get { return (self.socket as? CocoaMQTTSocket)?.clientIdentity }
-        set { (self.socket as? CocoaMQTTSocket)?.clientIdentity = newValue }
+        get { return (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity }
+        set { (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity = newValue }
     }
 
     /// Whether custom CA validation also accepts the system trust store.

--- a/Source/CocoaMQTTClientIdentity.swift
+++ b/Source/CocoaMQTTClientIdentity.swift
@@ -276,6 +276,15 @@ public final class CocoaMQTTClientIdentity: NSObject {
     }
 }
 
+/// An optional transport capability for configuring a mutual-TLS client identity.
+///
+/// This is separate from `CocoaMQTTSocketProtocol` so existing custom socket
+/// implementations remain source compatible. Custom transports can adopt this
+/// protocol when they support client-certificate authentication.
+public protocol CocoaMQTTClientIdentityConfiguring: AnyObject {
+    var clientIdentity: CocoaMQTTClientIdentity? { get set }
+}
+
 private enum DERError: Error {
     case invalid
 }

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -251,7 +251,7 @@ public extension CocoaMQTTSocketProtocol {
 
 // MARK: - CocoaMQTTSocket
 
-public class CocoaMQTTSocket: NSObject {
+public class CocoaMQTTSocket: NSObject, CocoaMQTTClientIdentityConfiguring {
 
     private static let trustEvaluationQueue = DispatchQueue(
         label: "trust.cocoamqtt.emqx",

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -85,6 +85,30 @@ enum CocoaMQTTServerTrustEvaluator {
         }
         return true
     }
+
+    @discardableResult
+    static func evaluate(
+        _ trust: SecTrust,
+        socket: CocoaMQTTSocketProtocol,
+        defaultServerName: String?,
+        completionHandler: @escaping (Bool) -> Void
+    ) -> Bool {
+        if let socket = socket as? CocoaMQTTSocket {
+            return socket.evaluateServerTrust(
+                trust,
+                completionHandler: completionHandler
+            )
+        }
+        guard let configuration = socket as? CocoaMQTTServerTrustConfiguring else {
+            return false
+        }
+        return evaluate(
+            trust,
+            configuration: configuration,
+            serverName: configuration.tlsServerName ?? defaultServerName,
+            completionHandler: completionHandler
+        )
+    }
 }
 
 /// Selects one trust callback and prevents competing callbacks from resolving

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -9,6 +9,84 @@ import Foundation
 import Security
 import MqttCocoaAsyncSocket
 
+/// An optional transport capability for configuring TLS server trust.
+///
+/// Keeping this separate from `CocoaMQTTSocketProtocol` preserves source
+/// compatibility for existing custom transports.
+public protocol CocoaMQTTServerTrustConfiguring: AnyObject {
+    var tlsServerName: String? { get set }
+    var trustedServerCertificates: [SecCertificate] { get set }
+    var usesSystemTrustStore: Bool { get set }
+    var manuallyEvaluateTrust: Bool { get set }
+}
+
+enum CocoaMQTTServerTrustEvaluator {
+    private static let queue = DispatchQueue(
+        label: "trust.cocoamqtt.emqx",
+        qos: .userInitiated
+    )
+
+    /// Returns false when the transport should retain its default trust policy.
+    @discardableResult
+    static func evaluate(
+        _ trust: SecTrust,
+        configuration: CocoaMQTTServerTrustConfiguring,
+        serverName: String?,
+        completionHandler: @escaping (Bool) -> Void
+    ) -> Bool {
+        let certificates = configuration.trustedServerCertificates
+        if configuration.manuallyEvaluateTrust && certificates.isEmpty {
+            completionHandler(false)
+            return true
+        }
+        guard !certificates.isEmpty || configuration.tlsServerName != nil else {
+            return false
+        }
+        guard let serverName else {
+            completionHandler(false)
+            return true
+        }
+
+        guard SecTrustSetPolicies(
+            trust,
+            SecPolicyCreateSSL(true, serverName as CFString)
+        ) == errSecSuccess else {
+            completionHandler(false)
+            return true
+        }
+        if !certificates.isEmpty {
+            guard SecTrustSetAnchorCertificates(
+                trust,
+                certificates as CFArray
+            ) == errSecSuccess,
+            SecTrustSetAnchorCertificatesOnly(
+                trust,
+                !configuration.usesSystemTrustStore
+            ) == errSecSuccess else {
+                completionHandler(false)
+                return true
+            }
+        }
+
+        let queue = Self.queue
+        queue.async {
+            if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
+                SecTrustEvaluateAsyncWithError(trust, queue) { _, trusted, error in
+                    if let error {
+                        printError("TLS server trust evaluation failed: \(error)")
+                    }
+                    completionHandler(trusted)
+                }
+            } else {
+                SecTrustEvaluateAsync(trust, queue) { _, result in
+                    completionHandler(result == .proceed || result == .unspecified)
+                }
+            }
+        }
+        return true
+    }
+}
+
 /// Selects one trust callback and prevents competing callbacks from resolving
 /// the same transport challenge more than once.
 enum CocoaMQTTTrustHandling {
@@ -51,6 +129,7 @@ enum CocoaMQTTTrustHandling {
     static func resolveURLSessionChallenge(
         urlSessionHandler: (@escaping URLSessionCompletion) -> Bool,
         legacyHandler: (@escaping (Bool) -> Void) -> Bool,
+        fallback: (@escaping (Bool) -> Void) -> Bool = { _ in false },
         legacyCredential: URLCredential,
         completionHandler: @escaping URLSessionCompletion
     ) {
@@ -67,6 +146,13 @@ enum CocoaMQTTTrustHandling {
         if legacyHandler({ accepted in
             // A legacy `true` is an explicit trust decision, not a request to
             // repeat the system validation that may already have failed.
+            completion(accepted
+                ? (.useCredential, legacyCredential)
+                : (.rejectProtectionSpace, nil))
+        }) {
+            return
+        }
+        if fallback({ accepted in
             completion(accepted
                 ? (.useCredential, legacyCredential)
                 : (.rejectProtectionSpace, nil))
@@ -251,12 +337,9 @@ public extension CocoaMQTTSocketProtocol {
 
 // MARK: - CocoaMQTTSocket
 
-public class CocoaMQTTSocket: NSObject, CocoaMQTTClientIdentityConfiguring {
-
-    private static let trustEvaluationQueue = DispatchQueue(
-        label: "trust.cocoamqtt.emqx",
-        qos: .userInitiated
-    )
+public class CocoaMQTTSocket: NSObject,
+    CocoaMQTTClientIdentityConfiguring,
+    CocoaMQTTServerTrustConfiguring {
 
     public var backgroundOnSocket = true
 
@@ -282,8 +365,9 @@ public class CocoaMQTTSocket: NSObject, CocoaMQTTClientIdentityConfiguring {
     /// system trust store. Default is true.
     @objc public var usesSystemTrustStore = true
 
-    /// Pauses automatic server trust handling and forwards the trust decision
-    /// to the client's delegate or `didReceiveTrust` closure.
+    /// Gives the client's trust callback first chance to decide. Without a
+    /// callback, configured custom CA certificates are still evaluated;
+    /// without either, the connection is rejected.
     @objc public var manuallyEvaluateTrust = false
 
     /// Legacy name for enabling manual trust evaluation. Setting this does not
@@ -450,33 +534,12 @@ extension CocoaMQTTSocket: MGCDAsyncSocketDelegate {
     /// when no built-in custom-anchor policy is configured.
     @discardableResult
     func evaluateServerTrust(_ trust: SecTrust, completionHandler: @escaping (Bool) -> Void) -> Bool {
-        guard !trustedServerCertificates.isEmpty,
-              let serverName = effectiveTLSServerName() else { return false }
-
-        let policy = SecPolicyCreateSSL(true, serverName as CFString)
-        guard SecTrustSetPolicies(trust, policy) == errSecSuccess,
-              SecTrustSetAnchorCertificates(trust, trustedServerCertificates as CFArray) == errSecSuccess,
-              SecTrustSetAnchorCertificatesOnly(trust, !usesSystemTrustStore) == errSecSuccess else {
-            completionHandler(false)
-            return true
-        }
-
-        let queue = Self.trustEvaluationQueue
-        queue.async {
-            if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
-                SecTrustEvaluateAsyncWithError(trust, queue) { _, trusted, error in
-                    if let error = error {
-                        printError("TLS server trust evaluation failed: \(error)")
-                    }
-                    completionHandler(trusted)
-                }
-            } else {
-                SecTrustEvaluateAsync(trust, queue) { _, result in
-                    completionHandler(result == .proceed || result == .unspecified)
-                }
-            }
-        }
-        return true
+        CocoaMQTTServerTrustEvaluator.evaluate(
+            trust,
+            configuration: self,
+            serverName: effectiveTLSServerName(),
+            completionHandler: completionHandler
+        )
     }
 
     private func effectiveTLSServerName(fallback: String? = nil) -> String? {

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -76,14 +76,16 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
     public var usesSystemTrustStore = true
 
     /// Gives the client trust callback first chance to decide. Configured
-    /// custom CA certificates remain the fallback.
+    /// custom CA certificates remain the fallback; without either, enabling
+    /// this setting rejects the connection.
     public var manuallyEvaluateTrust = false
 
     /// Client identity sent by the built-in Foundation transport during the
     /// TLS handshake. The older Starscream transport does not support this
     /// setting. Custom connection builders may opt in by returning a
     /// `CocoaMQTTClientIdentityConfiguring` connection. Set this before
-    /// connecting.
+    /// connecting. The Foundation transport sends it only to the original
+    /// WebSocket host and port.
     public var clientIdentity: CocoaMQTTClientIdentity?
 
     /// Incoming WebSocket message buffering limit for the built-in Foundation
@@ -399,6 +401,8 @@ public extension CocoaMQTTWebSocket {
         public weak var delegate: CocoaMQTTWebSocketConnectionDelegate?
         public lazy var queue = DispatchQueue(label: "CocoaMQTTFoundationWebSocketConnection-\(self.hashValue)")
         public var clientIdentity: CocoaMQTTClientIdentity?
+        private let endpointHost: String?
+        private let endpointPort: Int?
         var maximumMessageSize: Int {
             get {
                 task?.maximumMessageSize ?? CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize
@@ -414,6 +418,8 @@ public extension CocoaMQTTWebSocket {
         var task: URLSessionWebSocketTask?
 
         public init(url: URL, config: URLSessionConfiguration) {
+            endpointHost = url.host
+            endpointPort = url.port ?? (url.scheme?.lowercased() == "wss" ? 443 : 80)
             super.init()
             let theSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
             session = theSession
@@ -473,8 +479,17 @@ extension CocoaMQTTWebSocket.FoundationConnection: CocoaMQTTWebSocketMessageSize
 extension CocoaMQTTWebSocket.FoundationConnection: URLSessionWebSocketDelegate {
     public func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         queue.async {
-            if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate,
-               let clientIdentity = self.clientIdentity {
+            if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate {
+                let protectionSpace = challenge.protectionSpace
+                guard let endpointHost = self.endpointHost,
+                      let endpointPort = self.endpointPort,
+                      !protectionSpace.isProxy(),
+                      protectionSpace.host.caseInsensitiveCompare(endpointHost) == .orderedSame,
+                      protectionSpace.port == endpointPort,
+                      let clientIdentity = self.clientIdentity else {
+                    completionHandler(.cancelAuthenticationChallenge, nil)
+                    return
+                }
                 completionHandler(
                     .useCredential,
                     URLCredential(

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -53,7 +53,7 @@ private protocol CocoaMQTTWebSocketMessageSizeConfiguring: AnyObject {
 
 // MARK: - CocoaMQTTWebSocket
 
-public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
+public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket, CocoaMQTTClientIdentityConfiguring {
 
     private static let foundationDefaultMaximumMessageSize = 1_048_576
 
@@ -62,6 +62,13 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
     public var shouldConnectWithURIOnly = false
 
     public var headers: [String: String] = [:]
+
+    /// Client identity sent by the built-in Foundation transport during the
+    /// TLS handshake. The older Starscream transport does not support this
+    /// setting. Custom connection builders may opt in by returning a
+    /// `CocoaMQTTClientIdentityConfiguring` connection. Set this before
+    /// connecting.
+    public var clientIdentity: CocoaMQTTClientIdentity?
 
     /// Incoming WebSocket message buffering limit for the built-in Foundation
     /// transport. A message must be smaller than this value. The default is
@@ -131,6 +138,9 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket {
             let newConnection = try builder.buildConnection(forURL: url, withHeaders: self.headers)
             if let configurableConnection = newConnection as? CocoaMQTTWebSocketMessageSizeConfiguring {
                 configurableConnection.maximumMessageSize = maximumMessageSize
+            }
+            if let configurableConnection = newConnection as? CocoaMQTTClientIdentityConfiguring {
+                configurableConnection.clientIdentity = clientIdentity
             }
             connection = newConnection
             newConnection.delegate = self
@@ -368,10 +378,11 @@ extension CocoaMQTTWebSocket: CocoaMQTTWebSocketConnectionDelegate {
 
 @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension CocoaMQTTWebSocket {
-    class FoundationConnection: NSObject, CocoaMQTTWebSocketConnection {
+    class FoundationConnection: NSObject, CocoaMQTTWebSocketConnection, CocoaMQTTClientIdentityConfiguring {
 
         public weak var delegate: CocoaMQTTWebSocketConnectionDelegate?
         public lazy var queue = DispatchQueue(label: "CocoaMQTTFoundationWebSocketConnection-\(self.hashValue)")
+        public var clientIdentity: CocoaMQTTClientIdentity?
         var maximumMessageSize: Int {
             get {
                 task?.maximumMessageSize ?? CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize
@@ -446,6 +457,18 @@ extension CocoaMQTTWebSocket.FoundationConnection: CocoaMQTTWebSocketMessageSize
 extension CocoaMQTTWebSocket.FoundationConnection: URLSessionWebSocketDelegate {
     public func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         queue.async {
+            if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate,
+               let clientIdentity = self.clientIdentity {
+                completionHandler(
+                    .useCredential,
+                    URLCredential(
+                        identity: clientIdentity.identity,
+                        certificates: clientIdentity.intermediateCertificates,
+                        persistence: .forSession
+                    )
+                )
+                return
+            }
             if let trust = challenge.protectionSpace.serverTrust, let delegate = self.delegate {
                 delegate.urlSessionConnection(self, didReceiveTrust: trust, didReceiveChallenge: challenge, completionHandler: completionHandler)
             } else {

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -80,19 +80,22 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
     /// this setting rejects the connection.
     public var manuallyEvaluateTrust = false
 
-    /// Client identity sent by the built-in Foundation transport during the
-    /// TLS handshake. The older Starscream transport does not support this
-    /// setting. Custom connection builders may opt in by returning a
+    /// Client identity sent during the TLS handshake by the built-in Apple
+    /// `URLSessionWebSocketTask` transport, selected automatically on macOS
+    /// 10.15, iOS 13, tvOS 13, visionOS 1, and later. The Starscream fallback
+    /// used on older OS versions does not apply this identity. Custom
+    /// connection builders may opt in by returning a
     /// `CocoaMQTTClientIdentityConfiguring` connection. Set this before
-    /// connecting. The Foundation transport sends it only to the original
+    /// connecting. The built-in transport sends it only to the original
     /// WebSocket host and port.
     public var clientIdentity: CocoaMQTTClientIdentity?
 
-    /// Incoming WebSocket message buffering limit for the built-in Foundation
-    /// transport. A message must be smaller than this value. The default is
-    /// 1 MiB, zero removes the limit, and negative values reset to the default.
-    /// Set this before connecting; custom builders must configure their own
-    /// transports. The older Starscream transport does not use this setting.
+    /// Incoming WebSocket message buffering limit for the built-in Apple
+    /// `URLSessionWebSocketTask` transport. A message must be smaller than this
+    /// value. The default is 1 MiB, zero removes the limit, and negative values
+    /// reset to the default. Set this before connecting; custom builders must
+    /// configure their own transports. The older Starscream fallback does not
+    /// use this setting.
     /// Use zero only when the peer and message sizes are otherwise controlled,
     /// because it permits unbounded message buffering.
     public var maximumMessageSize = CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize {

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -53,7 +53,9 @@ private protocol CocoaMQTTWebSocketMessageSizeConfiguring: AnyObject {
 
 // MARK: - CocoaMQTTWebSocket
 
-public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket, CocoaMQTTClientIdentityConfiguring {
+public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
+    CocoaMQTTClientIdentityConfiguring,
+    CocoaMQTTServerTrustConfiguring {
 
     private static let foundationDefaultMaximumMessageSize = 1_048_576
 
@@ -62,6 +64,20 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket, CocoaMQT
     public var shouldConnectWithURIOnly = false
 
     public var headers: [String: String] = [:]
+
+    /// Server name used for TLS identity verification. Defaults to the URL
+    /// host, which continues to control routing and TLS SNI.
+    public var tlsServerName: String?
+
+    /// Additional CA certificates trusted by the Foundation transport.
+    public var trustedServerCertificates = [SecCertificate]()
+
+    /// Whether custom CA validation also accepts the system trust store.
+    public var usesSystemTrustStore = true
+
+    /// Gives the client trust callback first chance to decide. Configured
+    /// custom CA certificates remain the fallback.
+    public var manuallyEvaluateTrust = false
 
     /// Client identity sent by the built-in Foundation transport during the
     /// TLS handshake. The older Starscream transport does not support this


### PR DESCRIPTION
## What changed
- keep mutual-TLS client identity and server-trust configuration as optional transport capabilities without changing `CocoaMQTTSocketProtocol`
- apply `clientIdentity` to the built-in Apple `URLSessionWebSocketTask` connection and answer URLSession client-certificate challenges with its identity and intermediate chain
- scope that identity to the original WebSocket host and port; cancel missing, proxy, or cross-host client-certificate challenges instead of consulting default credential storage
- make `tlsServerName`, `trustedServerCertificates`, `usesSystemTrustStore`, and `manuallyEvaluateTrust` available to built-in TCP and `URLSessionWebSocketTask` transports
- preserve URLSession delegate and legacy trust-callback priority before the configured trust fallback
- use `CocoaMQTTServerTrustConfiguring` for manual trust fallback while preserving the built-in TCP raw peer-name override
- add composable MQTT 3.1.1/5 WSS constructors to the Example and let the PEM/PKCS#12 helpers configure `tlsServerName`
- guide users through WSS client creation, identity/trust configuration, then `connect()` using links to the Example functions rather than README code duplication
- document that `CocoaMQTTWebSocket` automatically selects `URLSessionWebSocketTask` on modern Apple OS versions and falls back to Starscream on older versions
- remove misleading README instructions to import or directly depend on Starscream when consuming `CocoaMQTTWebSocket`
- add WSS loopback and focused challenge coverage for MQTT 3.1.1, MQTT 5, missing client identity, cross-host identity protection, an untrusted server CA, custom transport trust, and empty manual trust

## Why
The WebSocket transport previously ignored `CocoaMQTT.clientIdentity`, so brokers requiring a client certificate could not complete the TLS handshake. Private broker CA configuration also required a WebSocket-specific callback even though the equivalent high-level TCP settings already existed.

The default builder automatically uses Apple Foundation and `URLSessionWebSocketTask` on iOS 13, macOS 10.15, tvOS 13, visionOS 1, and later; users do not select a separate transport. Older supported OS versions fall back to Starscream, whose released API does not expose a client identity, so mTLS client authentication remains unavailable on that legacy path. Custom connection builders can opt in through `CocoaMQTTClientIdentityConfiguring`.

Closes #325.

## Verification
- `swift test --filter WebSocketMTLSIntegrationTests` (7 passed)
- `swift test --filter TLSChallengeResolutionTests` (26 passed)
- `swift test --filter TLSLoopbackIntegrationTests` (9 passed)
- `swift test --filter ClientIdentityTests` (14 passed)
- `swift test --skip CocoaMQTTTests.CocoaMQTTTests` (304 tests, 1 environment-gated skip)
- `Tools/lint.sh`
- `swift build`
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `swift run --package-path Tests/Swift6Compatibility --scratch-path /tmp/CocoaMQTT-Swift6Compatibility-325 Swift6Compatibility`
- visionOS cross-compile for `CocoaMQTT` and `CocoaMQTTWebSocket`
- `xcodebuild -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath /tmp/CocoaMQTT-issue-325-xcode-review build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project Example/Example.xcodeproj -scheme Example -sdk iphonesimulator -destination "generic/platform=iOS Simulator" -derivedDataPath /tmp/CocoaMQTT-Example-325-review build CODE_SIGNING_ALLOWED=NO`
- `pod lib lint CocoaMQTT.podspec --allow-warnings --skip-tests` built macOS/iOS successfully, then could not run tvOS validation because this machine has no tvOS Simulator