### PR TITLE
Add CocoaMQTT 3 contribution guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## What changed
+
+<!-- Describe the implementation and why it is needed. -->
+
+## Related issue
+
+<!-- Use Fixes #123, Closes #123, or Refs #123 where appropriate. -->
+
+## Target branch
+
+<!--
+This template copy describes CocoaMQTT 3 work. GitHub currently defaults new
+pull requests to release/2.x, so verify and change the base before submission.
+-->
+
+- [ ] This pull request targets `master`.
+- [ ] The change applies only to CocoaMQTT 3.
+- [ ] The change also applies to 2.x; a separate reviewed backport will follow.
+
+## Compatibility
+
+<!-- Describe source, binary, runtime, platform, and MQTT behavior impact. -->
+
+- [ ] No public API compatibility change
+- [ ] Compatibility or migration impact is documented above
+- [ ] Any intentional CocoaMQTT 3 breaking change has an approved issue and a
+      documented migration path
+
+## Verification
+
+<!-- List the exact commands and environments used. -->
+
+- [ ] Added or updated focused regression coverage
+- [ ] Ran the relevant SwiftPM tests
+- [ ] Ran lint/build/package checks relevant to this change
+- [ ] Covered affected transport paths such as TCP, TLS, mTLS, or WebSocket
+- [ ] Added screenshots or a recording for Example app UI changes, if any

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to CocoaMQTT
+
+Thank you for helping improve CocoaMQTT. This copy of the contribution guide
+describes CocoaMQTT 3 development on `master`. The repository default remains
+the maintained `release/2.x` line until CocoaMQTT 3 is ready, so contributors
+must choose the pull request base deliberately.
+
+## Choose the target branch
+
+| Change | Pull request base |
+| --- | --- |
+| CocoaMQTT 3 architecture, features, or breaking changes | `master` |
+| Security, protocol-correctness, regression, or compatibility fix needed only by the maintained 2.x line | `release/2.x` |
+| Fix applicable to both lines | `master` first, followed by a reviewed cherry-pick or equivalent 2.x pull request |
+| Documentation describing only one release line | The branch that owns that documentation |
+
+GitHub initially selects `release/2.x` because it is the default branch. Change
+the base to `master` before opening a CocoaMQTT 3 pull request.
+
+Do not merge either branch wholesale into the other. They have intentionally
+different transport architectures, version metadata, dependencies, and
+compatibility policies. Share an applicable change through a reviewed
+cherry-pick or an equivalent branch-specific implementation. See the
+[2.x maintenance policy](https://github.com/emqx/CocoaMQTT/blob/release/2.x/MAINTENANCE.md)
+for the stable branch scope.
+
+## Before coding
+
+- Search existing issues and pull requests.
+- For behavior changes, describe the observed and expected MQTT behavior.
+- Reproduce bugs with the smallest practical test case.
+- Discuss broad architecture or public API changes in an issue before
+  implementation.
+- Preserve public API and Objective-C delegate compatibility unless an issue
+  explicitly approves a CocoaMQTT 3 breaking change and its migration path.
+
+## CocoaMQTT 3 design principles
+
+- Keep the MQTT 3.1.1 and MQTT 5 public facades while moving protocol-neutral
+  lifecycle behavior into shared, testable components.
+- Keep protocol differences explicit rather than selecting behavior through
+  global mutable state.
+- Validate transport changes against TCP, TLS, mutual TLS, WebSocket,
+  disconnect, timeout, and reconnect behavior as applicable.
+- Document minimum-platform, dependency, and migration impact for every
+  intentional breaking change.
+
+## Build and test
+
+From the repository root:
+
+```bash
+swift build
+swift test
+xcodebuild \
+  -project CocoaMQTT.xcodeproj \
+  -scheme "Mac Framework" \
+  -derivedDataPath . \
+  build
+```
+
+Broker-dependent tests expect local MQTT listeners such as `localhost:1883`
+and WebSocket `localhost:8083`. Start a local MQTT broker before running the
+full integration suite.
+
+Use focused deterministic XCTest coverage for frame parsing, state machines,
+and regressions. Add integration tests when transport or protocol flow cannot
+be validated reliably with a unit test.
+
+CocoaMQTT 3 snapshots are currently distributed through Swift Package Manager,
+not CocoaPods. When a change touches shared source or CocoaPods packaging that
+must remain valid before the 3.0 distribution policy is finalized, also run:
+
+```bash
+pod lib lint CocoaMQTT.podspec --allow-warnings --skip-tests
+```
+
+## Code style
+
+- Follow Swift 5 conventions with four-space indentation.
+- Use `UpperCamelCase` for types and protocols and `lowerCamelCase` for
+  properties and functions.
+- Keep file names aligned with their primary type.
+- Keep commits scoped to one logical change and include related tests.
+
+## Pull requests
+
+Every pull request should include:
+
+- what changed and why;
+- the linked issue or a clear explanation when no issue is needed;
+- compatibility and migration impact;
+- exact verification commands run;
+- screenshots or a short recording for Example app UI changes.
+
+All review conversations must be resolved, and required CI checks must pass,
+before merging.


### PR DESCRIPTION
## What changed

- forward-port the repository contribution policy introduced by #735 to `master`
- adapt the guide specifically for CocoaMQTT 3 architecture and compatibility decisions
- add a master-specific PR template that requires the correct base branch, migration impact, and affected transport coverage
- link the 2.x maintenance policy explicitly across branches instead of relying on a file that does not exist on `master`

## Why

The contribution files should be available on both long-lived branches, but the wording cannot be copied mechanically. `release/2.x` describes stable maintenance, while `master` governs CocoaMQTT 3 development and intentional architecture changes.

This is a selective forward-port of the documentation commit from #735, not a branch merge. No 2.4 version metadata, dependency, or implementation change is brought into `master`.

## Compatibility

Documentation and repository guidance only. No source or package API changes.

## Verification

- `git diff --check`
- `swift package dump-package`
- validated relative Markdown links
- reviewed the master wording against the 2.x version from #735