### PR TITLE
Remove the legacy Starscream WebSocket fallback

### DIFF
--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -143,8 +143,12 @@ jobs:
           import CocoaMQTTWebSocket
 
           let message = CocoaMQTTMessage(topic: "ci/spm", string: "ok")
-          let socket = CocoaMQTTWebSocket(uri: "/mqtt")
-          print("\(message.topic) \(socket.enableSSL)")
+          print(message.topic)
+
+          if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+              let socket = CocoaMQTTWebSocket(uri: "/mqtt")
+              print(socket.enableSSL)
+          }
           SPM_MAIN
 
           swift build --package-path "${TMP_DIR}"

--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -28,9 +28,9 @@ Pod::Spec.new do |s|
     ss.dependency "CocoaMQTT/Core"
     # Declaring any platform in a subspec overrides all inherited platform
     # values from the parent spec, so all supported platforms are redeclared.
-    ss.ios.deployment_target = "12.0"
-    ss.osx.deployment_target = "10.13"
-    ss.tvos.deployment_target = "12.0"
+    ss.ios.deployment_target = "13.0"
+    ss.osx.deployment_target = "10.15"
+    ss.tvos.deployment_target = "13.0"
     ss.source_files = "Source/WebSocket/CocoaMQTTWebSocket.swift"
   end
 end

--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -31,7 +31,6 @@ Pod::Spec.new do |s|
     ss.ios.deployment_target = "12.0"
     ss.osx.deployment_target = "10.13"
     ss.tvos.deployment_target = "12.0"
-    ss.dependency "Starscream", ">= 4.0.8", "< 6.0"
     ss.source_files = "Source/WebSocket/CocoaMQTTWebSocket.swift"
   end
 end

--- a/CocoaMQTT.xcodeproj/project.pbxproj
+++ b/CocoaMQTT.xcodeproj/project.pbxproj
@@ -66,11 +66,8 @@
 		C0DEC0DE0000000000000003 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000001 /* PrivacyInfo.xcprivacy */; };
 		C0DEC0DE0000000000000004 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000001 /* PrivacyInfo.xcprivacy */; };
 		C0DEC0DE0000000000000030 /* MqttCocoaAsyncSocket in Frameworks */ = {isa = PBXBuildFile; productRef = C0DEC0DE0000000000000020 /* MqttCocoaAsyncSocket */; };
-		C0DEC0DE0000000000000031 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = C0DEC0DE0000000000000021 /* Starscream */; };
 		C0DEC0DE0000000000000032 /* MqttCocoaAsyncSocket in Frameworks */ = {isa = PBXBuildFile; productRef = C0DEC0DE0000000000000022 /* MqttCocoaAsyncSocket */; };
-		C0DEC0DE0000000000000033 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = C0DEC0DE0000000000000023 /* Starscream */; };
 		C0DEC0DE0000000000000034 /* MqttCocoaAsyncSocket in Frameworks */ = {isa = PBXBuildFile; productRef = C0DEC0DE0000000000000024 /* MqttCocoaAsyncSocket */; };
-		C0DEC0DE0000000000000035 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = C0DEC0DE0000000000000025 /* Starscream */; };
 		6EC871E323A421A200F69AE8 /* CocoaMQTTSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC871E223A421A200F69AE8 /* CocoaMQTTSocket.swift */; };
 		6EC871E523A421DE00F69AE8 /* CocoaMQTTWebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC871E423A421DE00F69AE8 /* CocoaMQTTWebSocket.swift */; };
 		8225B53A227C2FC600E4DB51 /* CocoaMQTT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0409977A1C1B1529006B5A6D /* CocoaMQTT.swift */; };
@@ -276,7 +273,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0DEC0DE0000000000000030 /* MqttCocoaAsyncSocket in Frameworks */,
-				C0DEC0DE0000000000000031 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -285,7 +281,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0DEC0DE0000000000000032 /* MqttCocoaAsyncSocket in Frameworks */,
-				C0DEC0DE0000000000000033 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -294,7 +289,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0DEC0DE0000000000000034 /* MqttCocoaAsyncSocket in Frameworks */,
-				C0DEC0DE0000000000000035 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -499,7 +493,6 @@
 			name = "Mac CocoaMQTT";
 			packageProductDependencies = (
 				C0DEC0DE0000000000000020 /* MqttCocoaAsyncSocket */,
-				C0DEC0DE0000000000000021 /* Starscream */,
 			);
 			productName = CocoaMQTT;
 			productReference = 111124B224BB515E00E2DFBC /* CocoaMQTT.framework */;
@@ -521,7 +514,6 @@
 			name = "tvOS CocoaMQTT";
 			packageProductDependencies = (
 				C0DEC0DE0000000000000022 /* MqttCocoaAsyncSocket */,
-				C0DEC0DE0000000000000023 /* Starscream */,
 			);
 			productName = CocoaMQTT;
 			productReference = 111124DC24BB516400E2DFBC /* CocoaMQTT.framework */;
@@ -543,7 +535,6 @@
 			name = "iOS CocoaMQTT";
 			packageProductDependencies = (
 				C0DEC0DE0000000000000024 /* MqttCocoaAsyncSocket */,
-				C0DEC0DE0000000000000025 /* Starscream */,
 			);
 			productName = CocoaMQTT;
 			productReference = 8225B532227C2E8700E4DB51 /* CocoaMQTT.framework */;
@@ -604,7 +595,6 @@
 			mainGroup = 040997051C1B0B96006B5A6D;
 			packageReferences = (
 				C0DEC0DE0000000000000010 /* XCRemoteSwiftPackageReference "MqttCocoaAsyncSocket" */,
-				C0DEC0DE0000000000000011 /* XCRemoteSwiftPackageReference "Starscream" */,
 			);
 			productRefGroup = 040997101C1B0B96006B5A6D /* Products */;
 			projectDirPath = "";
@@ -1352,15 +1342,6 @@
 				minimumVersion = 1.0.8;
 			};
 		};
-		C0DEC0DE0000000000000011 /* XCRemoteSwiftPackageReference "Starscream" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/daltoniam/Starscream.git";
-			requirement = {
-				kind = versionRange;
-				maximumVersion = 6.0.0;
-				minimumVersion = 4.0.8;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1369,30 +1350,15 @@
 			package = C0DEC0DE0000000000000010 /* XCRemoteSwiftPackageReference "MqttCocoaAsyncSocket" */;
 			productName = MqttCocoaAsyncSocket;
 		};
-		C0DEC0DE0000000000000021 /* Starscream */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DEC0DE0000000000000011 /* XCRemoteSwiftPackageReference "Starscream" */;
-			productName = Starscream;
-		};
 		C0DEC0DE0000000000000022 /* MqttCocoaAsyncSocket */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C0DEC0DE0000000000000010 /* XCRemoteSwiftPackageReference "MqttCocoaAsyncSocket" */;
 			productName = MqttCocoaAsyncSocket;
 		};
-		C0DEC0DE0000000000000023 /* Starscream */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DEC0DE0000000000000011 /* XCRemoteSwiftPackageReference "Starscream" */;
-			productName = Starscream;
-		};
 		C0DEC0DE0000000000000024 /* MqttCocoaAsyncSocket */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C0DEC0DE0000000000000010 /* XCRemoteSwiftPackageReference "MqttCocoaAsyncSocket" */;
 			productName = MqttCocoaAsyncSocket;
-		};
-		C0DEC0DE0000000000000025 /* Starscream */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DEC0DE0000000000000011 /* XCRemoteSwiftPackageReference "Starscream" */;
-			productName = Starscream;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/CocoaMQTT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CocoaMQTT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "252b58627af4ec2ed56ec0afda49cc1e291682c75f8a31983c060b729c5d2240",
+  "originHash" : "01f997466d8e96cd2bf9119466c66469ba7eaf19c405ac3fd460f97e23dfa966",
   "pins" : [
     {
       "identity" : "mqttcocoaasyncsocket",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "ce3e18607fd01079495f86ff6195d8a3ca469f73",
         "version" : "1.0.8"
-      }
-    },
-    {
-      "identity" : "starscream",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/daltoniam/Starscream.git",
-      "state" : {
-        "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
-        "version" : "4.0.8"
       }
     }
   ],

--- a/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTWebSocketAuthenticationTests.swift
@@ -171,6 +171,16 @@ final class CocoaMQTTWebSocketAuthenticationTests: XCTestCase {
         }
     }
 
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+    func testDefaultBuilderUsesURLSessionWebSocketTransport() throws {
+        let connection = try CocoaMQTTWebSocket.DefaultConnectionBuilder().buildConnection(
+            forURL: try XCTUnwrap(URL(string: "wss://broker.example.com/mqtt")),
+            withHeaders: [:]
+        )
+
+        XCTAssertTrue(connection is CocoaMQTTWebSocket.FoundationConnection)
+    }
+
     func testSecureConnectForwardsCustomAuthorizerHeaders() throws {
         let builder = BuilderSpy()
         let websocket = CocoaMQTTWebSocket(uri: "/mqtt", builder: builder)

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "79a54671afdc862e41038a32b382d98dcc71a6104e7e918f9b6dd1146cf23da9",
+  "originHash" : "c66e096c5d7cf6ada1928002b025c19dce5ca8654a070c11590d23da849b0245",
   "pins" : [
     {
       "identity" : "mqttcocoaasyncsocket",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "ce3e18607fd01079495f86ff6195d8a3ca469f73",
         "version" : "1.0.8"
-      }
-    },
-    {
-      "identity" : "starscream",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/daltoniam/Starscream.git",
-      "state" : {
-        "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
-        "version" : "4.0.8"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -8,15 +8,6 @@
         "revision" : "ce3e18607fd01079495f86ff6195d8a3ca469f73",
         "version" : "1.0.8"
       }
-    },
-    {
-      "identity" : "starscream",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/daltoniam/Starscream.git",
-      "state" : {
-        "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
-        "version" : "4.0.8"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,6 @@ let package = Package(
         .library(name: "CocoaMQTTWebSocket", targets: ["CocoaMQTTWebSocket"])
     ],
     dependencies: [
-        // Allow Starscream 4.x and 5.x to avoid version conflicts in client apps
-        .package(url: "https://github.com/daltoniam/Starscream.git", "4.0.8"..<"6.0.0"),
         .package(url: "https://github.com/leeway1208/MqttCocoaAsyncSocket", from: "1.0.8"),
     ],
     targets: [
@@ -33,7 +31,7 @@ let package = Package(
         ),
         .target(
             name: "CocoaMQTTWebSocket",
-            dependencies: ["CocoaMQTT", "Starscream"],
+            dependencies: ["CocoaMQTT"],
             path: "Source/WebSocket",
             swiftSettings: [.define("IS_SWIFT_PACKAGE")]
         ),

--- a/README.md
+++ b/README.md
@@ -226,15 +226,18 @@ visionOS 1 and later.
 
 ### Migration from the Starscream fallback
 
-The next major release removes the Starscream dependency and the public
+CocoaMQTT 3 removes the Starscream dependency and the public
 `CocoaMQTTWebSocket.StarscreamConnection` adapter. Applications using
 `CocoaMQTTWebSocket` must raise their deployment target to the versions above,
 or guard its use with an availability check and provide another path on older
-systems. Applications that referenced Starscream APIs directly must add
-Starscream as their own dependency or migrate to
-`URLSessionWebSocketTask`. The public
-`CocoaMQTTWebSocketConnectionBuilder` extension point remains available for
-custom transports.
+systems.
+
+Adding Starscream as an application dependency does not restore the removed
+adapter. Applications must migrate to `URLSessionWebSocketTask`, remain on
+CocoaMQTT 2 when older OS support is required, or provide their own
+`CocoaMQTTWebSocketConnection` and `CocoaMQTTWebSocketConnectionBuilder`
+implementation. Applications that use Starscream directly for unrelated
+connections must declare it as their own dependency.
 
 If you integrated by **Swift Package Manager**, follow these steps:
 

--- a/README.md
+++ b/README.md
@@ -420,8 +420,6 @@ These third-party functions are used:
 
 ~~[GCDAsyncSocket](https://github.com/robbiehanson/CocoaAsyncSocket)~~
 * [MqttCocoaAsyncSocket](https://github.com/leeway1208/MqttCocoaAsyncSocket)
-* [Starscream](https://github.com/daltoniam/Starscream) (legacy WebSocket
-  fallback for older Apple OS versions)
 
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ are covered by a Swift 6 compatibility check in CI.
 
 Build with Xcode 11.1 / Swift 5.1
 
-IOS Target: 12.0 or above
-OSX Target: 10.13 or above
-TVOS Target: 12.0 or above with Swift Package Manager or CocoaPods WebSockets;
-10.0 or above with CocoaPods Core
+Core: iOS 12.0, macOS 10.13, and tvOS 12.0 or above with Swift Package
+Manager; tvOS 10.0 or above with CocoaPods Core
+WebSocket: iOS 13.0, macOS 10.15, and tvOS 13.0 or above
 visionOS Target: 1.0 or above (Swift Package Manager only, compile-verified in CI)
 
 ##  xcode 14.3 issue:
@@ -43,7 +42,10 @@ To integrate CocoaMQTT into your Xcode project using [Swift Package Manager](htt
 
 Swift Package Manager supports iOS, macOS, tvOS, and visionOS. Both the
 `CocoaMQTT` and `CocoaMQTTWebSocket` products are compile-verified against the
-visionOS SDK in CI.
+visionOS SDK in CI. Because Swift Package Manager platform declarations apply
+to the package rather than an individual product, availability annotations
+enforce the higher minimum OS versions when using `CocoaMQTTWebSocket`; the
+core `CocoaMQTT` product retains its existing minimum versions.
 
 At last, import "CocoaMQTT" to your project:
 
@@ -167,11 +169,9 @@ a trust callback or custom CA certificates rejects the connection.
 For TCP, create `CocoaMQTT` or `CocoaMQTT5` normally. For WSS, use the
 [MQTT 3.1.1 WebSocket client](Example/Example/MutualTLSConfiguration.swift#L35-L47)
 or [MQTT 5 WebSocket client](Example/Example/MutualTLSConfiguration.swift#L52-L64)
-example. `CocoaMQTTWebSocket` automatically uses Apple's
-`URLSessionWebSocketTask` on macOS 10.15, iOS 13, tvOS 13, visionOS 1, and
-later; no transport selection is required. Older supported OS versions
-automatically fall back to Starscream, where `clientIdentity` does not
-participate in the TLS handshake. Before calling `connect()`, apply either the
+example. `CocoaMQTTWebSocket` uses Apple's `URLSessionWebSocketTask` on macOS
+10.15, iOS 13, tvOS 13, visionOS 1, and later. Before calling `connect()`,
+apply either the
 [PEM/DER configuration](Example/Example/MutualTLSConfiguration.swift#L70-L93)
 or [PKCS#12 configuration](Example/Example/MutualTLSConfiguration.swift#L99-L118).
 Both configuration functions work with MQTT 3.1.1 and MQTT 5 over TCP or
@@ -189,9 +189,8 @@ the leaf bundle; duplicates and a repeated leaf are ignored. Pass the leaf
 issuer first and normally exclude the root. It is independent from
 `trustedServerCertificates`, which validates the broker. The PEM/DER importer
 requires macOS 10.14, iOS 12, tvOS 12, or visionOS 1. This API applies to the
-built-in TCP transport and the Apple `URLSessionWebSocketTask` transport. The
-older Starscream WebSocket fallback does not support client identities. Custom
-transports can opt in by conforming to
+built-in TCP transport and the Apple `URLSessionWebSocketTask` transport.
+Custom transports can opt in by conforming to
 `CocoaMQTTClientIdentityConfiguring`.
 
 `URLSessionWebSocketTask` client identities are scoped to the original
@@ -221,6 +220,21 @@ eligibility; use supported Security framework APIs and protect the private key.
 ## MQTT over WebSocket
 
 CocoaMQTT supports connecting to MQTT brokers over WebSocket.
+The built-in implementation uses Apple Foundation's
+`URLSessionWebSocketTask` and requires iOS 13, macOS 10.15, tvOS 13, or
+visionOS 1 and later.
+
+### Migration from the Starscream fallback
+
+The next major release removes the Starscream dependency and the public
+`CocoaMQTTWebSocket.StarscreamConnection` adapter. Applications using
+`CocoaMQTTWebSocket` must raise their deployment target to the versions above,
+or guard its use with an availability check and provide another path on older
+systems. Applications that referenced Starscream APIs directly must add
+Starscream as their own dependency or migrate to
+`URLSessionWebSocketTask`. The public
+`CocoaMQTTWebSocketConnectionBuilder` extension point remains available for
+custom transports.
 
 If you integrated by **Swift Package Manager**, follow these steps:
 
@@ -290,10 +304,9 @@ let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
 websocket.maximumMessageSize = 10 * 1024 * 1024 + 1 // Accept up to 10 MiB.
 ```
 
-This setting is independent of MQTT 5 Maximum Packet Size. It is not used by
-the older Starscream fallback, and custom connection builders must configure
-their own transport. Use `0` only when message sizes are otherwise controlled,
-because it permits unbounded buffering.
+This setting is independent of MQTT 5 Maximum Packet Size. Custom connection
+builders must configure their own transport. Use `0` only when message sizes
+are otherwise controlled, because it permits unbounded buffering.
 
 If you want to add additional custom header to the connection, you can use the following:
 

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -350,11 +350,9 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Client identity sent by transports that support mutual TLS.
     ///
-    /// The built-in TCP socket supports this capability. On modern Apple OS
-    /// versions, the default WebSocket transport uses `URLSessionWebSocketTask`
-    /// and also supports it. The Starscream fallback used on older OS versions
-    /// does not apply this identity. Custom transports may opt in by conforming
-    /// to `CocoaMQTTClientIdentityConfiguring`.
+    /// The built-in TCP socket and `URLSessionWebSocketTask` transport support
+    /// this capability. Custom transports may opt in by conforming to
+    /// `CocoaMQTTClientIdentityConfiguring`.
     public var clientIdentity: CocoaMQTTClientIdentity? {
         get { return (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity }
         set { (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity = newValue }

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -384,11 +384,9 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Client identity sent by transports that support mutual TLS.
     ///
-    /// The built-in TCP socket supports this capability. On modern Apple OS
-    /// versions, the default WebSocket transport uses `URLSessionWebSocketTask`
-    /// and also supports it. The Starscream fallback used on older OS versions
-    /// does not apply this identity. Custom transports may opt in by conforming
-    /// to `CocoaMQTTClientIdentityConfiguring`.
+    /// The built-in TCP socket and `URLSessionWebSocketTask` transport support
+    /// this capability. Custom transports may opt in by conforming to
+    /// `CocoaMQTTClientIdentityConfiguring`.
     public var clientIdentity: CocoaMQTTClientIdentity? {
         get { return (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity }
         set { (self.socket as? CocoaMQTTClientIdentityConfiguring)?.clientIdentity = newValue }

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Starscream
 #if IS_SWIFT_PACKAGE
 import CocoaMQTT
 #endif
@@ -113,15 +112,9 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
         public init() {}
 
         public func buildConnection(forURL url: URL, withHeaders headers: [String: String]) throws -> CocoaMQTTWebSocketConnection {
-            if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-                let config = URLSessionConfiguration.default
-                config.httpAdditionalHeaders = headers
-                return CocoaMQTTWebSocket.FoundationConnection(url: url, config: config)
-            } else {
-                var request = URLRequest(url: url)
-                headers.forEach { request.setValue($1, forHTTPHeaderField: $0)}
-                return CocoaMQTTWebSocket.StarscreamConnection(request: request)
-            }
+            let config = URLSessionConfiguration.default
+            config.httpAdditionalHeaders = headers
+            return CocoaMQTTWebSocket.FoundationConnection(url: url, config: config)
         }
     }
 
@@ -521,100 +514,6 @@ extension CocoaMQTTWebSocket.FoundationConnection: URLSessionWebSocketDelegate {
         queue.async {
             self.delegate?.connectionClosed(self, withError: CocoaMQTTError.FoundationConnection.closed(closeCode), withCode: nil)
         }
-    }
-}
-
-// MARK: - CocoaMQTTWebSocket.StarscreamConnection
-
-public extension CocoaMQTTWebSocket {
-    class StarscreamConnection: NSObject, CocoaMQTTWebSocketConnection {
-        public var reference: WebSocket
-        public weak var delegate: CocoaMQTTWebSocketConnectionDelegate?
-        public var queue: DispatchQueue {
-            get { reference.callbackQueue }
-            set { reference.callbackQueue = newValue }
-        }
-
-        public init(request: URLRequest) {
-            reference = WebSocket(request: request)
-            super.init()
-            reference.delegate = self
-        }
-
-        public func connect() {
-            reference.connect()
-        }
-
-        public func disconnect() {
-            reference.disconnect()
-        }
-
-        public func write(data: Data, handler: @escaping (Error?) -> Void) {
-            reference.write(data: data) {
-                handler(nil)
-            }
-        }
-    }
-}
-
-extension CocoaMQTTWebSocket.StarscreamConnection: CertificatePinning {
-    public func evaluateTrust(trust: SecTrust, domain: String?, completion: ((PinningState) -> Void)) {
-        var result: SecTrustResultType = .unspecified
-        SecTrustEvaluate(trust, &result)
-        let e = CFErrorCreate(kCFAllocatorDefault, "FoundationSecurityError" as NSString?, Int(result.rawValue), nil)
-        guard let delegate = self.delegate else {
-            return completion(.failed(e))
-        }
-
-        var shouldAccept = false
-        let semaphore = DispatchSemaphore(value: 0)
-        delegate.connection(self, didReceive: trust) { result in
-            shouldAccept = result
-            semaphore.signal()
-        }
-        semaphore.wait()
-
-        if shouldAccept {
-            completion(.success)
-        } else {
-            completion(.failed(e))
-        }
-    }
-}
-
-extension CocoaMQTTWebSocket.StarscreamConnection: WebSocketDelegate {
-    public func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocketClient) {
-        switch event {
-        case .connected:
-            delegate?.connectionOpened(self)
-        case .disconnected(_, let code):
-            delegate?.connectionClosed(self, withError: nil, withCode: code)
-        case .text(let string):
-            delegate?.connection(self, receivedString: string)
-        case .binary(let data):
-            delegate?.connection(self, receivedData: data)
-        case .ping:
-            break
-        case .pong:
-            break
-        case .viabilityChanged:
-            break
-        case .reconnectSuggested:
-            break
-        case .cancelled:
-            delegate?.connectionClosed(self, withError: nil, withCode: nil)
-        case .error(let error):
-            delegate?.connectionClosed(self, withError: error, withCode: nil)
-        default:
-            break
-        }
-    }
-
-    // Backward-compatible overload for Starscream 4.x where the delegate used `client: WebSocket`.
-    // Keeping this method allows the same source to compile against both 4.x and 5.x.
-    public func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocket) {
-        // Forward to the WebSocketClient-based handler to avoid duplicate logic
-        self.didReceive(event: event, client: client as Starscream.WebSocketClient)
     }
 }
 

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -52,6 +52,7 @@ private protocol CocoaMQTTWebSocketMessageSizeConfiguring: AnyObject {
 
 // MARK: - CocoaMQTTWebSocket
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
     CocoaMQTTClientIdentityConfiguring,
     CocoaMQTTServerTrustConfiguring {
@@ -80,10 +81,8 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
     public var manuallyEvaluateTrust = false
 
     /// Client identity sent during the TLS handshake by the built-in Apple
-    /// `URLSessionWebSocketTask` transport, selected automatically on macOS
-    /// 10.15, iOS 13, tvOS 13, visionOS 1, and later. The Starscream fallback
-    /// used on older OS versions does not apply this identity. Custom
-    /// connection builders may opt in by returning a
+    /// `URLSessionWebSocketTask` transport. Custom connection builders may opt
+    /// in by returning a
     /// `CocoaMQTTClientIdentityConfiguring` connection. Set this before
     /// connecting. The built-in transport sends it only to the original
     /// WebSocket host and port.
@@ -93,8 +92,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
     /// `URLSessionWebSocketTask` transport. A message must be smaller than this
     /// value. The default is 1 MiB, zero removes the limit, and negative values
     /// reset to the default. Set this before connecting; custom builders must
-    /// configure their own transports. The older Starscream fallback does not
-    /// use this setting.
+    /// configure their own transports.
     /// Use zero only when the peer and message sizes are otherwise controlled,
     /// because it permits unbounded message buffering.
     public var maximumMessageSize = CocoaMQTTWebSocket.foundationDefaultMaximumMessageSize {
@@ -331,6 +329,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension CocoaMQTTWebSocket: CocoaMQTTWebSocketConnectionDelegate {
     public func urlSessionConnection(_ conn: CocoaMQTTWebSocketConnection, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         guard let delegate = delegate else {
@@ -519,6 +518,7 @@ extension CocoaMQTTWebSocket.FoundationConnection: URLSessionWebSocketDelegate {
 
 // MARK: - Helper
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension CocoaMQTTWebSocket {
 
     func __delegate_queue(_ fun: @escaping () -> Void) {

--- a/Tests/Swift6Compatibility/Sources/Swift6Compatibility/main.swift
+++ b/Tests/Swift6Compatibility/Sources/Swift6Compatibility/main.swift
@@ -5,12 +5,15 @@ let coreClient = CocoaMQTT(
     clientID: "swift-6-core",
     host: "localhost"
 )
-let webSocketClient = CocoaMQTT5(
-    clientID: "swift-6-websocket",
-    host: "localhost",
-    port: 8083,
-    socket: CocoaMQTTWebSocket(uri: "/mqtt")
-)
 
 precondition(coreClient.clientID == "swift-6-core")
-precondition(webSocketClient.clientID == "swift-6-websocket")
+
+if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+    let webSocketClient = CocoaMQTT5(
+        clientID: "swift-6-websocket",
+        host: "localhost",
+        port: 8083,
+        socket: CocoaMQTTWebSocket(uri: "/mqtt")
+    )
+    precondition(webSocketClient.clientID == "swift-6-websocket")
+}


### PR DESCRIPTION
## Summary

- remove Starscream from SwiftPM, CocoaPods, Xcode project references, and lockfiles
- make `URLSessionWebSocketTask` the sole built-in WebSocket transport while retaining `CocoaMQTTWebSocketConnectionBuilder`
- keep Core deployment targets unchanged and enforce the WebSocket OS floor through API availability and the CocoaPods WebSockets subspec
- document the CocoaMQTT 3 breaking migration and update consumer/transport regression coverage

## Community attribution

This PR cherry-picks the original removal commit `02252f0c` from #456. Git authorship and the original author date are preserved in commit `5107aeb`, crediting Philipp Arndt. The later commits from that historical PR targeted an older concurrency architecture and were intentionally not reused.

## Compatibility

This is a breaking change for CocoaMQTT 3:

- the public `CocoaMQTTWebSocket.StarscreamConnection` adapter is removed
- built-in WebSocket use requires iOS 13, macOS 10.15, tvOS 13, or visionOS 1
- Core retains its existing deployment targets
- custom connection builders remain supported
- adding Starscream alone does not restore the removed adapter; the README documents migration, staying on CocoaMQTT 2, and custom-transport options

watchOS was evaluated but is not declared as a supported package platform: the current MqttCocoaAsyncSocket dependency does not compile for watchOS because it uses unavailable NSNetService and CFNetwork APIs.

Closes #731

## Verification

- `swift test --skip CocoaMQTTTests.CocoaMQTTTests` (305 tests, 1 environment-gated skip, 0 failures)
- `swift test --filter CocoaMQTTWebSocketAuthenticationTests`
- Swift 6 compatibility consumer
- iOS Example compile check
- macOS Xcode framework build
- visionOS Core and WebSocket cross-compiles
- `pod lib lint CocoaMQTT.podspec --allow-warnings --skip-tests --platforms=ios,macos`

The all-platform local pod lint reached tvOS but could not run because this machine has no tvOS Simulator; CI covers the full CocoaPods matrix.