### PR TITLE
Extract shared MQTT client core

### DIFF
--- a/CocoaMQTT.xcodeproj/project.pbxproj
+++ b/CocoaMQTT.xcodeproj/project.pbxproj
@@ -167,6 +167,10 @@
 		F0A400000000000000000003 /* MQTTKeepAliveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A400000000000000000001 /* MQTTKeepAliveController.swift */; };
 		F0A400000000000000000004 /* MQTTKeepAliveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A400000000000000000001 /* MQTTKeepAliveController.swift */; };
 		F0A400000000000000000006 /* KeepAliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A400000000000000000005 /* KeepAliveTests.swift */; };
+		F0A600000000000000000002 /* MQTTClientCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A600000000000000000001 /* MQTTClientCore.swift */; };
+		F0A600000000000000000003 /* MQTTClientCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A600000000000000000001 /* MQTTClientCore.swift */; };
+		F0A600000000000000000004 /* MQTTClientCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A600000000000000000001 /* MQTTClientCore.swift */; };
+		F0A600000000000000000006 /* ConnectionStateContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A600000000000000000005 /* ConnectionStateContractTests.swift */; };
 		A1B2C3D4E5F60718293A0001 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
 		A1B2C3D4E5F60718293A0002 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
 		A1B2C3D4E5F60718293A0003 /* utilities/ConcurrentAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */; };
@@ -261,6 +265,8 @@
 		F0A400000000000000000001 /* MQTTKeepAliveController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MQTTKeepAliveController.swift; sourceTree = "<group>"; };
 		F0A400000000000000000005 /* KeepAliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepAliveTests.swift; sourceTree = "<group>"; };
 		F0A500000000000000000001 /* CocoaMQTTClientIdentity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaMQTTClientIdentity.swift; sourceTree = "<group>"; };
+		F0A600000000000000000001 /* MQTTClientCore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MQTTClientCore.swift; sourceTree = "<group>"; };
+		F0A600000000000000000005 /* ConnectionStateContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStateContractTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = utilities/ConcurrentAtomic.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0012 /* ConcurrentAtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentAtomicTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0013 /* ThreadSafetyRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafetyRegressionTests.swift; sourceTree = "<group>"; };
@@ -330,6 +336,7 @@
 				0409971E1C1B0B96006B5A6D /* CocoaMQTTTests.swift */,
 				F0A300000000000000000005 /* MQTTAutoReconnectControllerTests.swift */,
 				F0A400000000000000000005 /* KeepAliveTests.swift */,
+				F0A600000000000000000005 /* ConnectionStateContractTests.swift */,
 				A1B2C3D4E5F60718293A0012 /* ConcurrentAtomicTests.swift */,
 				A1B2C3D4E5F60718293A0014 /* PublicLoggerAPITests.swift */,
 				8D14C7622345CAB5002D959E /* CocoaMQTTDeliverTests.swift */,
@@ -410,6 +417,7 @@
 				F0A200000000000000000001 /* MQTT5SessionState.swift */,
 				F0A300000000000000000001 /* MQTTAutoReconnectController.swift */,
 				F0A400000000000000000001 /* MQTTKeepAliveController.swift */,
+				F0A600000000000000000001 /* MQTTClientCore.swift */,
 				A1B2C3D4E5F60718293A0011 /* utilities/ConcurrentAtomic.swift */,
 				9228E8C827610A9100063DF2 /* CocoaMQTTReasonCode.swift */,
 				9228E8C427610A8500063DF2 /* CocoaMQTTProperty.swift */,
@@ -653,6 +661,7 @@
 				F0A200000000000000000003 /* MQTT5SessionState.swift in Sources */,
 				F0A300000000000000000003 /* MQTTAutoReconnectController.swift in Sources */,
 				F0A400000000000000000003 /* MQTTKeepAliveController.swift in Sources */,
+				F0A600000000000000000003 /* MQTTClientCore.swift in Sources */,
 				F0A500000000000000000003 /* CocoaMQTTClientIdentity.swift in Sources */,
 				1111248E24BB515E00E2DFBC /* CocoaMQTT.swift in Sources */,
 				9228E8CF27610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
@@ -709,6 +718,7 @@
 				F0A200000000000000000004 /* MQTT5SessionState.swift in Sources */,
 				F0A300000000000000000004 /* MQTTAutoReconnectController.swift in Sources */,
 				F0A400000000000000000004 /* MQTTKeepAliveController.swift in Sources */,
+				F0A600000000000000000004 /* MQTTClientCore.swift in Sources */,
 				F0A500000000000000000004 /* CocoaMQTTClientIdentity.swift in Sources */,
 				111124B824BB516300E2DFBC /* CocoaMQTT.swift in Sources */,
 				9228E8D027610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
@@ -765,6 +775,7 @@
 				F0A200000000000000000002 /* MQTT5SessionState.swift in Sources */,
 				F0A300000000000000000002 /* MQTTAutoReconnectController.swift in Sources */,
 				F0A400000000000000000002 /* MQTTKeepAliveController.swift in Sources */,
+				F0A600000000000000000002 /* MQTTClientCore.swift in Sources */,
 				F0A500000000000000000002 /* CocoaMQTTClientIdentity.swift in Sources */,
 				8225B53A227C2FC600E4DB51 /* CocoaMQTT.swift in Sources */,
 				9228E8CE27610AA400063DF2 /* MqttAuthProperties.swift in Sources */,
@@ -820,6 +831,7 @@
 				8D14C7632345CAB5002D959E /* CocoaMQTTDeliverTests.swift in Sources */,
 				F0A300000000000000000006 /* MQTTAutoReconnectControllerTests.swift in Sources */,
 				F0A400000000000000000006 /* KeepAliveTests.swift in Sources */,
+				F0A600000000000000000006 /* ConnectionStateContractTests.swift in Sources */,
 				8D14C7672349C2A3002D959E /* CocoaMQTTStorageTests.swift in Sources */,
 				8225B556227C334700E4DB51 /* CocoaMQTTTests.swift in Sources */,
 				A1B2C3D4E5F60718293A0004 /* ConcurrentAtomicTests.swift in Sources */,

--- a/CocoaMQTTTests/ConnectionStateContractTests.swift
+++ b/CocoaMQTTTests/ConnectionStateContractTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import CocoaMQTT
+
+final class ConnectionStateContractTests: XCTestCase {
+    private struct ClientHarness {
+        let name: String
+        let state: () -> CocoaMQTTConnState
+        let setState: (CocoaMQTTConnState) -> Void
+        let setDelegateQueue: (DispatchQueue) -> Void
+        let observeState: (@escaping (CocoaMQTTConnState) -> Void) -> Void
+    }
+
+    private func clients() -> [ClientHarness] {
+        let mqtt = CocoaMQTT(clientID: "connection-state-contract-311-\(UUID().uuidString)")
+        let mqtt5 = CocoaMQTT5(clientID: "connection-state-contract-5-\(UUID().uuidString)")
+
+        return [
+            ClientHarness(
+                name: "MQTT 3.1.1",
+                state: { mqtt.connState },
+                setState: { mqtt.connState = $0 },
+                setDelegateQueue: { mqtt.delegateQueue = $0 },
+                observeState: { observer in
+                    mqtt.didChangeState = { _, state in observer(state) }
+                }
+            ),
+            ClientHarness(
+                name: "MQTT 5",
+                state: { mqtt5.connState },
+                setState: { mqtt5.connState = $0 },
+                setDelegateQueue: { mqtt5.delegateQueue = $0 },
+                observeState: { observer in
+                    mqtt5.didChangeState = { _, state in observer(state) }
+                }
+            )
+        ]
+    }
+
+    func testClientsStartDisconnectedAndMakeWritesSynchronouslyVisible() {
+        for client in clients() {
+            XCTAssertEqual(client.state(), .disconnected, client.name)
+
+            client.setState(.connecting)
+            XCTAssertEqual(client.state(), .connecting, client.name)
+
+            client.setState(.connected)
+            XCTAssertEqual(client.state(), .connected, client.name)
+        }
+    }
+
+    func testClientsDispatchStateCallbacksInWriteOrder() {
+        for client in clients() {
+            let callbackQueue = DispatchQueue(
+                label: "tests.connection-state-contract.callback.\(client.name)"
+            )
+            let callbackGate = DispatchSemaphore(value: 0)
+            let callbacksReceived = expectation(
+                description: "\(client.name) state callbacks"
+            )
+            callbacksReceived.expectedFulfillmentCount = 4
+            var receivedStates = [CocoaMQTTConnState]()
+
+            callbackQueue.async {
+                callbackGate.wait()
+            }
+            client.setDelegateQueue(callbackQueue)
+            client.observeState { state in
+                receivedStates.append(state)
+                callbacksReceived.fulfill()
+            }
+
+            client.setState(.connecting)
+            client.setState(.connecting)
+            client.setState(.connected)
+            client.setState(.disconnected)
+            callbackGate.signal()
+
+            wait(for: [callbacksReceived], timeout: 1)
+            callbackQueue.sync {}
+            XCTAssertEqual(
+                receivedStates,
+                [.connecting, .connecting, .connected, .disconnected],
+                client.name
+            )
+        }
+    }
+}

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -201,46 +201,22 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Changing the queue affects callbacks emitted after the assignment; callbacks
     /// already submitted remain on the queue captured when their event occurred.
     public var delegateQueue: DispatchQueue {
-        get {
-            delegateQueueLock.lock()
-            defer { delegateQueueLock.unlock() }
-            return _delegateQueue
-        }
-        set {
-            delegateQueueLock.lock()
-            _delegateQueue = newValue
-            delegateQueueLock.unlock()
-        }
+        get { core.delegateQueue }
+        set { core.delegateQueue = newValue }
     }
-    private let delegateQueueLock = NSLock()
-    private var _delegateQueue = DispatchQueue.main
 
     /// Owns ordered socket, reader, timer, and delivery events. Application code
     /// cannot replace this queue through `delegateQueue`.
-    let eventLoopQueue: DispatchQueue
-    private var socketDelegateProxy: CocoaMQTTSocketDelegateProxy!
+    var eventLoopQueue: DispatchQueue { core.eventLoopQueue }
+    private var core: MQTTClientCore!
 
     public var connState: CocoaMQTTConnState {
-        get {
-            connStateLock.lock()
-            defer { connStateLock.unlock() }
-            return _connState
-        }
-        set {
-            connStateLock.lock()
-            _connState = newValue
-            connStateLock.unlock()
-            __delegate_queue { mqtt in
-                mqtt.delegate?.mqtt?(mqtt, didStateChangeTo: newValue)
-                mqtt.didChangeState(mqtt, newValue)
-            }
-        }
+        get { core.state }
+        set { core.state = newValue }
     }
-    private let connStateLock = NSLock()
-    private var _connState = CocoaMQTTConnState.disconnected
 
     // deliver
-    private var deliver = CocoaMQTTDeliver()
+    private var deliver: CocoaMQTTDeliver { core.deliver }
 
     /// Re-deliver the un-acked messages
     public var deliverTimeout: Double {
@@ -264,7 +240,6 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Keep alive time interval
     public var keepAlive: UInt16 = 60
-    private let keepAliveController: MQTTKeepAliveController
 
     /// Maximum duration in seconds for each Remaining Length byte and the complete payload read.
     /// Each deadline starts with its read and is not reset by partial data. Header reads remain unlimited.
@@ -274,8 +249,8 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Enable auto-reconnect mechanism
     public var autoReconnect: Bool {
-        get { autoReconnectController.isEnabled }
-        set { autoReconnectController.isEnabled = newValue }
+        get { core.autoReconnect }
+        set { core.autoReconnect = newValue }
     }
 
     /// Reconnect time interval
@@ -283,8 +258,8 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// - note: This value will be increased with `autoReconnectTimeInterval *= 2`
     ///         if reconnect failed
     public var autoReconnectTimeInterval: UInt16 {
-        get { autoReconnectController.autoReconnectTimeInterval }
-        set { autoReconnectController.autoReconnectTimeInterval = newValue }
+        get { core.autoReconnectTimeInterval }
+        set { core.autoReconnectTimeInterval = newValue }
     }
 
     /// Maximum auto reconnect time interval
@@ -292,27 +267,25 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// The timer starts from `autoReconnectTimeInterval` second and grows exponentially until this value
     /// After that, it uses this value for subsequent requests.
     public var maxAutoReconnectTimeInterval: UInt16 {
-        get { autoReconnectController.maxAutoReconnectTimeInterval }
-        set { autoReconnectController.maxAutoReconnectTimeInterval = newValue }
+        get { core.maxAutoReconnectTimeInterval }
+        set { core.maxAutoReconnectTimeInterval = newValue }
     }
 
     /// Auto-reconnect backoff interval in seconds for the current reconnect cycle.
     ///
     /// This value is advanced for the next reconnect attempt while auto-reconnect is active,
     /// and resets to `0` when auto-reconnect is inactive.
-    public var reconnectTimeInterval: UInt16 { autoReconnectController.reconnectTimeInterval }
+    public var reconnectTimeInterval: UInt16 { core.reconnectTimeInterval }
 
     /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.
     ///
     /// The value resets to `0` after a successful connection or expected disconnect.
-    public var reconnectAttemptCount: UInt { autoReconnectController.reconnectAttemptCount }
+    public var reconnectAttemptCount: UInt { core.reconnectAttemptCount }
 
     /// Whether auto-reconnect is currently paused by the application.
     public var isAutoReconnectPaused: Bool {
-        autoReconnectController.isPaused
+        core.isAutoReconnectPaused
     }
-
-    private let autoReconnectController: MQTTAutoReconnectController
 
     /// Console log level
     public var logLevel: CocoaMQTTLoggerLevel {
@@ -326,8 +299,8 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
 
     /// Enable SSL connection
     public var enableSSL: Bool {
-        get { return self.socket.enableSSL }
-        set { socket.enableSSL = newValue }
+        get { core.enableSSL }
+        set { core.enableSSL = newValue }
     }
 
     ///
@@ -396,13 +369,11 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Sending messages
     fileprivate var sendingMessages = ThreadSafeDictionary<UInt64, CocoaMQTTMessage>(label: "sendingMessages")
 
-    private let packetIdentifiers = MQTTPacketIdentifierAllocator()
-    private var _deliveryToken = UInt64(UInt16.max)
-    private let messageIdentifierLock = NSLock()
-    private let clientStateLock = NSRecursiveLock()
+    private var packetIdentifiers: MQTTPacketIdentifierAllocator { core.packetIdentifiers }
+    private var clientStateLock: NSRecursiveLock { core.lifecycleLock }
     private var activeClientID: String
-    fileprivate var socket: CocoaMQTTSocketProtocol
-    fileprivate var reader: CocoaMQTTReader?
+    fileprivate var socket: CocoaMQTTSocketProtocol { core.socket }
+    fileprivate var reader: CocoaMQTTReader? { core.reader }
 
     // Closures
     public var didConnectAck: (CocoaMQTT, CocoaMQTTConnAck) -> Void = { _, _ in }
@@ -435,34 +406,24 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         self.activeClientID = clientID
         self.host = host
         self.port = port
-        self.socket = socket
-        let eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT.event-loop.\(UUID().uuidString)")
-        self.eventLoopQueue = eventLoopQueue
-        self.autoReconnectController = MQTTAutoReconnectController(eventLoopQueue: eventLoopQueue)
-        self.keepAliveController = MQTTKeepAliveController(eventLoopQueue: eventLoopQueue)
         super.init()
-        autoReconnectController.delegate = self
-        keepAliveController.delegate = self
-        socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
-        socketDelegateProxy.delegate = self
-        deliver.delegate = self
+        core = MQTTClientCore(
+            socket: socket,
+            protocolVersion: .v311,
+            queueLabel: "io.emqx.CocoaMQTT.event-loop.\(UUID().uuidString)"
+        )
+        core.delegate = self
     }
 
-    deinit {
-        keepAliveController.stop()
-        socket.disconnectForClientDeinit()
-    }
-
-    fileprivate func send(_ frame: Frame, tag: Int = 0, disconnectAfterWriting: Bool = false) {
-        printDebug("SEND: \(frame)")
-        let data = frame.bytes(version: version)
-        let packet = Data(bytes: data, count: data.count)
-        let writeTimeout = socketWriteTimeout
-        if disconnectAfterWriting {
-            socket.writeAndDisconnect(packet, withTimeout: writeTimeout, tag: tag)
-        } else {
-            socket.write(packet, withTimeout: writeTimeout, tag: tag)
-        }
+    @discardableResult
+    fileprivate func send(_ frame: Frame, tag: Int = 0, disconnectAfterWriting: Bool = false) -> Bool {
+        core.send(
+            frame,
+            version: version,
+            timeout: socketWriteTimeout,
+            tag: tag,
+            disconnectAfterWriting: disconnectAfterWriting
+        )
     }
 
     fileprivate func sendConnectFrame() {
@@ -479,18 +440,11 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     }
 
     fileprivate func nextDeliveryToken() -> UInt64 {
-        messageIdentifierLock.lock()
-        defer { messageIdentifierLock.unlock() }
-        if _deliveryToken >= UInt64(Int.max) {
-            _deliveryToken = UInt64(UInt16.max) + 1
-        } else {
-            _deliveryToken += 1
-        }
-        return _deliveryToken
+        core.nextDeliveryToken()
     }
 
     fileprivate func discardStoredSession() {
-        CocoaMQTTStorage(by: activeClientID, protocolVersion: .v311)?.removeAll()
+        core.discardStoredSession(clientID: activeClientID, protocolVersion: .v311)
     }
 
     private func discardCurrentSession(preservingConnectionQueue: Bool = false) {
@@ -501,49 +455,26 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     }
 
     private func discardInMemorySession(preservingConnectionQueue: Bool = false) {
-        let pendingPublishes = preservingConnectionQueue
-            ? deliver.connectionPendingFrames().compactMap { $0 as? FramePublish }
-            : []
-        deliver.cleanAll(
-            detachStorage: true,
-            preserveConnectionQueue: preservingConnectionQueue
-        )
-        if preservingConnectionQueue {
-            let pendingTokens = Set(pendingPublishes.map { $0.deliveryToken ?? UInt64($0.msgid) })
-            sendingMessages.replace(with: sendingMessages.snapshot().filter { pendingTokens.contains($0.key) })
-        } else {
-            sendingMessages.removeAll()
-        }
-        subscriptionsWaitingAck.removeAll()
-        unsubscriptionsWaitingAck.removeAll()
-        subscriptionsStorage.removeAll()
-        packetIdentifiers.reset()
-        for publish in pendingPublishes where publish.qos > .qos0 {
-            packetIdentifiers.markInUse(publish.msgid)
+        core.discardInMemorySession(
+            preservingConnectionQueue: preservingConnectionQueue,
+            sendingMessages: sendingMessages,
+            subscriptionsWaitingAck: subscriptionsWaitingAck,
+            unsubscriptionsWaitingAck: unsubscriptionsWaitingAck
+        ) {
+            subscriptionsStorage.removeAll()
         }
     }
 
     private func markStoredPacketIdentifiersInUse() {
-        guard let frames = CocoaMQTTStorage(by: activeClientID, protocolVersion: .v311)?.readAll() else {
-            return
-        }
-        for frame in frames {
-            if let publish = frame as? FramePublish {
-                packetIdentifiers.markInUse(publish.msgid)
-            } else if let pubrel = frame as? FramePubRel {
-                packetIdentifiers.markInUse(pubrel.msgid)
-            }
-        }
+        core.markStoredPacketIdentifiersInUse(clientID: activeClientID, protocolVersion: .v311)
     }
 
     /// Callers must hold `clientStateLock`.
     private func clearPendingSubscriptionRequestsLocked() {
-        for identifier in subscriptionsWaitingAck.removeAllValues().keys {
-            packetIdentifiers.release(identifier)
-        }
-        for identifier in unsubscriptionsWaitingAck.removeAllValues().keys {
-            packetIdentifiers.release(identifier)
-        }
+        core.clearPendingPacketIdentifiers(
+            subscriptionsWaitingAck: subscriptionsWaitingAck,
+            unsubscriptionsWaitingAck: unsubscriptionsWaitingAck
+        )
     }
 
     fileprivate func puback(_ type: FrameType, msgid: UInt16) {
@@ -588,38 +519,21 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
         }
         // Publish uses the same lock, so pausing transport and starting the
         // connection queue are atomic relative to queue admission.
-        clientStateLock.lock()
-        deliver.setTransportEnabled(false)
-        if activeClientID != clientID {
-            discardInMemorySession()
-        }
-        activeClientID = clientID
-        markStoredPacketIdentifiersInUse()
-        deliver.beginConnection()
-        clientStateLock.unlock()
-        socket.setDelegate(socketDelegateProxy, delegateQueue: eventLoopQueue)
-        reader = CocoaMQTTReader(
-            socket: socket,
-            delegate: self,
+        return core.connect(
+            host: host,
+            port: port,
+            timeout: timeout,
             protocolVersion: .v311,
-            packetReadTimeout: packetReadTimeout
-        )
-        do {
-            if timeout > 0 {
-                try socket.connect(toHost: self.host, onPort: self.port, withTimeout: timeout)
-            } else {
-                try socket.connect(toHost: self.host, onPort: self.port)
+            packetReadTimeout: packetReadTimeout,
+            readerDelegate: self
+        ) {
+            deliver.setTransportEnabled(false)
+            if activeClientID != clientID {
+                discardInMemorySession()
             }
-
-            eventLoopQueue.async { [weak self] in
-                guard let self = self else { return }
-                self.connState = .connecting
-            }
-
-            return true
-        } catch let error as NSError {
-            printError("socket connect error: \(error.description)")
-            return false
+            activeClientID = clientID
+            markStoredPacketIdentifiersInUse()
+            deliver.beginConnection()
         }
     }
 
@@ -634,9 +548,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Disconnect unexpectedly.
     /// This keeps auto-reconnect behavior enabled.
     func internal_disconnect() {
-        keepAliveController.stop()
-        autoReconnectController.beginUnexpectedDisconnect()
-        socket.disconnect()
+        core.disconnectUnexpectedly()
     }
 
     /// Pause auto-reconnect attempts without disabling `autoReconnect`.
@@ -644,7 +556,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Use this when the application knows reconnect attempts should not run yet,
     /// for example while waiting for network reachability to recover.
     public func pauseAutoReconnect() {
-        autoReconnectController.pause()
+        core.pauseAutoReconnect()
     }
 
     /// Resume auto-reconnect attempts after `pauseAutoReconnect()`.
@@ -652,32 +564,18 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// If an auto-reconnect attempt is pending, this schedules the next reconnect
     /// attempt immediately.
     public func resumeAutoReconnect() {
-        guard let schedule = autoReconnectController.resume(
-            connectionIsDisconnected: connState == .disconnected
-        ) else { return }
-        notifyAutoReconnectScheduled(schedule)
+        core.resumeAutoReconnect()
     }
 
     private func expected_disconnect() {
-        guard autoReconnectController.beginExpectedDisconnect() else { return }
-        keepAliveController.stop()
-        send(FrameDisconnect(), tag: -0xE0, disconnectAfterWriting: true)
+        core.disconnectExpectedly {
+            send(FrameDisconnect(), tag: -0xE0, disconnectAfterWriting: true)
+        }
     }
 
     /// Send a PING request to broker
     public func ping() {
-        keepAliveController.pingSent()
-        sendPing()
-    }
-
-    private func sendPing() {
-        printDebug("ping")
-        send(FramePingReq(), tag: -0xC0)
-
-        __delegate_queue { mqtt in
-            mqtt.delegate?.mqttDidPing(mqtt)
-            mqtt.didPing(mqtt)
-        }
+        core.ping()
     }
 
     /// Publish a message to broker
@@ -806,10 +704,10 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     }
 }
 
-// MARK: CocoaMQTTDeliverProtocol
-extension CocoaMQTT: CocoaMQTTDeliverProtocol {
+// MARK: Shared core delivery adapter
+extension CocoaMQTT {
 
-    func deliver(_ deliver: CocoaMQTTDeliver, didReject frame: Frame) {
+    func clientCore(_ core: MQTTClientCore, didReject frame: Frame) {
         guard let publish = frame as? FramePublish, !publish.isSessionRecovery else { return }
         clientStateLock.lock()
         sendingMessages.removeValue(forKey: publish.deliveryToken ?? UInt64(publish.msgid))
@@ -817,7 +715,7 @@ extension CocoaMQTT: CocoaMQTTDeliverProtocol {
         clientStateLock.unlock()
     }
 
-    func deliver(_ deliver: CocoaMQTTDeliver, wantToSend frame: Frame) {
+    func clientCore(_ core: MQTTClientCore, wantsToSend frame: Frame) {
         if let publish = frame as? FramePublish {
             let msgid = publish.msgid
             let deliveryToken = publish.deliveryToken ?? UInt64(msgid)
@@ -862,136 +760,86 @@ extension CocoaMQTT {
         completionOnEventLoop: ((CocoaMQTT) -> Void)? = nil,
         onDeallocated: (() -> Void)? = nil
     ) {
-        let callbackQueue = delegateQueue
-        callbackQueue.async { [weak self] in
-            guard let self = self else {
-                onDeallocated?()
-                return
-            }
-            fun(self)
-            guard let completionOnEventLoop = completionOnEventLoop else { return }
-            self.eventLoopQueue.async { [weak self] in
-                guard let self = self else { return }
-                completionOnEventLoop(self)
+        let coreCompletion = completionOnEventLoop.map { completion in
+            { (delegate: MQTTClientCoreDelegate) in
+                guard let mqtt = delegate as? CocoaMQTT else { return }
+                completion(mqtt)
             }
         }
-    }
-
-    private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
-        __delegate_queue { mqtt in
-            guard mqtt.autoReconnectController.isCurrent(schedule) else { return }
-            mqtt.delegate?.mqtt?(mqtt, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
-            mqtt.didScheduleReconnect(mqtt, schedule.attemptCount, schedule.interval)
-        }
+        core.dispatchCallback({ delegate in
+            guard let mqtt = delegate as? CocoaMQTT else { return }
+            fun(mqtt)
+        }, completionOnEventLoop: coreCompletion, onDeallocated: onDeallocated)
     }
 }
 
-extension CocoaMQTT: MQTTAutoReconnectControllerDelegate {
-    func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController) {
-        guard !connect(),
-              let schedule = controller.reconnectAttemptFailedToStart() else { return }
-        notifyAutoReconnectScheduled(schedule)
-    }
-}
-
-// MARK: - CocoaMQTTSocketDelegate
-extension CocoaMQTT: CocoaMQTTSocketDelegate {
-
-    public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
-        autoReconnectController.socketConnected()
+extension CocoaMQTT: MQTTClientCoreDelegate {
+    func clientCoreDidConnectTransport(_ core: MQTTClientCore) {
         sendConnectFrame()
     }
 
-    public func socket(_ socket: CocoaMQTTSocketProtocol,
-                       didReceive trust: SecTrust,
-                       completionHandler: @escaping (Bool) -> Swift.Void) {
-
+    func clientCore(
+        _ core: MQTTClientCore,
+        didReceive trust: SecTrust,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
         printDebug("Call the SSL/TLS manually validating function")
+        CocoaMQTTTrustHandling.resolveManualTrust(handler: { completion in
+            if delegate?.mqtt?(self, didReceive: trust, completionHandler: completion) != nil {
+                return true
+            }
+            guard let handler = customDidReceiveTrust else { return false }
+            handler(self, trust, completion)
+            return true
+        }, fallback: { completion in
+            CocoaMQTTServerTrustEvaluator.evaluate(
+                trust,
+                socket: core.socket,
+                defaultServerName: host,
+                completionHandler: completion
+            )
+        }, completionHandler: completionHandler)
+    }
 
-        __delegate_queue({ mqtt in
-            CocoaMQTTTrustHandling.resolveManualTrust(handler: { completion in
-                if mqtt.delegate?.mqtt?(mqtt, didReceive: trust, completionHandler: completion) != nil {
+    func clientCore(
+        _ core: MQTTClientCore,
+        didReceiveTrust trust: SecTrust,
+        challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
+        CocoaMQTTTrustHandling.resolveURLSessionChallenge(
+            urlSessionHandler: { completion in
+                delegate?.mqttUrlSession?(
+                    self,
+                    didReceiveTrust: trust,
+                    didReceiveChallenge: challenge,
+                    completionHandler: completion
+                ) != nil
+            },
+            legacyHandler: { completion in
+                if delegate?.mqtt?(self, didReceive: trust, completionHandler: completion) != nil {
                     return true
                 }
-                guard let handler = mqtt.customDidReceiveTrust else { return false }
-                handler(mqtt, trust, completion)
+                guard let handler = customDidReceiveTrust else { return false }
+                handler(self, trust, completion)
                 return true
-            }, fallback: { completion in
+            },
+            fallback: { completion in
                 CocoaMQTTServerTrustEvaluator.evaluate(
                     trust,
-                    socket: socket,
-                    defaultServerName: mqtt.host,
+                    socket: core.socket,
+                    defaultServerName: challenge.protectionSpace.host,
                     completionHandler: completion
                 )
-            }, completionHandler: completionHandler)
-        }, onDeallocated: { completionHandler(false) })
+            },
+            legacyCredential: URLCredential(trust: trust),
+            completionHandler: completionHandler
+        )
     }
 
-    public func socketUrlSession(_ socket: CocoaMQTTSocketProtocol, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
-
-        __delegate_queue({ mqtt in
-            CocoaMQTTTrustHandling.resolveURLSessionChallenge(
-                urlSessionHandler: { completion in
-                    mqtt.delegate?.mqttUrlSession?(
-                        mqtt,
-                        didReceiveTrust: trust,
-                        didReceiveChallenge: challenge,
-                        completionHandler: completion
-                    ) != nil
-                },
-                legacyHandler: { completion in
-                    if mqtt.delegate?.mqtt?(mqtt, didReceive: trust, completionHandler: completion) != nil {
-                        return true
-                    }
-                    guard let handler = mqtt.customDidReceiveTrust else { return false }
-                    handler(mqtt, trust, completion)
-                    return true
-                },
-                fallback: { completion in
-                    return CocoaMQTTServerTrustEvaluator.evaluate(
-                        trust,
-                        socket: socket,
-                        defaultServerName: challenge.protectionSpace.host,
-                        completionHandler: completion
-                    )
-                },
-                legacyCredential: URLCredential(trust: trust),
-                completionHandler: completionHandler
-            )
-        }, onDeallocated: { completionHandler(.cancelAuthenticationChallenge, nil) })
-    }
-
-    // ?
-    public func socketDidSecure(_ sock: MGCDAsyncSocket) {
-        printDebug("Socket has successfully completed SSL/TLS negotiation")
-        sendConnectFrame()
-    }
-
-    public func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {}
-
-    public func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {
-        let etag = CocoaMQTTReadTag(rawValue: tag)!
-        var bytes = [UInt8]([0])
-        switch etag {
-        case CocoaMQTTReadTag.header:
-            data.copyBytes(to: &bytes, count: 1)
-            reader!.headerReady(bytes[0])
-        case CocoaMQTTReadTag.length:
-            data.copyBytes(to: &bytes, count: 1)
-            reader!.lengthReady(bytes[0])
-        case CocoaMQTTReadTag.payload:
-            reader!.payloadReady(data)
-        }
-    }
-
-    public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
-        // Clean up
-        keepAliveController.stop()
-        socket.setDelegate(nil, delegateQueue: nil)
+    func clientCore(_ core: MQTTClientCore, willDisconnectWithError error: Error?) {
         clientStateLock.lock()
-        // Publish uses the same lock, so queue admission cannot race with the
-        // transition from the disconnected session to the next connection.
         deliver.beginConnection()
         clearPendingSubscriptionRequestsLocked()
         let pendingDeliveryTokens = Set(deliver.connectionPendingFrames().compactMap {
@@ -1005,20 +853,84 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
             discardInMemorySession(preservingConnectionQueue: true)
         }
         clientStateLock.unlock()
-        let reconnectContext = autoReconnectController.socketDidDisconnect()
-
-        connState = .disconnected
-        __delegate_queue({ mqtt in
-            mqtt.delegate?.mqttDidDisconnect(mqtt, withError: err)
-            mqtt.didDisconnect(mqtt, err)
-        }, completionOnEventLoop: { mqtt in
-            mqtt.continueAfterDisconnectCallbacks(reconnectContext)
-        })
     }
 
-    private func continueAfterDisconnectCallbacks(_ context: MQTTAutoReconnectDisconnectContext) {
-        guard let schedule = autoReconnectController.completeDisconnectCallbacks(context) else { return }
-        notifyAutoReconnectScheduled(schedule)
+    func clientCore(_ core: MQTTClientCore, didDisconnectWithError error: Error?) {
+        delegate?.mqttDidDisconnect(self, withError: error)
+        didDisconnect(self, error)
+    }
+
+    func clientCoreRequestsReconnect(_ core: MQTTClientCore) -> Bool {
+        connect()
+    }
+
+    func clientCoreRequestsPing(_ core: MQTTClientCore) -> Bool {
+        printDebug("ping")
+        return send(FramePingReq(), tag: -0xC0)
+    }
+
+    func clientCoreDidSendPing(_ core: MQTTClientCore) {
+        delegate?.mqttDidPing(self)
+        didPing(self)
+    }
+
+    func clientCore(_ core: MQTTClientCore, didChangeStateTo state: CocoaMQTTConnState) {
+        delegate?.mqtt?(self, didStateChangeTo: state)
+        didChangeState(self, state)
+    }
+
+    func clientCore(
+        _ core: MQTTClientCore,
+        didScheduleReconnect schedule: CocoaMQTTAutoReconnectSchedule
+    ) {
+        delegate?.mqtt?(self, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
+        didScheduleReconnect(self, schedule.attemptCount, schedule.interval)
+    }
+}
+
+// Keep the historical public socket-delegate conformance source-compatible.
+// The built-in transport is wired to `MQTTClientCore` directly.
+extension CocoaMQTT: CocoaMQTTSocketDelegate {
+    public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+        core.socketConnected(socket)
+    }
+
+    public func socket(
+        _ socket: CocoaMQTTSocketProtocol,
+        didReceive trust: SecTrust,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        core.socket(socket, didReceive: trust, completionHandler: completionHandler)
+    }
+
+    public func socketUrlSession(
+        _ socket: CocoaMQTTSocketProtocol,
+        didReceiveTrust trust: SecTrust,
+        didReceiveChallenge challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        core.socketUrlSession(
+            socket,
+            didReceiveTrust: trust,
+            didReceiveChallenge: challenge,
+            completionHandler: completionHandler
+        )
+    }
+
+    public func socketDidSecure(_ socket: MGCDAsyncSocket) {
+        core.socketDidSecure(socket)
+    }
+
+    public func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {
+        core.socket(socket, didWriteDataWithTag: tag)
+    }
+
+    public func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {
+        core.socket(socket, didRead: data, withTag: tag)
+    }
+
+    public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError error: Error?) {
+        core.socketDidDisconnect(socket, withError: error)
     }
 }
 
@@ -1032,7 +944,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
             // Disable auto-reconnect
 
-            autoReconnectController.connectionSucceeded()
+            core.connectionSucceeded()
 
             // recover session if enable
 
@@ -1065,7 +977,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
             deliver.completeConnection()
             connState = .connected
             // Start only after session recovery has completed and the client can send PINGREQ.
-            keepAliveController.start(interval: keepAlive)
+            core.startKeepAlive(interval: keepAlive)
 
         } else {
             connState = .disconnected
@@ -1219,7 +1131,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
 
     func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
-        keepAliveController.pingResponseReceived()
+        core.pingResponseReceived()
 
         __delegate_queue { mqtt in
             mqtt.delegate?.mqttDidReceivePong(mqtt)
@@ -1238,22 +1150,6 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
     }
 }
 
-extension CocoaMQTT: MQTTKeepAliveControllerDelegate {
-    func keepAliveControllerRequestsPing(_ controller: MQTTKeepAliveController) {
-        guard connState == .connected else {
-            controller.stop()
-            return
-        }
-        sendPing()
-    }
-
-    func keepAliveControllerDidTimeOut(_ controller: MQTTKeepAliveController) {
-        guard connState == .connected else { return }
-        printWarning("PINGRESP timed out, closing socket")
-        internal_disconnect()
-    }
-}
-
 // For tests
 extension CocoaMQTT {
     func t_sendingMessagesCount() -> Int {
@@ -1265,7 +1161,7 @@ extension CocoaMQTT {
     }
 
     func t_keepAliveInterval() -> TimeInterval? {
-        keepAliveController.interval
+        core.keepAliveInterval
     }
 
     func t_waitUntilDeliverIdle() {

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -210,30 +210,20 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Changing the queue affects callbacks emitted after the assignment; callbacks
     /// already submitted remain on the queue captured when their event occurred.
     public var delegateQueue: DispatchQueue {
-        get {
-            delegateQueueLock.lock()
-            defer { delegateQueueLock.unlock() }
-            return _delegateQueue
-        }
-        set {
-            delegateQueueLock.lock()
-            _delegateQueue = newValue
-            delegateQueueLock.unlock()
-        }
+        get { core.delegateQueue }
+        set { core.delegateQueue = newValue }
     }
-    private let delegateQueueLock = NSLock()
-    private var _delegateQueue = DispatchQueue.main
 
     /// Owns ordered socket, reader, timer, and delivery events. Application code
     /// cannot replace this queue through `delegateQueue`.
-    let eventLoopQueue: DispatchQueue
-    private var socketDelegateProxy: CocoaMQTTSocketDelegateProxy!
+    var eventLoopQueue: DispatchQueue { core.eventLoopQueue }
+    private var core: MQTTClientCore!
 
     @ConcurrentAtomic(wrappedValue: CocoaMQTTConnState.disconnected, label: "CocoaMQTT5.connState")
     public var connState
 
     // deliver
-    private var deliver = CocoaMQTTDeliver()
+    private var deliver: CocoaMQTTDeliver { core.deliver }
 
     /// Retained for source compatibility. MQTT 5 retransmits unacknowledged
     /// messages only when a persistent session is resumed, so this value does
@@ -259,7 +249,6 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Keep alive time interval
     public var keepAlive: UInt16 = 60
-    private let keepAliveController: MQTTKeepAliveController
 
     /// Maximum duration in seconds for each Remaining Length byte and the complete payload read.
     /// Each deadline starts with its read and is not reset by partial data. Header reads remain unlimited.
@@ -269,8 +258,8 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Enable auto-reconnect mechanism
     public var autoReconnect: Bool {
-        get { autoReconnectController.isEnabled }
-        set { autoReconnectController.isEnabled = newValue }
+        get { core.autoReconnect }
+        set { core.autoReconnect = newValue }
     }
 
     /// Reconnect time interval
@@ -278,8 +267,8 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// - note: This value will be increased with `autoReconnectTimeInterval *= 2`
     ///         if reconnect failed
     public var autoReconnectTimeInterval: UInt16 {
-        get { autoReconnectController.autoReconnectTimeInterval }
-        set { autoReconnectController.autoReconnectTimeInterval = newValue }
+        get { core.autoReconnectTimeInterval }
+        set { core.autoReconnectTimeInterval = newValue }
     }
 
     /// Maximum auto reconnect time interval
@@ -287,8 +276,8 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// The timer starts from `autoReconnectTimeInterval` second and grows exponentially until this value
     /// After that, it uses this value for subsequent requests.
     public var maxAutoReconnectTimeInterval: UInt16 {
-        get { autoReconnectController.maxAutoReconnectTimeInterval }
-        set { autoReconnectController.maxAutoReconnectTimeInterval = newValue }
+        get { core.maxAutoReconnectTimeInterval }
+        set { core.maxAutoReconnectTimeInterval = newValue }
     }
 
     /// 3.1.2.11 CONNECT Properties
@@ -301,19 +290,17 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     ///
     /// This value is advanced for the next reconnect attempt while auto-reconnect is active,
     /// and resets to `0` when auto-reconnect is inactive.
-    public var reconnectTimeInterval: UInt16 { autoReconnectController.reconnectTimeInterval }
+    public var reconnectTimeInterval: UInt16 { core.reconnectTimeInterval }
 
     /// Number of reconnect attempts scheduled in the current auto-reconnect cycle.
     ///
     /// The value resets to `0` after a successful connection or expected disconnect.
-    public var reconnectAttemptCount: UInt { autoReconnectController.reconnectAttemptCount }
+    public var reconnectAttemptCount: UInt { core.reconnectAttemptCount }
 
     /// Whether auto-reconnect is currently paused by the application.
     public var isAutoReconnectPaused: Bool {
-        autoReconnectController.isPaused
+        core.isAutoReconnectPaused
     }
-
-    private let autoReconnectController: MQTTAutoReconnectController
     private let disconnectReasonLock = NSLock()
     private var pendingLocalDisconnectReasonCode: CocoaMQTTDISCONNECTReasonCode?
     private var _lastDisconnectReason: CocoaMQTT5DisconnectReason?
@@ -330,7 +317,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     private var sessionExpiryControllerClientID: String?
     private var sessionExpiryControllers = [String: MQTT5SessionExpiryController]()
     private var activeClientID: String
-    private let clientStateLock = NSRecursiveLock()
+    private var clientStateLock: NSRecursiveLock { core.lifecycleLock }
     private var serverMaximumQoS = CocoaMQTTQoS.qos2
     private var serverRetainAvailable = true
     private var serverMaximumPacketSize = UInt32.max
@@ -360,8 +347,8 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Enable SSL connection
     public var enableSSL: Bool {
-        get { return self.socket.enableSSL }
-        set { socket.enableSSL = newValue }
+        get { core.enableSSL }
+        set { core.enableSSL = newValue }
     }
 
     ///
@@ -424,11 +411,9 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Sending messages
     fileprivate var sendingMessages = ThreadSafeDictionary<UInt64, CocoaMQTT5Message>(label: "sendingMessages5")
 
-    private let packetIdentifiers = MQTTPacketIdentifierAllocator()
-    private var _deliveryToken = UInt64(UInt16.max)
-    private let messageIdentifierLock = NSLock()
-    fileprivate var socket: CocoaMQTTSocketProtocol
-    fileprivate var reader: CocoaMQTTReader?
+    private var packetIdentifiers: MQTTPacketIdentifierAllocator { core.packetIdentifiers }
+    fileprivate var socket: CocoaMQTTSocketProtocol { core.socket }
+    fileprivate var reader: CocoaMQTTReader? { core.reader }
 
     // Closures
     public var didConnectAck: (CocoaMQTT5, CocoaMQTTCONNACKReasonCode, MqttDecodeConnAck?) -> Void = { _, _, _ in }
@@ -464,55 +449,34 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         self.activeClientID = clientID
         self.host = host
         self.port = port
-        self.socket = socket
-        let eventLoopQueue = DispatchQueue(label: "io.emqx.CocoaMQTT5.event-loop.\(UUID().uuidString)")
-        self.eventLoopQueue = eventLoopQueue
-        self.autoReconnectController = MQTTAutoReconnectController(eventLoopQueue: eventLoopQueue)
-        self.keepAliveController = MQTTKeepAliveController(eventLoopQueue: eventLoopQueue)
         super.init()
-        autoReconnectController.delegate = self
-        keepAliveController.delegate = self
-        socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
-        socketDelegateProxy.delegate = self
-        $connState.setMutationObserver { [weak self] state in
-            guard let self = self else { return }
-            self.__delegate_queue { mqtt5 in
-                mqtt5.delegate?.mqtt5?(mqtt5, didStateChangeTo: state)
-                mqtt5.didChangeState(mqtt5, state)
-            }
-        }
+        core = MQTTClientCore(
+            socket: socket,
+            state: $connState,
+            protocolVersion: .v5,
+            queueLabel: "io.emqx.CocoaMQTT5.event-loop.\(UUID().uuidString)"
+        )
+        core.delegate = self
         configureSessionExpiryController(for: clientID)
-        deliver.protocolVersion = .v5
-        deliver.delegate = self
     }
 
     deinit {
-        keepAliveController.stop()
         sessionExpiryController?.handleDisconnect()
-        socket.disconnectForClientDeinit()
     }
 
     @discardableResult
     fileprivate func send(_ frame: Frame, tag: Int = 0, disconnectAfterWriting: Bool = false) -> Bool {
-        printDebug("SEND: \(frame)")
-        let data = frame.bytes(version: version)
-
         clientStateLock.lock()
         let maximumPacketSize = serverMaximumPacketSize
         clientStateLock.unlock()
-        guard UInt64(data.count) <= UInt64(maximumPacketSize) else {
-            printError("Packet exceeds the server Maximum Packet Size: \(frame)")
-            return false
-        }
-
-        let packet = Data(bytes: data, count: data.count)
-        let writeTimeout = socketWriteTimeout
-        if disconnectAfterWriting {
-            socket.writeAndDisconnect(packet, withTimeout: writeTimeout, tag: tag)
-        } else {
-            socket.write(packet, withTimeout: writeTimeout, tag: tag)
-        }
-        return true
+        return core.send(
+            frame,
+            version: version,
+            timeout: socketWriteTimeout,
+            maximumPacketSize: maximumPacketSize,
+            tag: tag,
+            disconnectAfterWriting: disconnectAfterWriting
+        )
     }
 
     fileprivate func sendConnectFrame() {
@@ -543,18 +507,11 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
 
     fileprivate func nextDeliveryToken() -> UInt64 {
-        messageIdentifierLock.lock()
-        defer { messageIdentifierLock.unlock() }
-        if _deliveryToken >= UInt64(Int.max) {
-            _deliveryToken = UInt64(UInt16.max) + 1
-        } else {
-            _deliveryToken += 1
-        }
-        return _deliveryToken
+        core.nextDeliveryToken()
     }
 
     fileprivate func discardStoredSession() {
-        CocoaMQTTStorage(by: activeClientID, protocolVersion: .v5)?.removeAll()
+        core.discardStoredSession(clientID: activeClientID, protocolVersion: .v5)
     }
 
     private func discardCurrentSession(preservingConnectionQueue: Bool = false) {
@@ -565,39 +522,18 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
 
     private func discardInMemorySession(preservingConnectionQueue: Bool = false) {
-        let pendingPublishes = preservingConnectionQueue
-            ? deliver.connectionPendingFrames().compactMap { $0 as? FramePublish }
-            : []
-        deliver.cleanAll(
-            detachStorage: true,
-            preserveConnectionQueue: preservingConnectionQueue
-        )
-        if preservingConnectionQueue {
-            let pendingTokens = Set(pendingPublishes.map { $0.deliveryToken ?? UInt64($0.msgid) })
-            sendingMessages.replace(with: sendingMessages.snapshot().filter { pendingTokens.contains($0.key) })
-        } else {
-            sendingMessages.removeAll()
-        }
-        subscriptionsWaitingAck.removeAll()
-        unsubscriptionsWaitingAck.removeAll()
-        subscriptions.removeAll()
-        packetIdentifiers.reset()
-        for publish in pendingPublishes where publish.qos > .qos0 {
-            packetIdentifiers.markInUse(publish.msgid)
+        core.discardInMemorySession(
+            preservingConnectionQueue: preservingConnectionQueue,
+            sendingMessages: sendingMessages,
+            subscriptionsWaitingAck: subscriptionsWaitingAck,
+            unsubscriptionsWaitingAck: unsubscriptionsWaitingAck
+        ) {
+            subscriptions.removeAll()
         }
     }
 
     private func markStoredPacketIdentifiersInUse() {
-        guard let frames = CocoaMQTTStorage(by: activeClientID, protocolVersion: .v5)?.readAll() else {
-            return
-        }
-        for frame in frames {
-            if let publish = frame as? FramePublish {
-                packetIdentifiers.markInUse(publish.msgid)
-            } else if let pubrel = frame as? FramePubRel {
-                packetIdentifiers.markInUse(pubrel.msgid)
-            }
-        }
+        core.markStoredPacketIdentifiersInUse(clientID: activeClientID, protocolVersion: .v5)
     }
 
     private func configureSessionExpiryController(for clientID: String) {
@@ -627,12 +563,10 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     /// Callers must hold `clientStateLock`.
     private func clearPendingSubscriptionRequestsLocked() {
-        for identifier in subscriptionsWaitingAck.removeAllValues().keys {
-            packetIdentifiers.release(identifier)
-        }
-        for identifier in unsubscriptionsWaitingAck.removeAllValues().keys {
-            packetIdentifiers.release(identifier)
-        }
+        core.clearPendingPacketIdentifiers(
+            subscriptionsWaitingAck: subscriptionsWaitingAck,
+            unsubscriptionsWaitingAck: unsubscriptionsWaitingAck
+        )
     }
 
     /// Restore values that apply before a server has negotiated limits for a
@@ -697,44 +631,27 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
         }
         // Publish uses the same lock, so pausing transport and starting the
         // connection queue are atomic relative to queue admission.
-        clientStateLock.lock()
-        deliver.setTransportEnabled(false)
-        if activeClientID != clientID {
-            discardInMemorySession()
-        }
-        activeClientID = clientID
-        resetServerCapabilities()
-        topicAliases.clear()
-        configureSessionExpiryController(for: activeClientID)
-        markStoredPacketIdentifiersInUse()
-        deliver.beginConnection()
-        clientStateLock.unlock()
         resetDisconnectReasonState()
         sessionExpiryController?.prepareStoredSessionForConnect()
-        socket.setDelegate(socketDelegateProxy, delegateQueue: eventLoopQueue)
-        reader = CocoaMQTTReader(
-            socket: socket,
-            delegate: self,
+        return core.connect(
+            host: host,
+            port: port,
+            timeout: timeout,
             protocolVersion: .v5,
             maximumPacketSize: connectProperties?.maximumPacketSize,
-            packetReadTimeout: packetReadTimeout
-        )
-        do {
-            if timeout > 0 {
-                try socket.connect(toHost: self.host, onPort: self.port, withTimeout: timeout)
-            } else {
-                try socket.connect(toHost: self.host, onPort: self.port)
+            packetReadTimeout: packetReadTimeout,
+            readerDelegate: self
+        ) {
+            deliver.setTransportEnabled(false)
+            if activeClientID != clientID {
+                discardInMemorySession()
             }
-
-            eventLoopQueue.async { [weak self] in
-                guard let self = self else { return }
-                self.connState = .connecting
-            }
-
-            return true
-        } catch let error as NSError {
-            printError("socket connect error: \(error.description)")
-            return false
+            activeClientID = clientID
+            resetServerCapabilities()
+            topicAliases.clear()
+            configureSessionExpiryController(for: activeClientID)
+            markStoredPacketIdentifiersInUse()
+            deliver.beginConnection()
         }
     }
 
@@ -757,9 +674,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Disconnect unexpectedly.
     /// This keeps auto-reconnect behavior enabled.
     func internal_disconnect() {
-        keepAliveController.stop()
-        autoReconnectController.beginUnexpectedDisconnect()
-        socket.disconnect()
+        core.disconnectUnexpectedly()
     }
 
     /// Pause auto-reconnect attempts without disabling `autoReconnect`.
@@ -767,7 +682,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// Use this when the application knows reconnect attempts should not run yet,
     /// for example while waiting for network reachability to recover.
     public func pauseAutoReconnect() {
-        autoReconnectController.pause()
+        core.pauseAutoReconnect()
     }
 
     /// Resume auto-reconnect attempts after `pauseAutoReconnect()`.
@@ -775,10 +690,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// If an auto-reconnect attempt is pending, this schedules the next reconnect
     /// attempt immediately.
     public func resumeAutoReconnect() {
-        guard let schedule = autoReconnectController.resume(
-            connectionIsDisconnected: connState == .disconnected
-        ) else { return }
-        notifyAutoReconnectScheduled(schedule)
+        core.resumeAutoReconnect()
     }
 
     func internal_disconnect_withProperties(reasonCode: CocoaMQTTDISCONNECTReasonCode, userProperties: [String: String] ) {
@@ -788,35 +700,20 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     private func expected_disconnect(reasonCode: CocoaMQTTDISCONNECTReasonCode,
                                      userProperties: [String: String]? = nil,
                                      recordsLocalReason: Bool = false) {
-        guard autoReconnectController.beginExpectedDisconnect() else { return }
-        keepAliveController.stop()
-        if recordsLocalReason {
-            markPendingLocalDisconnect(reasonCode: reasonCode)
-        }
-        var frameDisconnect = FrameDisconnect(disconnectReasonCode: reasonCode)
-        frameDisconnect.userProperties = userProperties ?? [:]
-        guard send(frameDisconnect, tag: -0xE0, disconnectAfterWriting: true) else {
-            socket.disconnect()
-            return
-        }
+        core.disconnectExpectedly(prepare: {
+            if recordsLocalReason {
+                markPendingLocalDisconnect(reasonCode: reasonCode)
+            }
+        }, sendDisconnect: {
+            var frameDisconnect = FrameDisconnect(disconnectReasonCode: reasonCode)
+            frameDisconnect.userProperties = userProperties ?? [:]
+            return send(frameDisconnect, tag: -0xE0, disconnectAfterWriting: true)
+        })
     }
+
     /// Send a PING request to broker
     public func ping() {
-        keepAliveController.pingSent()
-        sendPing()
-    }
-
-    private func sendPing() {
-        printDebug("ping")
-        guard send(FramePingReq(), tag: -0xC0) else {
-            internal_disconnect()
-            return
-        }
-
-        __delegate_queue { mqtt5 in
-            mqtt5.delegate?.mqtt5DidPing(mqtt5)
-            mqtt5.didPing(mqtt5)
-        }
+        core.ping()
     }
 
     /// Publish a message to broker
@@ -1070,10 +967,10 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
 }
 
-// MARK: CocoaMQTTDeliverProtocol
-extension CocoaMQTT5: CocoaMQTTDeliverProtocol {
+// MARK: Shared core delivery adapter
+extension CocoaMQTT5 {
 
-    func deliver(_ deliver: CocoaMQTTDeliver, didReject frame: Frame) {
+    func clientCore(_ core: MQTTClientCore, didReject frame: Frame) {
         guard let publish = frame as? FramePublish, !publish.isSessionRecovery else { return }
         clientStateLock.lock()
         sendingMessages.removeValue(forKey: publish.deliveryToken ?? UInt64(publish.msgid))
@@ -1081,7 +978,7 @@ extension CocoaMQTT5: CocoaMQTTDeliverProtocol {
         clientStateLock.unlock()
     }
 
-    func deliver(_ deliver: CocoaMQTTDeliver, wantToSend frame: Frame) {
+    func clientCore(_ core: MQTTClientCore, wantsToSend frame: Frame) {
         if let publish = frame as? FramePublish {
             let msgid = publish.msgid
             let deliveryToken = publish.deliveryToken ?? UInt64(msgid)
@@ -1129,28 +1026,18 @@ extension CocoaMQTT5 {
         completionOnEventLoop: ((CocoaMQTT5) -> Void)? = nil,
         onDeallocated: (() -> Void)? = nil
     ) {
-        let callbackQueue = delegateQueue
-        callbackQueue.async { [weak self] in
-            guard let self = self else {
-                onDeallocated?()
-                return
-            }
-            fun(self)
-            guard let completionOnEventLoop = completionOnEventLoop else { return }
-            self.eventLoopQueue.async { [weak self] in
-                guard let self = self else { return }
-                completionOnEventLoop(self)
+        let coreCompletion = completionOnEventLoop.map { completion in
+            { (delegate: MQTTClientCoreDelegate) in
+                guard let mqtt5 = delegate as? CocoaMQTT5 else { return }
+                completion(mqtt5)
             }
         }
+        core.dispatchCallback({ delegate in
+            guard let mqtt5 = delegate as? CocoaMQTT5 else { return }
+            fun(mqtt5)
+        }, completionOnEventLoop: coreCompletion, onDeallocated: onDeallocated)
     }
 
-    private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
-        __delegate_queue { mqtt5 in
-            guard mqtt5.autoReconnectController.isCurrent(schedule) else { return }
-            mqtt5.delegate?.mqtt5?(mqtt5, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
-            mqtt5.didScheduleReconnect(mqtt5, schedule.attemptCount, schedule.interval)
-        }
-    }
     private func resetDisconnectReasonState() {
         disconnectReasonLock.lock()
         pendingLocalDisconnectReasonCode = nil
@@ -1189,112 +1076,73 @@ extension CocoaMQTT5 {
     }
 }
 
-extension CocoaMQTT5: MQTTAutoReconnectControllerDelegate {
-    func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController) {
-        guard !connect(),
-              let schedule = controller.reconnectAttemptFailedToStart() else { return }
-        notifyAutoReconnectScheduled(schedule)
-    }
-}
-
-// MARK: - CocoaMQTTSocketDelegate
-extension CocoaMQTT5: CocoaMQTTSocketDelegate {
-
-    public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
-        autoReconnectController.socketConnected()
+extension CocoaMQTT5: MQTTClientCoreDelegate {
+    func clientCoreDidConnectTransport(_ core: MQTTClientCore) {
         sendConnectFrame()
     }
 
-    public func socket(_ socket: CocoaMQTTSocketProtocol,
-                       didReceive trust: SecTrust,
-                       completionHandler: @escaping (Bool) -> Swift.Void) {
-
+    func clientCore(
+        _ core: MQTTClientCore,
+        didReceive trust: SecTrust,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
         printDebug("Call the SSL/TLS manually validating function")
+        CocoaMQTTTrustHandling.resolveManualTrust(handler: { completion in
+            if delegate?.mqtt5?(self, didReceive: trust, completionHandler: completion) != nil {
+                return true
+            }
+            guard let handler = customDidReceiveTrust else { return false }
+            handler(self, trust, completion)
+            return true
+        }, fallback: { completion in
+            CocoaMQTTServerTrustEvaluator.evaluate(
+                trust,
+                socket: core.socket,
+                defaultServerName: host,
+                completionHandler: completion
+            )
+        }, completionHandler: completionHandler)
+    }
 
-        __delegate_queue({ mqtt5 in
-            CocoaMQTTTrustHandling.resolveManualTrust(handler: { completion in
-                if mqtt5.delegate?.mqtt5?(mqtt5, didReceive: trust, completionHandler: completion) != nil {
+    func clientCore(
+        _ core: MQTTClientCore,
+        didReceiveTrust trust: SecTrust,
+        challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
+        CocoaMQTTTrustHandling.resolveURLSessionChallenge(
+            urlSessionHandler: { completion in
+                delegate?.mqtt5UrlSession?(
+                    self,
+                    didReceiveTrust: trust,
+                    didReceiveChallenge: challenge,
+                    completionHandler: completion
+                ) != nil
+            },
+            legacyHandler: { completion in
+                if delegate?.mqtt5?(self, didReceive: trust, completionHandler: completion) != nil {
                     return true
                 }
-                guard let handler = mqtt5.customDidReceiveTrust else { return false }
-                handler(mqtt5, trust, completion)
+                guard let handler = customDidReceiveTrust else { return false }
+                handler(self, trust, completion)
                 return true
-            }, fallback: { completion in
+            },
+            fallback: { completion in
                 CocoaMQTTServerTrustEvaluator.evaluate(
                     trust,
-                    socket: socket,
-                    defaultServerName: mqtt5.host,
+                    socket: core.socket,
+                    defaultServerName: challenge.protectionSpace.host,
                     completionHandler: completion
                 )
-            }, completionHandler: completionHandler)
-        }, onDeallocated: { completionHandler(false) })
+            },
+            legacyCredential: URLCredential(trust: trust),
+            completionHandler: completionHandler
+        )
     }
 
-    public func socketUrlSession(_ socket: CocoaMQTTSocketProtocol, didReceiveTrust trust: SecTrust, didReceiveChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        printDebug("Call the SSL/TLS manually validating function - socketUrlSession")
-
-        __delegate_queue({ mqtt5 in
-            CocoaMQTTTrustHandling.resolveURLSessionChallenge(
-                urlSessionHandler: { completion in
-                    mqtt5.delegate?.mqtt5UrlSession?(
-                        mqtt5,
-                        didReceiveTrust: trust,
-                        didReceiveChallenge: challenge,
-                        completionHandler: completion
-                    ) != nil
-                },
-                legacyHandler: { completion in
-                    if mqtt5.delegate?.mqtt5?(mqtt5, didReceive: trust, completionHandler: completion) != nil {
-                        return true
-                    }
-                    guard let handler = mqtt5.customDidReceiveTrust else { return false }
-                    handler(mqtt5, trust, completion)
-                    return true
-                },
-                fallback: { completion in
-                    return CocoaMQTTServerTrustEvaluator.evaluate(
-                        trust,
-                        socket: socket,
-                        defaultServerName: challenge.protectionSpace.host,
-                        completionHandler: completion
-                    )
-                },
-                legacyCredential: URLCredential(trust: trust),
-                completionHandler: completionHandler
-            )
-        }, onDeallocated: { completionHandler(.cancelAuthenticationChallenge, nil) })
-    }
-
-    // ?
-    public func socketDidSecure(_ sock: MGCDAsyncSocket) {
-        printDebug("Socket has successfully completed SSL/TLS negotiation")
-        sendConnectFrame()
-    }
-
-    public func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {}
-
-    public func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {
-        let etag = CocoaMQTTReadTag(rawValue: tag)!
-        var bytes = [UInt8]([0])
-        switch etag {
-        case CocoaMQTTReadTag.header:
-            data.copyBytes(to: &bytes, count: 1)
-            reader!.headerReady(bytes[0])
-        case CocoaMQTTReadTag.length:
-            data.copyBytes(to: &bytes, count: 1)
-            reader!.lengthReady(bytes[0])
-        case CocoaMQTTReadTag.payload:
-            reader!.payloadReady(data)
-        }
-    }
-
-    public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError err: Error?) {
-        // Clean up
-        keepAliveController.stop()
-        socket.setDelegate(nil, delegateQueue: nil)
+    func clientCore(_ core: MQTTClientCore, willDisconnectWithError error: Error?) {
         clientStateLock.lock()
-        // Publish uses the same lock, so no frame can enter the new connection
-        // queue while it still observes aliases or limits from the old one.
         deliver.beginConnection()
         topicAliases.clear()
         resetServerCapabilities()
@@ -1308,21 +1156,85 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         }
         clientStateLock.unlock()
         sessionExpiryController?.handleDisconnect()
-        updateDisconnectReasonAfterSocketDisconnect(error: err)
-        let reconnectContext = autoReconnectController.socketDidDisconnect()
-
-        connState = .disconnected
-        __delegate_queue({ mqtt5 in
-            mqtt5.delegate?.mqtt5DidDisconnect(mqtt5, withError: err)
-            mqtt5.didDisconnect(mqtt5, err)
-        }, completionOnEventLoop: { mqtt5 in
-            mqtt5.continueAfterDisconnectCallbacks(reconnectContext)
-        })
+        updateDisconnectReasonAfterSocketDisconnect(error: error)
     }
 
-    private func continueAfterDisconnectCallbacks(_ context: MQTTAutoReconnectDisconnectContext) {
-        guard let schedule = autoReconnectController.completeDisconnectCallbacks(context) else { return }
-        notifyAutoReconnectScheduled(schedule)
+    func clientCore(_ core: MQTTClientCore, didDisconnectWithError error: Error?) {
+        delegate?.mqtt5DidDisconnect(self, withError: error)
+        didDisconnect(self, error)
+    }
+
+    func clientCoreRequestsReconnect(_ core: MQTTClientCore) -> Bool {
+        connect()
+    }
+
+    func clientCoreRequestsPing(_ core: MQTTClientCore) -> Bool {
+        printDebug("ping")
+        return send(FramePingReq(), tag: -0xC0)
+    }
+
+    func clientCoreDidSendPing(_ core: MQTTClientCore) {
+        delegate?.mqtt5DidPing(self)
+        didPing(self)
+    }
+
+    func clientCore(_ core: MQTTClientCore, didChangeStateTo state: CocoaMQTTConnState) {
+        delegate?.mqtt5?(self, didStateChangeTo: state)
+        didChangeState(self, state)
+    }
+
+    func clientCore(
+        _ core: MQTTClientCore,
+        didScheduleReconnect schedule: CocoaMQTTAutoReconnectSchedule
+    ) {
+        delegate?.mqtt5?(self, didScheduleReconnect: schedule.attemptCount, after: schedule.interval)
+        didScheduleReconnect(self, schedule.attemptCount, schedule.interval)
+    }
+}
+
+// Keep the historical public socket-delegate conformance source-compatible.
+// The built-in transport is wired to `MQTTClientCore` directly.
+extension CocoaMQTT5: CocoaMQTTSocketDelegate {
+    public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+        core.socketConnected(socket)
+    }
+
+    public func socket(
+        _ socket: CocoaMQTTSocketProtocol,
+        didReceive trust: SecTrust,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        core.socket(socket, didReceive: trust, completionHandler: completionHandler)
+    }
+
+    public func socketUrlSession(
+        _ socket: CocoaMQTTSocketProtocol,
+        didReceiveTrust trust: SecTrust,
+        didReceiveChallenge challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        core.socketUrlSession(
+            socket,
+            didReceiveTrust: trust,
+            didReceiveChallenge: challenge,
+            completionHandler: completionHandler
+        )
+    }
+
+    public func socketDidSecure(_ socket: MGCDAsyncSocket) {
+        core.socketDidSecure(socket)
+    }
+
+    public func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {
+        core.socket(socket, didWriteDataWithTag: tag)
+    }
+
+    public func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {
+        core.socket(socket, didRead: data, withTag: tag)
+    }
+
+    public func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError error: Error?) {
+        core.socketDidDisconnect(socket, withError: error)
     }
 }
 
@@ -1409,7 +1321,7 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
             // Disable auto-reconnect
 
-            autoReconnectController.connectionSucceeded()
+            core.connectionSucceeded()
 
             let negotiatedKeepAlive = properties?.serverKeepAlive ?? keepAlive
 
@@ -1452,7 +1364,7 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             deliver.completeConnection()
             connState = .connected
             // Start only after session recovery has completed and the client can send PINGREQ.
-            keepAliveController.start(interval: negotiatedKeepAlive)
+            core.startKeepAlive(interval: negotiatedKeepAlive)
 
         } else {
             connState = .disconnected
@@ -1656,28 +1568,12 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
 
     func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
-        keepAliveController.pingResponseReceived()
+        core.pingResponseReceived()
 
         __delegate_queue { mqtt5 in
             mqtt5.delegate?.mqtt5DidReceivePong(mqtt5)
             mqtt5.didReceivePong(mqtt5)
         }
-    }
-}
-
-extension CocoaMQTT5: MQTTKeepAliveControllerDelegate {
-    func keepAliveControllerRequestsPing(_ controller: MQTTKeepAliveController) {
-        guard connState == .connected else {
-            controller.stop()
-            return
-        }
-        sendPing()
-    }
-
-    func keepAliveControllerDidTimeOut(_ controller: MQTTKeepAliveController) {
-        guard connState == .connected else { return }
-        printWarning("PINGRESP timed out, closing socket")
-        internal_disconnect()
     }
 }
 
@@ -1692,7 +1588,7 @@ extension CocoaMQTT5 {
     }
 
     func t_keepAliveInterval() -> TimeInterval? {
-        keepAliveController.interval
+        core.keepAliveInterval
     }
 
     func t_sessionExpiryControllerCount() -> Int {

--- a/Source/MQTTClientCore.swift
+++ b/Source/MQTTClientCore.swift
@@ -1,0 +1,491 @@
+//
+//  MQTTClientCore.swift
+//  CocoaMQTT
+//
+
+import Foundation
+import Security
+import MqttCocoaAsyncSocket
+
+protocol MQTTClientCoreDelegate: AnyObject {
+    func clientCoreDidConnectTransport(_ core: MQTTClientCore)
+    func clientCore(
+        _ core: MQTTClientCore,
+        didReceive trust: SecTrust,
+        completionHandler: @escaping (Bool) -> Void
+    )
+    func clientCore(
+        _ core: MQTTClientCore,
+        didReceiveTrust trust: SecTrust,
+        challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    )
+    func clientCore(_ core: MQTTClientCore, willDisconnectWithError error: Error?)
+    func clientCore(_ core: MQTTClientCore, didDisconnectWithError error: Error?)
+    func clientCoreRequestsReconnect(_ core: MQTTClientCore) -> Bool
+    func clientCoreRequestsPing(_ core: MQTTClientCore) -> Bool
+    func clientCoreDidSendPing(_ core: MQTTClientCore)
+    func clientCore(_ core: MQTTClientCore, didReject frame: Frame)
+    func clientCore(_ core: MQTTClientCore, wantsToSend frame: Frame)
+    func clientCore(_ core: MQTTClientCore, didChangeStateTo state: CocoaMQTTConnState)
+    func clientCore(
+        _ core: MQTTClientCore,
+        didScheduleReconnect schedule: CocoaMQTTAutoReconnectSchedule
+    )
+}
+
+/// Owns the protocol-neutral connection lifecycle shared by the MQTT 3.1.1
+/// and MQTT 5 public facades. Protocol frames and session rules stay in the
+/// facade and enter this core through the typed delegate boundary above.
+final class MQTTClientCore {
+    weak var delegate: MQTTClientCoreDelegate?
+
+    let eventLoopQueue: DispatchQueue
+    let lifecycleLock = NSRecursiveLock()
+    var socket: CocoaMQTTSocketProtocol
+    let deliver: CocoaMQTTDeliver
+    let packetIdentifiers = MQTTPacketIdentifierAllocator()
+
+    private(set) var reader: CocoaMQTTReader?
+    private let connectionState: ConcurrentAtomic<CocoaMQTTConnState>
+    private let autoReconnectController: MQTTAutoReconnectController
+    private let keepAliveController: MQTTKeepAliveController
+    private let socketDelegateProxy: CocoaMQTTSocketDelegateProxy
+    private let delegateQueueLock = NSLock()
+    private let deliveryTokenLock = NSLock()
+    private var storedDelegateQueue = DispatchQueue.main
+    private var deliveryToken = UInt64(UInt16.max)
+
+    var delegateQueue: DispatchQueue {
+        get {
+            delegateQueueLock.lock()
+            defer { delegateQueueLock.unlock() }
+            return storedDelegateQueue
+        }
+        set {
+            delegateQueueLock.lock()
+            storedDelegateQueue = newValue
+            delegateQueueLock.unlock()
+        }
+    }
+
+    var state: CocoaMQTTConnState {
+        get { connectionState.wrappedValue }
+        set { connectionState.wrappedValue = newValue }
+    }
+
+    var enableSSL: Bool {
+        get { socket.enableSSL }
+        set { socket.enableSSL = newValue }
+    }
+
+    var autoReconnect: Bool {
+        get { autoReconnectController.isEnabled }
+        set { autoReconnectController.isEnabled = newValue }
+    }
+
+    var autoReconnectTimeInterval: UInt16 {
+        get { autoReconnectController.autoReconnectTimeInterval }
+        set { autoReconnectController.autoReconnectTimeInterval = newValue }
+    }
+
+    var maxAutoReconnectTimeInterval: UInt16 {
+        get { autoReconnectController.maxAutoReconnectTimeInterval }
+        set { autoReconnectController.maxAutoReconnectTimeInterval = newValue }
+    }
+
+    var reconnectTimeInterval: UInt16 { autoReconnectController.reconnectTimeInterval }
+    var reconnectAttemptCount: UInt { autoReconnectController.reconnectAttemptCount }
+    var isAutoReconnectPaused: Bool { autoReconnectController.isPaused }
+    var keepAliveInterval: TimeInterval? { keepAliveController.interval }
+
+    init(
+        socket: CocoaMQTTSocketProtocol,
+        state: ConcurrentAtomic<CocoaMQTTConnState>,
+        protocolVersion: CocoaMQTTProtocolVersion,
+        queueLabel: String
+    ) {
+        self.socket = socket
+        self.connectionState = state
+        let deliver = CocoaMQTTDeliver()
+        deliver.protocolVersion = protocolVersion
+        self.deliver = deliver
+        let eventLoopQueue = DispatchQueue(label: queueLabel)
+        self.eventLoopQueue = eventLoopQueue
+        self.autoReconnectController = MQTTAutoReconnectController(eventLoopQueue: eventLoopQueue)
+        self.keepAliveController = MQTTKeepAliveController(eventLoopQueue: eventLoopQueue)
+        self.socketDelegateProxy = CocoaMQTTSocketDelegateProxy(eventLoopQueue: eventLoopQueue)
+        autoReconnectController.delegate = self
+        keepAliveController.delegate = self
+        socketDelegateProxy.delegate = self
+        deliver.delegate = self
+        connectionState.setMutationObserver { [weak self] state in
+            guard let self else { return }
+            self.dispatchCallback { [weak self] delegate in
+                guard let self else { return }
+                delegate.clientCore(self, didChangeStateTo: state)
+            }
+        }
+    }
+
+    convenience init(
+        socket: CocoaMQTTSocketProtocol,
+        protocolVersion: CocoaMQTTProtocolVersion,
+        queueLabel: String
+    ) {
+        self.init(
+            socket: socket,
+            state: ConcurrentAtomic(wrappedValue: .disconnected, label: "\(queueLabel).state"),
+            protocolVersion: protocolVersion,
+            queueLabel: queueLabel
+        )
+    }
+
+    deinit {
+        keepAliveController.stop()
+        socket.disconnectForClientDeinit()
+    }
+
+    func connect(
+        host: String,
+        port: UInt16,
+        timeout: TimeInterval,
+        protocolVersion: CocoaMQTTProtocolVersion,
+        maximumPacketSize: UInt32? = nil,
+        packetReadTimeout: TimeInterval,
+        readerDelegate: CocoaMQTTReaderDelegate,
+        prepare: () -> Void
+    ) -> Bool {
+        lifecycleLock.lock()
+        prepare()
+        lifecycleLock.unlock()
+
+        socket.setDelegate(socketDelegateProxy, delegateQueue: eventLoopQueue)
+        reader = CocoaMQTTReader(
+            socket: socket,
+            delegate: readerDelegate,
+            protocolVersion: protocolVersion,
+            maximumPacketSize: maximumPacketSize,
+            packetReadTimeout: packetReadTimeout
+        )
+        do {
+            if timeout > 0 {
+                try socket.connect(toHost: host, onPort: port, withTimeout: timeout)
+            } else {
+                try socket.connect(toHost: host, onPort: port)
+            }
+            eventLoopQueue.async { [weak self] in
+                self?.state = .connecting
+            }
+            return true
+        } catch let error as NSError {
+            printError("socket connect error: \(error.description)")
+            return false
+        }
+    }
+
+    @discardableResult
+    func send(
+        _ frame: Frame,
+        version: String,
+        timeout: TimeInterval,
+        maximumPacketSize: UInt32? = nil,
+        tag: Int = 0,
+        disconnectAfterWriting: Bool = false
+    ) -> Bool {
+        printDebug("SEND: \(frame)")
+        let bytes = frame.bytes(version: version)
+        if let maximumPacketSize,
+           UInt64(bytes.count) > UInt64(maximumPacketSize) {
+            printError("Packet exceeds the server Maximum Packet Size: \(frame)")
+            return false
+        }
+        let packet = Data(bytes: bytes, count: bytes.count)
+        if disconnectAfterWriting {
+            socket.writeAndDisconnect(packet, withTimeout: timeout, tag: tag)
+        } else {
+            socket.write(packet, withTimeout: timeout, tag: tag)
+        }
+        return true
+    }
+
+    func disconnectUnexpectedly() {
+        keepAliveController.stop()
+        autoReconnectController.beginUnexpectedDisconnect()
+        socket.disconnect()
+    }
+
+    func disconnectExpectedly(
+        prepare: () -> Void = {},
+        sendDisconnect: () -> Bool
+    ) {
+        guard autoReconnectController.beginExpectedDisconnect() else { return }
+        keepAliveController.stop()
+        prepare()
+        if !sendDisconnect() {
+            socket.disconnect()
+        }
+    }
+
+    func pauseAutoReconnect() {
+        autoReconnectController.pause()
+    }
+
+    func resumeAutoReconnect() {
+        guard let schedule = autoReconnectController.resume(
+            connectionIsDisconnected: state == .disconnected
+        ) else { return }
+        notifyAutoReconnectScheduled(schedule)
+    }
+
+    func ping() {
+        keepAliveController.pingSent()
+        requestPing(requiresConnectedState: false)
+    }
+
+    func connectionSucceeded() {
+        autoReconnectController.connectionSucceeded()
+    }
+
+    func startKeepAlive(interval: UInt16) {
+        keepAliveController.start(interval: interval)
+    }
+
+    func pingResponseReceived() {
+        keepAliveController.pingResponseReceived()
+    }
+
+    func nextDeliveryToken() -> UInt64 {
+        deliveryTokenLock.lock()
+        defer { deliveryTokenLock.unlock() }
+        if deliveryToken >= UInt64(Int.max) {
+            deliveryToken = UInt64(UInt16.max) + 1
+        } else {
+            deliveryToken += 1
+        }
+        return deliveryToken
+    }
+
+    func discardStoredSession(clientID: String, protocolVersion: CocoaMQTTProtocolVersion) {
+        CocoaMQTTStorage(by: clientID, protocolVersion: protocolVersion)?.removeAll()
+    }
+
+    func discardInMemorySession<Message, SubscriptionRequest, UnsubRequest>(
+        preservingConnectionQueue: Bool,
+        sendingMessages: ThreadSafeDictionary<UInt64, Message>,
+        subscriptionsWaitingAck: ThreadSafeDictionary<UInt16, SubscriptionRequest>,
+        unsubscriptionsWaitingAck: ThreadSafeDictionary<UInt16, UnsubRequest>,
+        clearSubscriptions: () -> Void
+    ) {
+        let pendingPublishes = preservingConnectionQueue
+            ? deliver.connectionPendingFrames().compactMap { $0 as? FramePublish }
+            : []
+        deliver.cleanAll(
+            detachStorage: true,
+            preserveConnectionQueue: preservingConnectionQueue
+        )
+        if preservingConnectionQueue {
+            let pendingTokens = Set(pendingPublishes.map {
+                $0.deliveryToken ?? UInt64($0.msgid)
+            })
+            sendingMessages.replace(
+                with: sendingMessages.snapshot().filter { pendingTokens.contains($0.key) }
+            )
+        } else {
+            sendingMessages.removeAll()
+        }
+        subscriptionsWaitingAck.removeAll()
+        unsubscriptionsWaitingAck.removeAll()
+        clearSubscriptions()
+        packetIdentifiers.reset()
+        for publish in pendingPublishes where publish.qos > .qos0 {
+            packetIdentifiers.markInUse(publish.msgid)
+        }
+    }
+
+    func markStoredPacketIdentifiersInUse(
+        clientID: String,
+        protocolVersion: CocoaMQTTProtocolVersion
+    ) {
+        guard let frames = CocoaMQTTStorage(
+            by: clientID,
+            protocolVersion: protocolVersion
+        )?.readAll() else { return }
+        for frame in frames {
+            if let publish = frame as? FramePublish {
+                packetIdentifiers.markInUse(publish.msgid)
+            } else if let pubrel = frame as? FramePubRel {
+                packetIdentifiers.markInUse(pubrel.msgid)
+            }
+        }
+    }
+
+    func clearPendingPacketIdentifiers<SubscriptionRequest, UnsubRequest>(
+        subscriptionsWaitingAck: ThreadSafeDictionary<UInt16, SubscriptionRequest>,
+        unsubscriptionsWaitingAck: ThreadSafeDictionary<UInt16, UnsubRequest>
+    ) {
+        for identifier in subscriptionsWaitingAck.removeAllValues().keys {
+            packetIdentifiers.release(identifier)
+        }
+        for identifier in unsubscriptionsWaitingAck.removeAllValues().keys {
+            packetIdentifiers.release(identifier)
+        }
+    }
+
+    func dispatchCallback(
+        _ callback: @escaping (MQTTClientCoreDelegate) -> Void,
+        completionOnEventLoop: ((MQTTClientCoreDelegate) -> Void)? = nil,
+        onDeallocated: (() -> Void)? = nil
+    ) {
+        let callbackQueue = delegateQueue
+        callbackQueue.async { [weak self] in
+            guard let self, let delegate = self.delegate else {
+                onDeallocated?()
+                return
+            }
+            callback(delegate)
+            guard let completionOnEventLoop else { return }
+            self.eventLoopQueue.async { [weak self] in
+                guard let self, let delegate = self.delegate else { return }
+                completionOnEventLoop(delegate)
+            }
+        }
+    }
+
+    private func requestPing(requiresConnectedState: Bool = true) {
+        if requiresConnectedState && state != .connected {
+            keepAliveController.stop()
+            return
+        }
+        guard delegate?.clientCoreRequestsPing(self) == true else {
+            disconnectUnexpectedly()
+            return
+        }
+        dispatchCallback { [weak self] delegate in
+            guard let self else { return }
+            delegate.clientCoreDidSendPing(self)
+        }
+    }
+
+    private func notifyAutoReconnectScheduled(_ schedule: CocoaMQTTAutoReconnectSchedule) {
+        dispatchCallback { [weak self] delegate in
+            guard let self,
+                  self.autoReconnectController.isCurrent(schedule) else { return }
+            delegate.clientCore(self, didScheduleReconnect: schedule)
+        }
+    }
+}
+
+extension MQTTClientCore: CocoaMQTTDeliverProtocol {
+    func deliver(_ deliver: CocoaMQTTDeliver, didReject frame: Frame) {
+        delegate?.clientCore(self, didReject: frame)
+    }
+
+    func deliver(_ deliver: CocoaMQTTDeliver, wantToSend frame: Frame) {
+        delegate?.clientCore(self, wantsToSend: frame)
+    }
+}
+
+extension MQTTClientCore: MQTTAutoReconnectControllerDelegate {
+    func autoReconnectControllerRequestsReconnect(_ controller: MQTTAutoReconnectController) {
+        guard delegate?.clientCoreRequestsReconnect(self) == false,
+              let schedule = controller.reconnectAttemptFailedToStart() else { return }
+        notifyAutoReconnectScheduled(schedule)
+    }
+}
+
+extension MQTTClientCore: MQTTKeepAliveControllerDelegate {
+    func keepAliveControllerRequestsPing(_ controller: MQTTKeepAliveController) {
+        requestPing()
+    }
+
+    func keepAliveControllerDidTimeOut(_ controller: MQTTKeepAliveController) {
+        guard state == .connected else { return }
+        printWarning("PINGRESP timed out, closing socket")
+        disconnectUnexpectedly()
+    }
+}
+
+extension MQTTClientCore: CocoaMQTTSocketDelegate {
+    func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+        autoReconnectController.socketConnected()
+        delegate?.clientCoreDidConnectTransport(self)
+    }
+
+    func socket(
+        _ socket: CocoaMQTTSocketProtocol,
+        didReceive trust: SecTrust,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        dispatchCallback({ [weak self] delegate in
+            guard let self else {
+                completionHandler(false)
+                return
+            }
+            delegate.clientCore(self, didReceive: trust, completionHandler: completionHandler)
+        }, onDeallocated: { completionHandler(false) })
+    }
+
+    func socketUrlSession(
+        _ socket: CocoaMQTTSocketProtocol,
+        didReceiveTrust trust: SecTrust,
+        didReceiveChallenge challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        dispatchCallback({ [weak self] delegate in
+            guard let self else {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+                return
+            }
+            delegate.clientCore(
+                self,
+                didReceiveTrust: trust,
+                challenge: challenge,
+                completionHandler: completionHandler
+            )
+        }, onDeallocated: {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+        })
+    }
+
+    func socketDidSecure(_ socket: MGCDAsyncSocket) {
+        printDebug("Socket has successfully completed SSL/TLS negotiation")
+        delegate?.clientCoreDidConnectTransport(self)
+    }
+
+    func socket(_ socket: CocoaMQTTSocketProtocol, didWriteDataWithTag tag: Int) {}
+
+    func socket(_ socket: CocoaMQTTSocketProtocol, didRead data: Data, withTag tag: Int) {
+        let readTag = CocoaMQTTReadTag(rawValue: tag)!
+        var bytes = [UInt8]([0])
+        switch readTag {
+        case .header:
+            data.copyBytes(to: &bytes, count: 1)
+            reader!.headerReady(bytes[0])
+        case .length:
+            data.copyBytes(to: &bytes, count: 1)
+            reader!.lengthReady(bytes[0])
+        case .payload:
+            reader!.payloadReady(data)
+        }
+    }
+
+    func socketDidDisconnect(_ socket: CocoaMQTTSocketProtocol, withError error: Error?) {
+        keepAliveController.stop()
+        socket.setDelegate(nil, delegateQueue: nil)
+        delegate?.clientCore(self, willDisconnectWithError: error)
+        let reconnectContext = autoReconnectController.socketDidDisconnect()
+
+        state = .disconnected
+        dispatchCallback({ [weak self] delegate in
+            guard let self else { return }
+            delegate.clientCore(self, didDisconnectWithError: error)
+        }, completionOnEventLoop: { [weak self] _ in
+            guard let self,
+                  let schedule = self.autoReconnectController.completeDisconnectCallbacks(
+                    reconnectContext
+                  ) else { return }
+            self.notifyAutoReconnectScheduled(schedule)
+        })
+    }
+}


### PR DESCRIPTION
## What changed

- add an internal `MQTTClientCore` used by both MQTT 3.1.1 and MQTT 5
- move the protocol-neutral runtime into that core:
  - transport delegate normalization and reader lifecycle
  - connection state and callback dispatch
  - expected/unexpected disconnect sequencing
  - auto-reconnect and keepalive
  - frame serialization and socket writes
  - delivery engine, packet identifiers, and delivery tokens
  - common in-memory/persisted-session cleanup bookkeeping
- keep protocol-specific behavior in the public facades through a typed adapter boundary: CONNECT/CONNACK frames, MQTT 5 capabilities, topic aliases, session expiry, properties, and reason codes
- run the same connection-state contract tests against both public clients
- include the shared core and contract tests in the Xcode project as well as SwiftPM

## Why

The MQTT 3.1.1 and MQTT 5 facades had independently evolved copies of the same connection lifecycle. That made fixes easy to apply to only one protocol version. This change establishes one implementation for the shared runtime while leaving protocol semantics explicit in each facade.

Fixes #699

## Compatibility

- no public API, Objective-C delegate, or protocol-conformance changes (verified with Swift API Digester)
- MQTT 5 keeps its public `$connState` projected value
- both clients retain public `CocoaMQTTSocketDelegate` conformance
- state writes remain synchronously visible; callbacks remain asynchronous on the captured `delegateQueue`
- repeated state assignments, manual `ping()`, reconnect callback ordering, custom socket event-loop normalization, and deinit behavior are preserved

## Verification

- `swift test --filter ConnectionStateContractTests`
- `swift test --filter 'SendingMessageLifecycleTests|CocoaMQTTDeliverTests|ConnectionStateContractTests'` — 64 passed
- focused lifecycle/reconnect/event-loop/TLS/thread-safety suite — 172 passed
- focused Thread Sanitizer suite across both clients — 6 passed, no reports
- `swift build --target CocoaMQTT -Xswiftc -swift-version -Xswiftc 6`
- `xcodebuild -project CocoaMQTT.xcodeproj -scheme "Mac Framework" -derivedDataPath /private/tmp/CocoaMQTT-699-derived CODE_SIGNING_ALLOWED=NO build`
- `Tools/lint.sh`
- `git diff --check`
- Swift API Digester comparison against `master` — no API differences

The 307-test local non-broker run reaches only the pre-existing TLS/WSS loopback fixture failures (14 assertion failures), reproduced identically on an untouched `master` worktree; all other tests pass. CI provides the configured loopback environment.