### PR TITLE
Prepare CocoaMQTT 2.4.0 LTS release

### DIFF
--- a/.github/api-breakage-allowlist-2.3.txt
+++ b/.github/api-breakage-allowlist-2.3.txt
@@ -1,0 +1,1 @@
+API breakage: typealias ThreadSafeDictionary.Iterator has underlying type change from Swift.IndexingIterator<CocoaMQTT.ThreadSafeDictionary<K, V>> to Swift.Dictionary<K, V>.Iterator

--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "Source/**/*.swift"
+      - "Source/Info.plist"
       - "Source/PrivacyInfo.xcprivacy"
       - "CocoaMQTTTests/**/*.swift"
       - "Package.swift"
@@ -11,6 +12,7 @@ on:
       - "CocoaMQTT.podspec"
       - "CocoaMQTT.xcodeproj/project.pbxproj"
       - "CocoaMQTT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+      - ".github/api-breakage-allowlist-2.3.txt"
       - ".github/workflows/distribution-check.yml"
   push:
     tags:
@@ -25,6 +27,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  api-compatibility:
+    name: CocoaMQTT 2.3 API Compatibility
+    runs-on: macos-15
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Diagnose API-breaking changes
+        run: |
+          swift package diagnose-api-breaking-changes 2.3.0 \
+            --products CocoaMQTT CocoaMQTTWebSocket \
+            --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt
+
+      - name: Preserve the pull request base API
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          swift package diagnose-api-breaking-changes "${BASE_SHA}" \
+            --products CocoaMQTT CocoaMQTTWebSocket
+
   tag-version-check:
     name: Tag Version Guard
     if: startsWith(github.ref, 'refs/tags/')
@@ -34,32 +61,45 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Verify pushed tag matches CocoaMQTT.podspec version
+      - name: Verify release version and branch
         run: |
           set -euo pipefail
 
           VERSION="$(ruby -ne 'puts $1 if /s\.version\s*=\s*"([^"]+)"/' CocoaMQTT.podspec)"
           SOURCE_TAG="$(ruby -ne 'puts $1 if /:tag\s*=>\s*"([^"]+)"/' CocoaMQTT.podspec)"
+          FRAMEWORK_VERSION="$(
+            python3 -c 'import plistlib; print(plistlib.load(open("Source/Info.plist", "rb"))["CFBundleShortVersionString"])'
+          )"
 
-          if [ -z "${VERSION}" ] || [ -z "${SOURCE_TAG}" ]; then
-            echo "Failed to parse version or source tag from CocoaMQTT.podspec"
+          if [ -z "${VERSION}" ] || [ -z "${SOURCE_TAG}" ] || [ -z "${FRAMEWORK_VERSION}" ]; then
+            echo "Failed to parse release version metadata"
             exit 1
           fi
 
-          if [ "${VERSION}" != "${SOURCE_TAG}" ]; then
-            echo "podspec version (${VERSION}) must match source tag (${SOURCE_TAG})"
+          if [ "${VERSION}" != "${SOURCE_TAG}" ] || [ "${VERSION}" != "${FRAMEWORK_VERSION}" ]; then
+            echo "Release versions must match: podspec=${VERSION}, source=${SOURCE_TAG}, framework=${FRAMEWORK_VERSION}"
             exit 1
           fi
 
           TAG_NAME="${GITHUB_REF#refs/tags/}"
-          TAG_VERSION="${TAG_NAME#v}"
-          if [ "${TAG_VERSION}" != "${VERSION}" ]; then
-            echo "Git tag (${TAG_NAME}) must match podspec version (${VERSION})"
+          if [ "${TAG_NAME}" != "${SOURCE_TAG}" ]; then
+            echo "Git tag (${TAG_NAME}) must exactly match podspec source tag (${SOURCE_TAG})"
             exit 1
           fi
 
-          echo "Tag/version guard passed: tag=${TAG_NAME}, podspec=${VERSION}"
+          if [[ "${VERSION}" == 2.* ]]; then
+            git fetch origin release/2.x
+            TAG_COMMIT="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+            if ! git merge-base --is-ancestor "${TAG_COMMIT}" origin/release/2.x; then
+              echo "CocoaMQTT 2.x tag must point to a commit on release/2.x"
+              exit 1
+            fi
+          fi
+
+          echo "Release guard passed: tag=${TAG_NAME}, version=${VERSION}"
 
   spm-smoke:
     name: SPM Release Smoke
@@ -210,20 +250,23 @@ jobs:
       - name: Install CocoaPods
         run: gem install cocoapods --no-document
 
-      - name: Verify podspec version and source tag
+      - name: Verify release version metadata
         run: |
           set -euo pipefail
 
           VERSION="$(ruby -ne 'puts $1 if /s\.version\s*=\s*"([^"]+)"/' CocoaMQTT.podspec)"
           SOURCE_TAG="$(ruby -ne 'puts $1 if /:tag\s*=>\s*"([^"]+)"/' CocoaMQTT.podspec)"
+          FRAMEWORK_VERSION="$(
+            python3 -c 'import plistlib; print(plistlib.load(open("Source/Info.plist", "rb"))["CFBundleShortVersionString"])'
+          )"
 
-          if [ -z "${VERSION}" ] || [ -z "${SOURCE_TAG}" ]; then
-            echo "Failed to parse CocoaMQTT.podspec version or source tag"
+          if [ -z "${VERSION}" ] || [ -z "${SOURCE_TAG}" ] || [ -z "${FRAMEWORK_VERSION}" ]; then
+            echo "Failed to parse release version metadata"
             exit 1
           fi
 
-          if [ "${VERSION}" != "${SOURCE_TAG}" ]; then
-            echo "podspec version (${VERSION}) must match source tag (${SOURCE_TAG})"
+          if [ "${VERSION}" != "${SOURCE_TAG}" ] || [ "${VERSION}" != "${FRAMEWORK_VERSION}" ]; then
+            echo "Release versions must match: podspec=${VERSION}, source=${SOURCE_TAG}, framework=${FRAMEWORK_VERSION}"
             exit 1
           fi
 

--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -12,7 +12,6 @@ on:
       - "CocoaMQTT.podspec"
       - "CocoaMQTT.xcodeproj/project.pbxproj"
       - "CocoaMQTT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
-      - ".github/api-breakage-allowlist-2.3.txt"
       - ".github/workflows/distribution-check.yml"
   push:
     tags:
@@ -27,31 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  api-compatibility:
-    name: CocoaMQTT 2.3 API Compatibility
-    runs-on: macos-15
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Diagnose API-breaking changes
-        run: |
-          swift package diagnose-api-breaking-changes 2.3.0 \
-            --products CocoaMQTT CocoaMQTTWebSocket \
-            --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt
-
-      - name: Preserve the pull request base API
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          swift package diagnose-api-breaking-changes "${BASE_SHA}" \
-            --products CocoaMQTT CocoaMQTTWebSocket
-
   tag-version-check:
     name: Tag Version Guard
     if: startsWith(github.ref, 'refs/tags/')
@@ -91,7 +65,9 @@ jobs:
           fi
 
           if [[ "${VERSION}" == 2.* ]]; then
-            git fetch origin release/2.x
+            git fetch origin \
+              release/2.x:refs/remotes/origin/release/2.x \
+              --force
             TAG_COMMIT="$(git rev-parse "${GITHUB_SHA}^{commit}")"
             if ! git merge-base --is-ancestor "${TAG_COMMIT}" origin/release/2.x; then
               echo "CocoaMQTT 2.x tag must point to a commit on release/2.x"

--- a/.github/workflows/lts-compatibility.yml
+++ b/.github/workflows/lts-compatibility.yml
@@ -1,0 +1,40 @@
+name: LTS Compatibility
+
+on:
+  pull_request:
+    branches:
+      - release/2.x
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  api-compatibility:
+    name: LTS API Compatibility
+    runs-on: macos-15
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Preserve the CocoaMQTT 2.3 public API
+        run: |
+          swift package diagnose-api-breaking-changes 2.3.0 \
+            --products CocoaMQTT CocoaMQTTWebSocket \
+            --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt
+
+      - name: Preserve the pull request base API
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          swift package diagnose-api-breaking-changes "${BASE_SHA}" \
+            --products CocoaMQTT CocoaMQTTWebSocket

--- a/.github/workflows/lts-compatibility.yml
+++ b/.github/workflows/lts-compatibility.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - release/2.x
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-2.x.yml
+++ b/.github/workflows/release-2.x.yml
@@ -1,12 +1,9 @@
 name: Release CocoaMQTT 2.x
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Stable 2.x version to release, for example 2.4.0
-        required: true
-        type: string
+  push:
+    branches:
+      - release/2.x
 
 permissions:
   contents: read
@@ -16,13 +13,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  package-validation:
-    name: Validate 2.x Package
-    runs-on: macos-15
-    timeout-minutes: 35
-
-    env:
-      VERSION: ${{ inputs.version }}
+  prepare_release:
+    name: Prepare 2.x release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_release: ${{ steps.release.outputs.should_release }}
+      version: ${{ steps.release.outputs.version }}
 
     steps:
       - name: Checkout release commit
@@ -30,20 +27,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify release branch, version, and tag availability
-        env:
-          RELEASE_REF: ${{ github.ref }}
+      - name: Verify release metadata and tag state
+        id: release
         run: |
           set -euo pipefail
-
-          if [ "${RELEASE_REF}" != "refs/heads/release/2.x" ]; then
-            echo "This workflow must run from release/2.x"
-            exit 1
-          fi
-          if [[ ! "${VERSION}" =~ ^2\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Version must be a stable semantic 2.x version"
-            exit 1
-          fi
 
           git fetch origin \
             release/2.x:refs/remotes/origin/release/2.x \
@@ -53,22 +40,57 @@ jobs:
             exit 1
           fi
 
-          POD_VERSION="$(ruby -ne 'puts $1 if /s\.version\s*=\s*"([^"]+)"/' CocoaMQTT.podspec)"
+          VERSION="$(ruby -ne 'puts $1 if /s\.version\s*=\s*"([^"]+)"/' CocoaMQTT.podspec)"
           SOURCE_TAG="$(ruby -ne 'puts $1 if /:tag\s*=>\s*"([^"]+)"/' CocoaMQTT.podspec)"
           FRAMEWORK_VERSION="$(
             python3 -c 'import plistlib; print(plistlib.load(open("Source/Info.plist", "rb"))["CFBundleShortVersionString"])'
           )"
-          if [ "${VERSION}" != "${POD_VERSION}" ] ||
-             [ "${VERSION}" != "${SOURCE_TAG}" ] ||
+          if [[ ! "${VERSION}" =~ ^2\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must be a stable semantic 2.x version"
+            exit 1
+          fi
+          if [ "${VERSION}" != "${SOURCE_TAG}" ] ||
              [ "${VERSION}" != "${FRAMEWORK_VERSION}" ]; then
             echo "Release metadata does not match ${VERSION}"
             exit 1
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
-            echo "Tag ${VERSION} already exists"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          REMOTE_TAG="$(
+            git ls-remote origin "refs/tags/${VERSION}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+          if [ -z "${REMOTE_TAG}" ]; then
+            echo "should_release=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          REMOTE_COMMIT="$(
+            git ls-remote origin "refs/tags/${VERSION}^{}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+          if [ -z "${REMOTE_COMMIT}" ]; then
+            REMOTE_COMMIT="${REMOTE_TAG}"
+          fi
+          if ! git merge-base --is-ancestor "${REMOTE_COMMIT}" HEAD; then
+            echo "Existing tag ${VERSION} is not an ancestor of release/2.x"
             exit 1
           fi
+
+          echo "Tag ${VERSION} already identifies an earlier release/2.x commit; no release is needed"
+          echo "should_release=false" >> "${GITHUB_OUTPUT}"
+
+  package-validation:
+    name: Validate 2.x Package
+    needs: prepare_release
+    if: needs.prepare_release.outputs.should_release == 'true'
+    runs-on: macos-15
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Verify public API compatibility
         run: |
@@ -84,13 +106,14 @@ jobs:
 
   cocoapods-validation:
     name: Validate 2.x CocoaPods
+    needs: prepare_release
+    if: needs.prepare_release.outputs.should_release == 'true'
     runs-on: macos-15
     timeout-minutes: 35
 
     env:
       COCOAPODS_DISABLE_STATS: "true"
       LANG: en_US.UTF-8
-      VERSION: ${{ inputs.version }}
 
     steps:
       - name: Checkout release commit
@@ -103,11 +126,6 @@ jobs:
 
       - name: Install CocoaPods
         run: gem install cocoapods --no-document
-
-      - name: Verify podspec version
-        run: |
-          POD_VERSION="$(ruby -ne 'puts $1 if /s\.version\s*=\s*"([^"]+)"/' CocoaMQTT.podspec)"
-          test "${VERSION}" = "${POD_VERSION}"
 
       - name: Lint CocoaPods subspecs
         run: |
@@ -125,15 +143,17 @@ jobs:
   create-tag:
     name: Create verified 2.x tag
     needs:
+      - prepare_release
       - package-validation
       - cocoapods-validation
+    if: needs.prepare_release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: write
 
     env:
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ needs.prepare_release.outputs.version }}
 
     steps:
       - name: Checkout verified release commit
@@ -145,10 +165,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${GITHUB_REF}" != "refs/heads/release/2.x" ]; then
-            echo "This workflow must run from release/2.x"
-            exit 1
-          fi
           git fetch origin \
             release/2.x:refs/remotes/origin/release/2.x \
             --force

--- a/.github/workflows/release-2.x.yml
+++ b/.github/workflows/release-2.x.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: release-cocoamqtt-2.x
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   prepare_release:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      should_release: ${{ steps.release.outputs.should_release }}
+      should_validate: ${{ steps.release.outputs.should_validate }}
       version: ${{ steps.release.outputs.version }}
       previous_tag: ${{ steps.release.outputs.previous_tag }}
 
@@ -85,7 +85,7 @@ jobs:
               awk 'NR == 1 { print $1 }'
           )"
           if [ -z "${REMOTE_TAG}" ]; then
-            echo "should_release=true" >> "${GITHUB_OUTPUT}"
+            echo "should_validate=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
           REMOTE_COMMIT="$(
@@ -101,12 +101,12 @@ jobs:
           fi
 
           echo "Tag ${VERSION} already identifies an earlier release/2.x commit; no release is needed"
-          echo "should_release=false" >> "${GITHUB_OUTPUT}"
+          echo "should_validate=false" >> "${GITHUB_OUTPUT}"
 
   package-validation:
     name: Validate 2.x Package
     needs: prepare_release
-    if: needs.prepare_release.outputs.should_release == 'true'
+    if: needs.prepare_release.outputs.should_validate == 'true'
     runs-on: macos-15
     timeout-minutes: 35
 
@@ -137,7 +137,7 @@ jobs:
   cocoapods-validation:
     name: Validate 2.x CocoaPods
     needs: prepare_release
-    if: needs.prepare_release.outputs.should_release == 'true'
+    if: needs.prepare_release.outputs.should_validate == 'true'
     runs-on: macos-15
     timeout-minutes: 35
 
@@ -169,3 +169,49 @@ jobs:
             --allow-warnings \
             --skip-tests \
             --fail-fast
+
+  release-readiness:
+    name: 2.x Release Ready
+    needs:
+      - prepare_release
+      - package-validation
+      - cocoapods-validation
+    if: needs.prepare_release.outputs.should_validate == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      VERSION: ${{ needs.prepare_release.outputs.version }}
+
+    steps:
+      - name: Checkout validated release commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Confirm current branch head and report tag target
+        run: |
+          set -euo pipefail
+
+          git fetch origin \
+            release/2.x:refs/remotes/origin/release/2.x \
+            --force
+          VALIDATED_COMMIT="$(git rev-parse HEAD)"
+          CURRENT_HEAD="$(git rev-parse origin/release/2.x)"
+          if [ "${VALIDATED_COMMIT}" != "${CURRENT_HEAD}" ]; then
+            echo "release/2.x advanced while release-readiness checks were running"
+            exit 1
+          fi
+
+          {
+            echo "## CocoaMQTT ${VERSION} is ready to tag"
+            echo
+            echo "Validated commit: \`${VALIDATED_COMMIT}\`"
+            echo
+            echo "Create the annotated tag only for this exact commit:"
+            echo
+            echo "\`\`\`console"
+            echo "git tag --annotate ${VERSION} ${VALIDATED_COMMIT} --message \"CocoaMQTT ${VERSION}\""
+            echo "git push origin refs/tags/${VERSION}"
+            echo "\`\`\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-2.x.yml
+++ b/.github/workflows/release-2.x.yml
@@ -165,3 +165,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag --annotate "${VERSION}" --message "CocoaMQTT ${VERSION}"
           git push origin "refs/tags/${VERSION}"
+
+          REMOTE_COMMIT="$(
+            git ls-remote origin "refs/tags/${VERSION}^{}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+          if [ "${REMOTE_COMMIT}" != "$(git rev-parse HEAD)" ]; then
+            echo "Remote tag ${VERSION} does not resolve to the validated commit"
+            exit 1
+          fi

--- a/.github/workflows/release-2.x.yml
+++ b/.github/workflows/release-2.x.yml
@@ -1,0 +1,167 @@
+name: Release CocoaMQTT 2.x
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable 2.x version to release, for example 2.4.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-cocoamqtt-2.x
+  cancel-in-progress: false
+
+jobs:
+  package-validation:
+    name: Validate 2.x Package
+    runs-on: macos-15
+    timeout-minutes: 35
+
+    env:
+      VERSION: ${{ inputs.version }}
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release branch, version, and tag availability
+        env:
+          RELEASE_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          if [ "${RELEASE_REF}" != "refs/heads/release/2.x" ]; then
+            echo "This workflow must run from release/2.x"
+            exit 1
+          fi
+          if [[ ! "${VERSION}" =~ ^2\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must be a stable semantic 2.x version"
+            exit 1
+          fi
+
+          git fetch origin \
+            release/2.x:refs/remotes/origin/release/2.x \
+            --force
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/release/2.x)" ]; then
+            echo "The checked-out commit is not the current release/2.x head"
+            exit 1
+          fi
+
+          POD_VERSION="$(ruby -ne 'puts $1 if /s\.version\s*=\s*"([^"]+)"/' CocoaMQTT.podspec)"
+          SOURCE_TAG="$(ruby -ne 'puts $1 if /:tag\s*=>\s*"([^"]+)"/' CocoaMQTT.podspec)"
+          FRAMEWORK_VERSION="$(
+            python3 -c 'import plistlib; print(plistlib.load(open("Source/Info.plist", "rb"))["CFBundleShortVersionString"])'
+          )"
+          if [ "${VERSION}" != "${POD_VERSION}" ] ||
+             [ "${VERSION}" != "${SOURCE_TAG}" ] ||
+             [ "${VERSION}" != "${FRAMEWORK_VERSION}" ]; then
+            echo "Release metadata does not match ${VERSION}"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${VERSION} already exists"
+            exit 1
+          fi
+
+      - name: Verify public API compatibility
+        run: |
+          swift package diagnose-api-breaking-changes 2.3.0 \
+            --products CocoaMQTT CocoaMQTTWebSocket \
+            --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt
+
+      - name: Build package
+        run: swift build
+
+      - name: Run deterministic and loopback tests
+        run: swift test --skip CocoaMQTTTests.CocoaMQTTTests
+
+  cocoapods-validation:
+    name: Validate 2.x CocoaPods
+    runs-on: macos-15
+    timeout-minutes: 35
+
+    env:
+      COCOAPODS_DISABLE_STATS: "true"
+      LANG: en_US.UTF-8
+      VERSION: ${{ inputs.version }}
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@19a43a6a2428d455dbd1b85344698725179c9d8c # v1
+        with:
+          ruby-version: "3.2"
+
+      - name: Install CocoaPods
+        run: gem install cocoapods --no-document
+
+      - name: Verify podspec version
+        run: |
+          POD_VERSION="$(ruby -ne 'puts $1 if /s\.version\s*=\s*"([^"]+)"/' CocoaMQTT.podspec)"
+          test "${VERSION}" = "${POD_VERSION}"
+
+      - name: Lint CocoaPods subspecs
+        run: |
+          pod lib lint CocoaMQTT.podspec \
+            --subspec=Core \
+            --allow-warnings \
+            --skip-tests \
+            --fail-fast
+          pod lib lint CocoaMQTT.podspec \
+            --subspec=WebSockets \
+            --allow-warnings \
+            --skip-tests \
+            --fail-fast
+
+  create-tag:
+    name: Create verified 2.x tag
+    needs:
+      - package-validation
+      - cocoapods-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+
+    env:
+      VERSION: ${{ inputs.version }}
+
+    steps:
+      - name: Checkout verified release commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create annotated release tag
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF}" != "refs/heads/release/2.x" ]; then
+            echo "This workflow must run from release/2.x"
+            exit 1
+          fi
+          git fetch origin \
+            release/2.x:refs/remotes/origin/release/2.x \
+            --force
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/release/2.x)" ]; then
+            echo "release/2.x advanced while validation was running"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${VERSION} already exists"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --annotate "${VERSION}" --message "CocoaMQTT ${VERSION}"
+          git push origin "refs/tags/${VERSION}"

--- a/.github/workflows/release-2.x.yml
+++ b/.github/workflows/release-2.x.yml
@@ -1,4 +1,4 @@
-name: Release CocoaMQTT 2.x
+name: Check CocoaMQTT 2.x Release
 
 on:
   push:
@@ -20,6 +20,7 @@ jobs:
     outputs:
       should_release: ${{ steps.release.outputs.should_release }}
       version: ${{ steps.release.outputs.version }}
+      previous_tag: ${{ steps.release.outputs.previous_tag }}
 
     steps:
       - name: Checkout release commit
@@ -55,7 +56,30 @@ jobs:
             exit 1
           fi
 
+          PREVIOUS_TAG="$(
+            git tag --list "2.*" |
+              ruby -rrubygems -e '
+                current = Gem::Version.new(ARGV.fetch(0))
+                versions = STDIN.each_line.each_with_object([]) do |line, result|
+                  tag = line.strip
+                  next unless tag.match?(/\A2\.\d+\.\d+\z/)
+                  version = Gem::Version.new(tag)
+                  result << [version, tag] if version < current
+                end
+                puts versions.max_by(&:first)&.last
+              ' "${VERSION}"
+          )"
+          if [ -z "${PREVIOUS_TAG}" ]; then
+            echo "No earlier stable 2.x tag exists for compatibility validation"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${PREVIOUS_TAG}^{commit}" HEAD; then
+            echo "Previous release tag ${PREVIOUS_TAG} is not an ancestor of release/2.x"
+            exit 1
+          fi
+
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "previous_tag=${PREVIOUS_TAG}" >> "${GITHUB_OUTPUT}"
           REMOTE_TAG="$(
             git ls-remote origin "refs/tags/${VERSION}" |
               awk 'NR == 1 { print $1 }'
@@ -93,10 +117,16 @@ jobs:
           fetch-depth: 0
 
       - name: Verify public API compatibility
+        env:
+          PREVIOUS_TAG: ${{ needs.prepare_release.outputs.previous_tag }}
         run: |
           swift package diagnose-api-breaking-changes 2.3.0 \
             --products CocoaMQTT CocoaMQTTWebSocket \
             --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt
+          if [ "${PREVIOUS_TAG}" != "2.3.0" ]; then
+            swift package diagnose-api-breaking-changes "${PREVIOUS_TAG}" \
+              --products CocoaMQTT CocoaMQTTWebSocket
+          fi
 
       - name: Build package
         run: swift build
@@ -139,54 +169,3 @@ jobs:
             --allow-warnings \
             --skip-tests \
             --fail-fast
-
-  create-tag:
-    name: Create verified 2.x tag
-    needs:
-      - prepare_release
-      - package-validation
-      - cocoapods-validation
-    if: needs.prepare_release.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write
-
-    env:
-      VERSION: ${{ needs.prepare_release.outputs.version }}
-
-    steps:
-      - name: Checkout verified release commit
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create annotated release tag
-        run: |
-          set -euo pipefail
-
-          git fetch origin \
-            release/2.x:refs/remotes/origin/release/2.x \
-            --force
-          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/release/2.x)" ]; then
-            echo "release/2.x advanced while validation was running"
-            exit 1
-          fi
-          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
-            echo "Tag ${VERSION} already exists"
-            exit 1
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag --annotate "${VERSION}" --message "CocoaMQTT ${VERSION}"
-          git push origin "refs/tags/${VERSION}"
-
-          REMOTE_COMMIT="$(
-            git ls-remote origin "refs/tags/${VERSION}^{}" |
-              awk 'NR == 1 { print $1 }'
-          )"
-          if [ "${REMOTE_COMMIT}" != "$(git rev-parse HEAD)" ]; then
-            echo "Remote tag ${VERSION} does not resolve to the validated commit"
-            exit 1
-          fi

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - release/2.x
     paths:
       - "Source/**/*.swift"
       - "CocoaMQTTTests/**/*.swift"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@ Compatibility note:
   type inference or the `Sequence` APIs. `for-in` and `map` use snapshot
   iteration. Index-based Collection access is not safe across concurrent
   mutations; use `snapshot()` for multi-step indexed access.
-- `ConcurrentAtomic.mutate` remains source-compatible but is now synchronous.
-  It returns only after applying the mutation. Its closure must not re-enter the
-  same wrapper. Use the new `withMutation` API when the transform needs to
-  return a value.
+- `ConcurrentAtomic` property assignment and `mutate` remain source-compatible
+  but now execute synchronously. They return only after applying the mutation,
+  so code must not rely on the former fire-and-forget ordering. A mutation
+  closure must not read from or write to the same wrapper because that would
+  re-enter its synchronization barrier. Use the new `withMutation` API when the
+  transform needs to return a value.
 - Deprecated decoder overloads without a `protocolVersion` now assume MQTT 5
   packet data. Use the explicit overload when decoding MQTT 3.1.1 data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 2.4.0
+
+CocoaMQTT 2.4.0 is the stable, long-term-maintenance baseline for the 2.x
+architecture. It preserves CocoaAsyncSocket and the Starscream fallback while
+collecting the correctness and compatibility work completed after 2.3.0.
+
+Highlights:
+
+- hardened MQTT 3.1.1 and MQTT 5 reconnect, session, QoS, keepalive, and
+  graceful-disconnect lifecycles;
+- fixed concurrent publish, callback, delivery, and connection-state races;
+- added configurable packet-read, socket-write, and WebSocket message limits;
+- unified TCP and Foundation WebSocket server trust configuration;
+- added PEM/DER and PKCS#12 client identities, including mutual TLS over TCP and
+  Foundation WebSockets;
+- added Swift 6 consumer checks and visionOS compile verification;
+- retained legacy decoder and `ConcurrentAtomic.mutate` entry points needed by
+  2.3 source consumers.
+
+Compatibility note:
+
+- `ThreadSafeDictionary.Iterator` now iterates over a stable dictionary snapshot
+  instead of indexing the live mutable dictionary. Code that explicitly names
+  the old concrete `IndexingIterator<ThreadSafeDictionary<...>>` type must use
+  type inference or the `Sequence` APIs. `for-in` and `map` use snapshot
+  iteration. Index-based Collection access is not safe across concurrent
+  mutations; use `snapshot()` for multi-step indexed access.
+- `ConcurrentAtomic.mutate` remains source-compatible but is now synchronous.
+  It returns only after applying the mutation. Its closure must not re-enter the
+  same wrapper. Use the new `withMutation` API when the transform needs to
+  return a value.
+- Deprecated decoder overloads without a `protocolVersion` now assume MQTT 5
+  packet data. Use the explicit overload when decoding MQTT 3.1.1 data.

--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "CocoaMQTT"
-  s.version     = "2.3.0"
+  s.version     = "2.4.0"
   s.summary     = "MQTT v3.1.1 client library for iOS and OS X written with Swift 5"
   s.homepage    = "https://github.com/emqx/CocoaMQTT"
   s.license     = { :type => "MIT" }
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "12.0"
   s.tvos.deployment_target = "10.0"
   # s.watchos.deployment_target = "2.0"
-  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.3.0"}
+  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.4.0"}
   s.default_subspec = 'Core'
   
   s.subspec 'Core' do |ss|

--- a/CocoaMQTTTests/ConcurrentAtomicTests.swift
+++ b/CocoaMQTTTests/ConcurrentAtomicTests.swift
@@ -2,6 +2,10 @@ import XCTest
 @testable import CocoaMQTT
 
 final class ConcurrentAtomicTests: XCTestCase {
+    private enum MutationError: Error, Equatable {
+        case expected
+    }
+
     @ConcurrentAtomic var value: Int = 1
 
     func testSetSync() {
@@ -22,6 +26,31 @@ final class ConcurrentAtomicTests: XCTestCase {
         }
 
         XCTAssertEqual(result, 20)
+        XCTAssertEqual(value, 20)
+    }
+
+    @available(*, deprecated, message: "Exercises the CocoaMQTT 2.3 compatibility overload")
+    func testResultReturningMutateCompatibilityOverload() {
+        value = 1
+        let result = $value.mutate { value -> Int in
+            value *= 20
+            return value
+        }
+
+        XCTAssertEqual(result, 20)
+        XCTAssertEqual(value, 20)
+    }
+
+    @available(*, deprecated, message: "Exercises the CocoaMQTT 2.3 compatibility overload")
+    func testThrowingMutateCompatibilityOverload() {
+        value = 1
+
+        XCTAssertThrowsError(try $value.mutate { value -> Int in
+            value = 20
+            throw MutationError.expected
+        }) { error in
+            XCTAssertEqual(error as? MutationError, .expected)
+        }
         XCTAssertEqual(value, 20)
     }
 

--- a/CocoaMQTTTests/ConcurrentAtomicTests.swift
+++ b/CocoaMQTTTests/ConcurrentAtomicTests.swift
@@ -14,9 +14,9 @@ final class ConcurrentAtomicTests: XCTestCase {
         XCTAssertEqual(value, 10)
     }
 
-    func testMutateReturnsAfterApplyingTransform() {
+    func testWithMutationReturnsAfterApplyingTransform() {
         value = 1
-        let result = $value.mutate { value in
+        let result = $value.withMutation { value in
             value *= 20
             return value
         }

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,48 @@
+# CocoaMQTT 2.x maintenance policy
+
+`release/2.x` is the long-term maintenance line for CocoaMQTT 2. Its first
+release is 2.4.0, based on commit
+`c09666c86084212736d68fa7c652d20ed4753c4c`, the final `master` commit before
+the CocoaMQTT 3 transport architecture changes.
+
+## Scope
+
+The 2.x line accepts:
+
+- security and protocol-correctness fixes;
+- regressions and high-impact bug fixes;
+- compatibility fixes for supported Apple platforms, Swift, Swift Package
+  Manager, and CocoaPods;
+- documentation and test improvements needed to support those fixes.
+
+The 2.x line does not accept new transport architecture, dependency migrations,
+minimum-platform increases, or broad new features. CocoaAsyncSocket remains the
+TCP transport, and Starscream remains the fallback WebSocket transport on older
+supported Apple operating systems.
+
+Applicable fixes developed on `master` should be reviewed and cherry-picked
+into `release/2.x`; the branches must not be merged wholesale.
+
+## Compatibility
+
+Patch releases in this line preserve the 2.4 public API and supported platform
+matrix. CI builds both package products, validates CocoaPods, and checks the
+public API against both 2.3.0 and the pull request base commit.
+
+`ThreadSafeDictionary.Iterator` intentionally changed from an index-based live
+iterator to a dictionary snapshot iterator. Restoring the old concrete iterator
+would reintroduce invalid-index crashes during concurrent mutation. The type
+continues to conform to `Collection`, while ordinary iteration uses a stable
+snapshot. Index-based Collection access is not safe across mutations; use
+`snapshot()` for multi-step indexed access.
+
+The deprecated decoder overloads without an explicit protocol version assume
+MQTT 5 packet data. `ConcurrentAtomic.mutate` retains its 2.3 source signature
+but executes synchronously in 2.4; its closure must not re-enter the same
+wrapper.
+
+## Support lifetime
+
+CocoaMQTT 2.x will be maintained for at least 12 months after CocoaMQTT 3.0.0
+is released. Any end-of-life date will be announced at least six months in
+advance in the repository README and GitHub releases.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -29,6 +29,9 @@ Patch releases in this line preserve the 2.4 public API and supported platform
 matrix. CI builds both package products, validates CocoaPods, and checks the
 public API against both 2.3.0 and the pull request base commit.
 
+Stable tags are created through the `Release CocoaMQTT 2.x` workflow after it
+revalidates release metadata, API compatibility, package tests, and CocoaPods.
+
 `ThreadSafeDictionary.Iterator` intentionally changed from an index-based live
 iterator to a dictionary snapshot iterator. Restoring the old concrete iterator
 would reintroduce invalid-index crashes during concurrent mutation. The type

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -31,6 +31,9 @@ public API against both 2.3.0 and the pull request base commit.
 
 Stable tags are created through the `Release CocoaMQTT 2.x` workflow after it
 revalidates release metadata, API compatibility, package tests, and CocoaPods.
+The workflow also verifies that the remote annotated tag resolves to the
+validated branch head. Repository rules prevent stable `2.*` tags from being
+moved or deleted.
 
 `ThreadSafeDictionary.Iterator` intentionally changed from an index-based live
 iterator to a dictionary snapshot iterator. Restoring the old concrete iterator

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -29,11 +29,12 @@ Patch releases in this line preserve the 2.4 public API and supported platform
 matrix. CI builds both package products, validates CocoaPods, and checks the
 public API against both 2.3.0 and the pull request base commit.
 
-Stable tags are created through the `Release CocoaMQTT 2.x` workflow after it
-revalidates release metadata, API compatibility, package tests, and CocoaPods.
-The workflow also verifies that the remote annotated tag resolves to the
-validated branch head. Repository rules prevent stable `2.*` tags from being
-moved or deleted.
+Merging a stable version metadata update into `release/2.x` starts the
+`Release CocoaMQTT 2.x` workflow. If that version is not already tagged, the
+workflow revalidates release metadata, API compatibility, package tests, and
+CocoaPods before creating the tag. It also verifies that the remote annotated
+tag resolves to the validated branch head. Repository rules prevent stable
+`2.*` tags from being moved or deleted.
 
 `ThreadSafeDictionary.Iterator` intentionally changed from an index-based live
 iterator to a dictionary snapshot iterator. Restoring the old concrete iterator

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -37,9 +37,9 @@ snapshot. Index-based Collection access is not safe across mutations; use
 `snapshot()` for multi-step indexed access.
 
 The deprecated decoder overloads without an explicit protocol version assume
-MQTT 5 packet data. `ConcurrentAtomic.mutate` retains its 2.3 source signature
-but executes synchronously in 2.4; its closure must not re-enter the same
-wrapper.
+MQTT 5 packet data. `ConcurrentAtomic` property assignment and `mutate` retain
+their 2.3 source signatures but execute synchronously in 2.4. A mutation
+closure must not read from or write to the same wrapper.
 
 ## Support lifetime
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -30,11 +30,16 @@ matrix. CI builds both package products, validates CocoaPods, and checks the
 public API against both 2.3.0 and the pull request base commit.
 
 Merging a stable version metadata update into `release/2.x` starts the
-`Release CocoaMQTT 2.x` workflow. If that version is not already tagged, the
-workflow revalidates release metadata, API compatibility, package tests, and
-CocoaPods before creating the tag. It also verifies that the remote annotated
-tag resolves to the validated branch head. Repository rules prevent stable
-`2.*` tags from being moved or deleted.
+`Check CocoaMQTT 2.x Release` workflow. If that version is not already tagged,
+the workflow revalidates release metadata, API compatibility against both 2.3.0
+and the preceding stable 2.x release, package tests, and CocoaPods. It does not
+create or publish a tag.
+
+After that workflow succeeds, a maintainer creates an annotated tag for the
+validated `release/2.x` head and pushes it. Do not create a stable `2.*` tag
+before the release-readiness workflow passes. The tag push runs the distribution
+checks, including validation against the tagged SPM and CocoaPods sources.
+Repository rules prevent stable `2.*` tags from being moved or deleted.
 
 `ThreadSafeDictionary.Iterator` intentionally changed from an index-based live
 iterator to a dictionary snapshot iterator. Restoring the old concrete iterator

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -35,11 +35,12 @@ the workflow revalidates release metadata, API compatibility against both 2.3.0
 and the preceding stable 2.x release, package tests, and CocoaPods. It does not
 create or publish a tag.
 
-After that workflow succeeds, a maintainer creates an annotated tag for the
-validated `release/2.x` head and pushes it. Do not create a stable `2.*` tag
-before the release-readiness workflow passes. The tag push runs the distribution
-checks, including validation against the tagged SPM and CocoaPods sources.
-Repository rules prevent stable `2.*` tags from being moved or deleted.
+The final `2.x Release Ready` job rechecks that the validated commit is still
+the current branch head and reports its full commit SHA. After that job succeeds,
+a maintainer creates an annotated tag for exactly that SHA and pushes it. Do not
+create a stable `2.*` tag before this job passes. The tag push runs the
+distribution checks, including validation against the tagged SPM and CocoaPods
+sources. Repository rules prevent stable `2.*` tags from being moved or deleted.
 
 `ThreadSafeDictionary.Iterator` intentionally changed from an index-based live
 iterator to a dictionary snapshot iterator. Restoring the old concrete iterator

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # CocoaMQTT
 
+> **CocoaMQTT 2.x LTS:** This branch contains the latest stable 2.x release
+> line. It preserves the established CocoaAsyncSocket and Starscream transport
+> architecture and receives compatibility, correctness, and security fixes.
+> CocoaMQTT 3 development continues on `master`. See the
+> [2.x maintenance policy](MAINTENANCE.md) and [changelog](CHANGELOG.md).
+
 ![PodVersion](https://img.shields.io/cocoapods/v/CocoaMQTT5.svg)
 ![Platforms](https://img.shields.io/cocoapods/p/CocoaMQTT5.svg)
 ![License](https://img.shields.io/cocoapods/l/BadgeSwift.svg?style=flat)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ are covered by a Swift 6 compatibility check in CI.
 
 ## Build
 
-Build with Xcode 11.1 / Swift 5.1
+Swift Package Manager requires Swift 5.7 / Xcode 14 or later. CocoaPods uses
+Swift 5 language mode. Both distribution paths are validated in CI with the
+toolchain named in the workflow configuration.
 
 IOS Target: 12.0 or above
 OSX Target: 10.13 or above

--- a/README.md
+++ b/README.md
@@ -20,22 +20,15 @@ are covered by a Swift 6 compatibility check in CI.
 
 ## Build
 
-Swift Package Manager requires Swift 5.7 / Xcode 14 or later. CocoaPods uses
-Swift 5 language mode. Both distribution paths are validated in CI with the
-toolchain named in the workflow configuration.
+The package manifest requires Swift tools 5.7. Release CI validates the current
+Xcode toolchain and Swift 6 compatibility; it does not independently exercise
+the oldest Swift 5.7 compiler. CocoaPods uses Swift 5 language mode.
 
 IOS Target: 12.0 or above
 OSX Target: 10.13 or above
 TVOS Target: 12.0 or above with Swift Package Manager or CocoaPods WebSockets;
 10.0 or above with CocoaPods Core
 visionOS Target: 1.0 or above (Swift Package Manager only, compile-verified in CI)
-
-##  xcode 14.3 issue:
-```ruby
-File not found: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_iphonesimulator.a
-```
-If you encounter the issue, Please update your project minimum depolyments to 11.0
-
 
 ## Installation
 

--- a/Source/CocoaMQTTProperty.swift
+++ b/Source/CocoaMQTTProperty.swift
@@ -48,6 +48,19 @@ public enum CocoaMQTTPropertyName: UInt8 {
     case sharedSubscriptionAvailable = 0x2A
 }
 
+/// Integer formats used by the legacy MQTT property decoder helpers.
+///
+/// This type remains available for source compatibility with CocoaMQTT 2.3.
+@available(*, deprecated, message: "CocoaMQTT decoders now validate integer formats internally")
+public enum formatInt: Int {
+    case formatUint8 = 0x11
+    case formatUint16 = 0x12
+    case formatUint32 = 0x14
+    case formatSint8 = 0x21
+    case formatSint16 = 0x22
+    case formatSint32 = 0x24
+}
+
 func getMQTTPropertyData(type: UInt8, value: [UInt8]) -> [UInt8] {
     var properties = [UInt8]()
     properties.append(UInt8(type))

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>2.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/MqttDecodeConnAck.swift
+++ b/Source/MqttDecodeConnAck.swift
@@ -54,6 +54,11 @@ public class MqttDecodeConnAck: NSObject {
     // 3.2.2.3.18 Authentication Data
     public var authenticationData = [UInt8]()
 
+    @available(*, deprecated, message: "Assumes MQTT 5 data; use properties(connackData:protocolVersion:)")
+    public func properties(connackData: [UInt8]) {
+        _ = properties(connackData: connackData, protocolVersion: .v5)
+    }
+
     @discardableResult
     public func properties(connackData: [UInt8],
                            protocolVersion: CocoaMQTTProtocolVersion) -> Bool {

--- a/Source/MqttDecodePubAck.swift
+++ b/Source/MqttDecodePubAck.swift
@@ -19,6 +19,11 @@ public class MqttDecodePubAck: NSObject {
     public var userProperty: [String: String]?
     public var userProperties = [CocoaMQTTUserProperty]()
 
+    @available(*, deprecated, message: "Assumes MQTT 5 data; use the overload with protocolVersion")
+    public func decodePubAck(fixedHeader: UInt8, pubAckData: [UInt8]) {
+        _ = decodePubAck(fixedHeader: fixedHeader, pubAckData: pubAckData, protocolVersion: .v5)
+    }
+
     @discardableResult
     public func decodePubAck(fixedHeader: UInt8,
                              pubAckData: [UInt8],

--- a/Source/MqttDecodePubComp.swift
+++ b/Source/MqttDecodePubComp.swift
@@ -19,6 +19,11 @@ public class MqttDecodePubComp: NSObject {
     public var userProperty: [String: String]?
     public var userProperties = [CocoaMQTTUserProperty]()
 
+    @available(*, deprecated, message: "Assumes MQTT 5 data; use the overload with protocolVersion")
+    public func decodePubComp(fixedHeader: UInt8, pubAckData: [UInt8]) {
+        _ = decodePubComp(fixedHeader: fixedHeader, pubAckData: pubAckData, protocolVersion: .v5)
+    }
+
     @discardableResult
     public func decodePubComp(fixedHeader: UInt8,
                               pubAckData: [UInt8],

--- a/Source/MqttDecodePubRec.swift
+++ b/Source/MqttDecodePubRec.swift
@@ -21,6 +21,11 @@ public class MqttDecodePubRec: NSObject {
     public var userProperty: [String: String]?
     public var userProperties = [CocoaMQTTUserProperty]()
 
+    @available(*, deprecated, message: "Assumes MQTT 5 data; use the overload with protocolVersion")
+    public func decodePubRec(fixedHeader: UInt8, pubAckData: [UInt8]) {
+        _ = decodePubRec(fixedHeader: fixedHeader, pubAckData: pubAckData, protocolVersion: .v5)
+    }
+
     @discardableResult
     public func decodePubRec(fixedHeader: UInt8,
                              pubAckData: [UInt8],

--- a/Source/MqttDecodePubRel.swift
+++ b/Source/MqttDecodePubRel.swift
@@ -19,6 +19,11 @@ public class MqttDecodePubRel: NSObject {
     public var userProperty: [String: String]?
     public var userProperties = [CocoaMQTTUserProperty]()
 
+    @available(*, deprecated, message: "Assumes MQTT 5 data; use the overload with protocolVersion")
+    public func decodePubRel(fixedHeader: UInt8, pubAckData: [UInt8]) {
+        _ = decodePubRel(fixedHeader: fixedHeader, pubAckData: pubAckData, protocolVersion: .v5)
+    }
+
     @discardableResult
     public func decodePubRel(fixedHeader: UInt8,
                              pubAckData: [UInt8],

--- a/Source/MqttDecodePublish.swift
+++ b/Source/MqttDecodePublish.swift
@@ -39,6 +39,11 @@ public class MqttDecodePublish: NSObject {
     public var packetIdentifier: UInt16?
     public var mqtt5DataIndex = 0
 
+    @available(*, deprecated, message: "Assumes MQTT 5 data; use the overload with protocolVersion")
+    public func decodePublish(fixedHeader: UInt8, publishData: [UInt8]) {
+        _ = decodePublish(fixedHeader: fixedHeader, publishData: publishData, protocolVersion: .v5)
+    }
+
     @discardableResult
     public func decodePublish(fixedHeader: UInt8,
                               publishData: [UInt8],

--- a/Source/MqttDecodeSubAck.swift
+++ b/Source/MqttDecodeSubAck.swift
@@ -20,6 +20,11 @@ public class MqttDecodeSubAck: NSObject {
     public var userProperty: [String: String]?
     public var userProperties = [CocoaMQTTUserProperty]()
 
+    @available(*, deprecated, message: "Assumes MQTT 5 data; use the overload with protocolVersion")
+    public func decodeSubAck(fixedHeader: UInt8, pubAckData: [UInt8]) {
+        _ = decodeSubAck(fixedHeader: fixedHeader, pubAckData: pubAckData, protocolVersion: .v5)
+    }
+
     @discardableResult
     public func decodeSubAck(fixedHeader: UInt8,
                              pubAckData: [UInt8],

--- a/Source/MqttDecodeUnsubAck.swift
+++ b/Source/MqttDecodeUnsubAck.swift
@@ -20,6 +20,11 @@ public class MqttDecodeUnsubAck: NSObject {
     public var userProperty: [String: String]?
     public var userProperties = [CocoaMQTTUserProperty]()
 
+    @available(*, deprecated, message: "Assumes MQTT 5 data; use the overload with protocolVersion")
+    public func decodeUnSubAck(fixedHeader: UInt8, pubAckData: [UInt8]) {
+        _ = decodeUnSubAck(fixedHeader: fixedHeader, pubAckData: pubAckData, protocolVersion: .v5)
+    }
+
     @discardableResult
     public func decodeUnSubAck(fixedHeader: UInt8,
                                pubAckData: [UInt8],

--- a/Source/ThreadSafeDictionary.swift
+++ b/Source/ThreadSafeDictionary.swift
@@ -8,12 +8,24 @@ import Foundation
 ///
 /// Iteration uses a stable snapshot so concurrent mutations cannot invalidate an
 /// iterator. Use `snapshot()` when an operation needs one consistent dictionary.
-public final class ThreadSafeDictionary<K: Hashable, V>: Sequence {
+///
+/// - Important: Index-based `Collection` operations are retained for source
+///   compatibility, but an index can be invalidated by a mutation between calls.
+///   Use `snapshot()` for multi-step indexed access.
+public final class ThreadSafeDictionary<K: Hashable, V>: Collection {
     public typealias Element = Dictionary<K, V>.Element
     public typealias Iterator = Dictionary<K, V>.Iterator
 
     private var dictionary: [K: V]
     private let concurrentQueue: DispatchQueue
+
+    public var startIndex: Dictionary<K, V>.Index {
+        concurrentQueue.sync { dictionary.startIndex }
+    }
+
+    public var endIndex: Dictionary<K, V>.Index {
+        concurrentQueue.sync { dictionary.endIndex }
+    }
 
     public var count: Int {
         concurrentQueue.sync { dictionary.count }
@@ -37,6 +49,12 @@ public final class ThreadSafeDictionary<K: Hashable, V>: Sequence {
         snapshot().makeIterator()
     }
 
+    public func index(after index: Dictionary<K, V>.Index) -> Dictionary<K, V>.Index {
+        concurrentQueue.sync {
+            dictionary.index(after: index)
+        }
+    }
+
     public subscript(key: K) -> V? {
         get {
             concurrentQueue.sync {
@@ -47,6 +65,12 @@ public final class ThreadSafeDictionary<K: Hashable, V>: Sequence {
             concurrentQueue.sync(flags: .barrier) {
                 dictionary[key] = newValue
             }
+        }
+    }
+
+    public subscript(index: Dictionary<K, V>.Index) -> Element {
+        concurrentQueue.sync {
+            dictionary[index]
         }
     }
 

--- a/Source/utilities/ConcurrentAtomic.swift
+++ b/Source/utilities/ConcurrentAtomic.swift
@@ -71,9 +71,32 @@ public class ConcurrentAtomic<T> {
     ///   same instance would deadlock.
     ///
     /// - Parameter transform: A closure that receives `inout` access to the wrapped value.
-    /// - Returns: The value returned by `transform`.
+    ///
+    /// Mutations are synchronous in 2.4 so callers can safely observe the result
+    /// immediately after this method returns. The escaping closure signature is
+    /// retained for CocoaMQTT 2.3 source compatibility.
+    public func mutate(_ transform: @escaping (inout T) -> Void) {
+        queue.sync(flags: .barrier) {
+            transform(&self._value)
+            self.mutationObserver?(self._value)
+        }
+    }
+
+    /// Compatibility overload for transforms that return a value.
+    ///
+    /// Prefer `withMutation` in new code to make the returned value explicit.
     @discardableResult
+    @available(*, deprecated, renamed: "withMutation(_:)")
     public func mutate<Result>(_ transform: (inout T) throws -> Result) rethrows -> Result {
+        try withMutation(transform)
+    }
+
+    /// Atomically mutates the wrapped value and returns the transform result.
+    ///
+    /// - Important: Do not re-enter this `ConcurrentAtomic` instance from
+    ///   `transform`.
+    @discardableResult
+    public func withMutation<Result>(_ transform: (inout T) throws -> Result) rethrows -> Result {
         try queue.sync(flags: .barrier) {
             defer { self.mutationObserver?(self._value) }
             return try transform(&self._value)


### PR DESCRIPTION
## What changed

- establish 2.4.0 as the first release on the long-term `release/2.x` line
- document the 2.x maintenance scope, support lifetime, compatibility notes, and 2.4 highlights
- restore CocoaMQTT 2.3 decoder and concurrency utility entry points
- preserve the return-value `ConcurrentAtomic.mutate` overload from the branch point and add the clearer `withMutation` API
- restore `ThreadSafeDictionary` collection APIs while retaining snapshot-based iteration
- add an always-on required LTS API gate against both 2.3.0 and each pull request's base commit
- add a release-readiness workflow that reacts to version metadata merges on `release/2.x` and validates API, tests, CocoaPods, metadata, and branch head without creating a tag
- validate future releases against both 2.3.0 and the preceding stable 2.x tag
- require manually created 2.x tags to come from `release/2.x`, exactly match podspec/framework metadata, and remain immutable
- update the podspec and Xcode framework version to 2.4.0

## Why

`release/2.x` branches from `c09666c`, the final master commit before the CocoaMQTT 3 transport architecture changes. This keeps the existing CocoaAsyncSocket and Starscream architecture available as a stable, maintained 2.x line.

SwiftPM initially reported 30 API breakages relative to 2.3.0. Compatibility shims resolve all but the concrete `ThreadSafeDictionary.Iterator` type change. That change is intentionally allowlisted because restoring the live index iterator would reintroduce invalid-index crashes during concurrent mutation. Ordinary `for-in` and `map` usage iterates over a stable snapshot; index-based Collection access must not span mutations.

The changelog also records the intentional behavior boundaries: `ConcurrentAtomic` property assignment and `mutate` are now synchronous, mutation closures must not re-enter the same wrapper, and deprecated decoder overloads without an explicit protocol version assume MQTT 5 packet data.

## Verification

- API compatibility against `2.3.0` with the documented Iterator allowlist
- API compatibility against `origin/release/2.x` with no allowlist
- previous-release selection resolves 2.4.0 to tag `2.3.0` and verifies tag ancestry
- `swift test --filter ConcurrentAtomicTests` — 8 tests, 0 failures (including the legacy result-returning and throwing overloads)
- `swift test --skip CocoaMQTTTests.CocoaMQTTTests` — 304 tests, 1 skipped, 0 failures on the preceding production-code head
- `Tools/lint.sh` — 0 violations
- Xcode Mac Framework Release build — built framework reports `CFBundleShortVersionString = 2.4.0`
- CocoaPods Core and WebSockets local lint on iOS/macOS
- release metadata and `release/2.x` ancestry guard simulation
- YAML parsing and embedded shell syntax checks for all changed workflows
- `git diff --check`

Full tvOS CocoaPods validation remains covered by CI because this machine has no tvOS simulator.

Merging this PR into `release/2.x` starts the `Check CocoaMQTT 2.x Release` workflow. It only checks the merge commit and never creates or publishes a tag. A newer branch push cancels stale readiness runs, and the final `2.x Release Ready` job rechecks the current branch head and reports the exact validated SHA. After that job passes, a maintainer may create the annotated `2.4.0` tag for exactly that SHA; the tag push then runs the tagged distribution checks.

